### PR TITLE
[IDLE-69] feat: 패스워드 찾기 페이지 UI 구현

### DIFF
--- a/frontend/android/app/src/main/AndroidManifest.xml
+++ b/frontend/android/app/src/main/AndroidManifest.xml
@@ -36,7 +36,7 @@
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
-                <data android:scheme="app.ngrok-free.48d7-211-47-82-177" android:host="oauth"/>
+                <data android:scheme="kr.mybrary" />
             </intent-filter>
         </activity>
         <!-- Don't delete the meta-data below.

--- a/frontend/android/app/src/main/AndroidManifest.xml
+++ b/frontend/android/app/src/main/AndroidManifest.xml
@@ -1,4 +1,11 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <queries>
+        <intent>
+            <action android:name="android.intent.action.VIEW" />
+            <data android:scheme="https" />
+        </intent>
+    </queries>
+
     <application
         android:label="mybrary"
         android:name="${applicationName}"
@@ -24,10 +31,19 @@
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
         </activity>
+        <activity android:name="com.linusu.flutter_web_auth.CallbackActivity" android:exported="true">
+            <intent-filter android:label="flutter_web_auth">
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="app.ngrok-free.48d7-211-47-82-177" android:host="oauth"/>
+            </intent-filter>
+        </activity>
         <!-- Don't delete the meta-data below.
              This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->
         <meta-data
             android:name="flutterEmbedding"
             android:value="2" />
+
     </application>
 </manifest>

--- a/frontend/ios/Flutter/Debug.xcconfig
+++ b/frontend/ios/Flutter/Debug.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"
 #include "Generated.xcconfig"

--- a/frontend/ios/Flutter/Release.xcconfig
+++ b/frontend/ios/Flutter/Release.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"
 #include "Generated.xcconfig"

--- a/frontend/ios/Podfile
+++ b/frontend/ios/Podfile
@@ -1,0 +1,44 @@
+# Uncomment this line to define a global platform for your project
+# platform :ios, '11.0'
+
+# CocoaPods analytics sends network stats synchronously affecting flutter build latency.
+ENV['COCOAPODS_DISABLE_STATS'] = 'true'
+
+project 'Runner', {
+  'Debug' => :debug,
+  'Profile' => :release,
+  'Release' => :release,
+}
+
+def flutter_root
+  generated_xcode_build_settings_path = File.expand_path(File.join('..', 'Flutter', 'Generated.xcconfig'), __FILE__)
+  unless File.exist?(generated_xcode_build_settings_path)
+    raise "#{generated_xcode_build_settings_path} must exist. If you're running pod install manually, make sure flutter pub get is executed first"
+  end
+
+  File.foreach(generated_xcode_build_settings_path) do |line|
+    matches = line.match(/FLUTTER_ROOT\=(.*)/)
+    return matches[1].strip if matches
+  end
+  raise "FLUTTER_ROOT not found in #{generated_xcode_build_settings_path}. Try deleting Generated.xcconfig, then run flutter pub get"
+end
+
+require File.expand_path(File.join('packages', 'flutter_tools', 'bin', 'podhelper'), flutter_root)
+
+flutter_ios_podfile_setup
+
+target 'Runner' do
+  use_frameworks!
+  use_modular_headers!
+
+  flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
+  target 'RunnerTests' do
+    inherit! :search_paths
+  end
+end
+
+post_install do |installer|
+  installer.pods_project.targets.each do |target|
+    flutter_additional_ios_build_settings(target)
+  end
+end

--- a/frontend/ios/Podfile.lock
+++ b/frontend/ios/Podfile.lock
@@ -1,0 +1,29 @@
+PODS:
+  - Flutter (1.0.0)
+  - fluttertoast (0.0.2):
+    - Flutter
+    - Toast
+  - Toast (4.0.0)
+
+DEPENDENCIES:
+  - Flutter (from `Flutter`)
+  - fluttertoast (from `.symlinks/plugins/fluttertoast/ios`)
+
+SPEC REPOS:
+  trunk:
+    - Toast
+
+EXTERNAL SOURCES:
+  Flutter:
+    :path: Flutter
+  fluttertoast:
+    :path: ".symlinks/plugins/fluttertoast/ios"
+
+SPEC CHECKSUMS:
+  Flutter: f04841e97a9d0b0a8025694d0796dd46242b2854
+  fluttertoast: fafc4fa4d01a6a9e4f772ecd190ffa525e9e2d9c
+  Toast: 91b396c56ee72a5790816f40d3a94dd357abc196
+
+PODFILE CHECKSUM: 70d9d25280d0dd177a5f637cdb0f0b0b12c6a189
+
+COCOAPODS: 1.12.1

--- a/frontend/ios/Podfile.lock
+++ b/frontend/ios/Podfile.lock
@@ -1,5 +1,7 @@
 PODS:
   - Flutter (1.0.0)
+  - flutter_web_auth (0.5.0):
+    - Flutter
   - fluttertoast (0.0.2):
     - Flutter
     - Toast
@@ -7,6 +9,7 @@ PODS:
 
 DEPENDENCIES:
   - Flutter (from `Flutter`)
+  - flutter_web_auth (from `.symlinks/plugins/flutter_web_auth/ios`)
   - fluttertoast (from `.symlinks/plugins/fluttertoast/ios`)
 
 SPEC REPOS:
@@ -16,11 +19,14 @@ SPEC REPOS:
 EXTERNAL SOURCES:
   Flutter:
     :path: Flutter
+  flutter_web_auth:
+    :path: ".symlinks/plugins/flutter_web_auth/ios"
   fluttertoast:
     :path: ".symlinks/plugins/fluttertoast/ios"
 
 SPEC CHECKSUMS:
   Flutter: f04841e97a9d0b0a8025694d0796dd46242b2854
+  flutter_web_auth: c25208760459cec375a3c39f6a8759165ca0fa4d
   fluttertoast: fafc4fa4d01a6a9e4f772ecd190ffa525e9e2d9c
   Toast: 91b396c56ee72a5790816f40d3a94dd357abc196
 

--- a/frontend/ios/Runner.xcodeproj/project.pbxproj
+++ b/frontend/ios/Runner.xcodeproj/project.pbxproj
@@ -8,12 +8,14 @@
 
 /* Begin PBXBuildFile section */
 		1498D2341E8E89220040F4C2 /* GeneratedPluginRegistrant.m in Sources */ = {isa = PBXBuildFile; fileRef = 1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */; };
+		331C808B294A63AB00263BE5 /* RunnerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 331C807B294A618700263BE5 /* RunnerTests.swift */; };
 		3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */; };
 		74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74858FAE1ED2DC5600515810 /* AppDelegate.swift */; };
 		97C146FC1CF9000F007C117D /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FA1CF9000F007C117D /* Main.storyboard */; };
 		97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FD1CF9000F007C117D /* Assets.xcassets */; };
 		97C147011CF9000F007C117D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */; };
-		331C808B294A63AB00263BE5 /* RunnerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 331C807B294A618700263BE5 /* RunnerTests.swift */; };
+		F395FD1491F3BD3DB836E6E7 /* Pods_RunnerTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 77149A13E33F14DF39D6B930 /* Pods_RunnerTests.framework */; };
+		F55192801A4CFA498C0A4410 /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 97B7D31EFF64C4434B0AB26F /* Pods_Runner.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -42,32 +44,57 @@
 /* Begin PBXFileReference section */
 		1498D2321E8E86230040F4C2 /* GeneratedPluginRegistrant.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GeneratedPluginRegistrant.h; sourceTree = "<group>"; };
 		1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GeneratedPluginRegistrant.m; sourceTree = "<group>"; };
+		331C807B294A618700263BE5 /* RunnerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunnerTests.swift; sourceTree = "<group>"; };
+		331C8081294A63A400263BE5 /* RunnerTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RunnerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = AppFrameworkInfo.plist; path = Flutter/AppFrameworkInfo.plist; sourceTree = "<group>"; };
+		489D6397608207C74443F591 /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
+		665272E41D185EB38ECC8BD0 /* Pods-RunnerTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.debug.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.debug.xcconfig"; sourceTree = "<group>"; };
+		6EE2BBE2A4DE7DB6439A3709 /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
 		74858FAD1ED2DC5600515810 /* Runner-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Runner-Bridging-Header.h"; sourceTree = "<group>"; };
 		74858FAE1ED2DC5600515810 /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		77149A13E33F14DF39D6B930 /* Pods_RunnerTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RunnerTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Release.xcconfig; path = Flutter/Release.xcconfig; sourceTree = "<group>"; };
+		91EAA1C0694805105CD72927 /* Pods-RunnerTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.release.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.release.xcconfig"; sourceTree = "<group>"; };
 		9740EEB21CF90195004384FC /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Debug.xcconfig; path = Flutter/Debug.xcconfig; sourceTree = "<group>"; };
 		9740EEB31CF90195004384FC /* Generated.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Generated.xcconfig; path = Flutter/Generated.xcconfig; sourceTree = "<group>"; };
+		97B7D31EFF64C4434B0AB26F /* Pods_Runner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		97C146EE1CF9000F007C117D /* Runner.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Runner.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		97C146FB1CF9000F007C117D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
 		97C146FD1CF9000F007C117D /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		97C147001CF9000F007C117D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		97C147021CF9000F007C117D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		331C807B294A618700263BE5 /* RunnerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunnerTests.swift; sourceTree = "<group>"; };
-		331C8081294A63A400263BE5 /* RunnerTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RunnerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		9B2A943D3ECBE7C727AE4412 /* Pods-RunnerTests.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.profile.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.profile.xcconfig"; sourceTree = "<group>"; };
+		F14396A50785D0D2FB8CC675 /* Pods-Runner.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.profile.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		14B897E08E2ED5BB3E4A68DD /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				F395FD1491F3BD3DB836E6E7 /* Pods_RunnerTests.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		97C146EB1CF9000F007C117D /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				F55192801A4CFA498C0A4410 /* Pods_Runner.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		331C8082294A63A400263BE5 /* RunnerTests */ = {
+			isa = PBXGroup;
+			children = (
+				331C807B294A618700263BE5 /* RunnerTests.swift */,
+			);
+			path = RunnerTests;
+			sourceTree = "<group>";
+		};
 		9740EEB11CF90186004384FC /* Flutter */ = {
 			isa = PBXGroup;
 			children = (
@@ -79,14 +106,6 @@
 			name = Flutter;
 			sourceTree = "<group>";
 		};
-		331C8082294A63A400263BE5 /* RunnerTests */ = {
-			isa = PBXGroup;
-			children = (
-				331C807B294A618700263BE5 /* RunnerTests.swift */,
-			);
-			path = RunnerTests;
-			sourceTree = "<group>";
-		};
 		97C146E51CF9000F007C117D = {
 			isa = PBXGroup;
 			children = (
@@ -94,6 +113,8 @@
 				97C146F01CF9000F007C117D /* Runner */,
 				97C146EF1CF9000F007C117D /* Products */,
 				331C8082294A63A400263BE5 /* RunnerTests */,
+				E9A8AD021C3B4E15E5C7FE0F /* Pods */,
+				EAB77CC8BBC1236357886B20 /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -121,6 +142,29 @@
 			path = Runner;
 			sourceTree = "<group>";
 		};
+		E9A8AD021C3B4E15E5C7FE0F /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				6EE2BBE2A4DE7DB6439A3709 /* Pods-Runner.debug.xcconfig */,
+				489D6397608207C74443F591 /* Pods-Runner.release.xcconfig */,
+				F14396A50785D0D2FB8CC675 /* Pods-Runner.profile.xcconfig */,
+				665272E41D185EB38ECC8BD0 /* Pods-RunnerTests.debug.xcconfig */,
+				91EAA1C0694805105CD72927 /* Pods-RunnerTests.release.xcconfig */,
+				9B2A943D3ECBE7C727AE4412 /* Pods-RunnerTests.profile.xcconfig */,
+			);
+			name = Pods;
+			path = Pods;
+			sourceTree = "<group>";
+		};
+		EAB77CC8BBC1236357886B20 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				97B7D31EFF64C4434B0AB26F /* Pods_Runner.framework */,
+				77149A13E33F14DF39D6B930 /* Pods_RunnerTests.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -128,9 +172,10 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 331C8087294A63A400263BE5 /* Build configuration list for PBXNativeTarget "RunnerTests" */;
 			buildPhases = (
+				7AF3FFA56A3927C5553A0371 /* [CP] Check Pods Manifest.lock */,
 				331C807D294A63A400263BE5 /* Sources */,
-				331C807E294A63A400263BE5 /* Frameworks */,
 				331C807F294A63A400263BE5 /* Resources */,
+				14B897E08E2ED5BB3E4A68DD /* Frameworks */,
 			);
 			buildRules = (
 			);
@@ -146,12 +191,14 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 97C147051CF9000F007C117D /* Build configuration list for PBXNativeTarget "Runner" */;
 			buildPhases = (
+				19DB462DC4321A5E9AC64E39 /* [CP] Check Pods Manifest.lock */,
 				9740EEB61CF901F6004384FC /* Run Script */,
 				97C146EA1CF9000F007C117D /* Sources */,
 				97C146EB1CF9000F007C117D /* Frameworks */,
 				97C146EC1CF9000F007C117D /* Resources */,
 				9705A1C41CF9048500538489 /* Embed Frameworks */,
 				3B06AD1E1E4923F5004D2608 /* Thin Binary */,
+				0198C305574CFF14A9073CD5 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -222,6 +269,45 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		0198C305574CFF14A9073CD5 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		19DB462DC4321A5E9AC64E39 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-Runner-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
 		3B06AD1E1E4923F5004D2608 /* Thin Binary */ = {
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;
@@ -237,6 +323,28 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" embed_and_thin";
+		};
+		7AF3FFA56A3927C5553A0371 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-RunnerTests-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
 		};
 		9740EEB61CF901F6004384FC /* Run Script */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -377,7 +485,7 @@
 		};
 		331C8088294A63A400263BE5 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = AE0B7B92F70575B8D7E0D07E /* Pods-RunnerTests.debug.xcconfig */;
+			baseConfigurationReference = 665272E41D185EB38ECC8BD0 /* Pods-RunnerTests.debug.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
@@ -395,7 +503,7 @@
 		};
 		331C8089294A63A400263BE5 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 89B67EB44CE7B6631473024E /* Pods-RunnerTests.release.xcconfig */;
+			baseConfigurationReference = 91EAA1C0694805105CD72927 /* Pods-RunnerTests.release.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
@@ -411,7 +519,7 @@
 		};
 		331C808A294A63A400263BE5 /* Profile */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 640959BDD8F10B91D80A66BE /* Pods-RunnerTests.profile.xcconfig */;
+			baseConfigurationReference = 9B2A943D3ECBE7C727AE4412 /* Pods-RunnerTests.profile.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;

--- a/frontend/ios/Runner.xcodeproj/project.pbxproj
+++ b/frontend/ios/Runner.xcodeproj/project.pbxproj
@@ -152,7 +152,6 @@
 				91EAA1C0694805105CD72927 /* Pods-RunnerTests.release.xcconfig */,
 				9B2A943D3ECBE7C727AE4412 /* Pods-RunnerTests.profile.xcconfig */,
 			);
-			name = Pods;
 			path = Pods;
 			sourceTree = "<group>";
 		};

--- a/frontend/ios/Runner.xcworkspace/contents.xcworkspacedata
+++ b/frontend/ios/Runner.xcworkspace/contents.xcworkspacedata
@@ -4,4 +4,7 @@
    <FileRef
       location = "group:Runner.xcodeproj">
    </FileRef>
+   <FileRef
+      location = "group:Pods/Pods.xcodeproj">
+   </FileRef>
 </Workspace>

--- a/frontend/ios/Runner/Info.plist
+++ b/frontend/ios/Runner/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>CADisableMinimumFrameDurationOnPhone</key>
+	<true/>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>
@@ -20,9 +22,32 @@
 	<string>$(FLUTTER_BUILD_NAME)</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+        <dict>
+            <key>CFBundleURLSchemes</key>
+            <array>
+                <string>kr.mybrary.mybrary</string>
+            </array>
+        </dict>
+    </array>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLName</key>
+			<string>kr.mybrary.mybrary</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>mybrary</string>
+			</array>
+		</dict>
+	</array>
 	<key>CFBundleVersion</key>
 	<string>$(FLUTTER_BUILD_NUMBER)</string>
 	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>UIApplicationSupportsIndirectInputEvents</key>
 	<true/>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
@@ -43,9 +68,5 @@
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
-	<key>CADisableMinimumFrameDurationOnPhone</key>
-	<true/>
-	<key>UIApplicationSupportsIndirectInputEvents</key>
-	<true/>
 </dict>
 </plist>

--- a/frontend/lib/components/login/login_input_component.dart
+++ b/frontend/lib/components/login/login_input_component.dart
@@ -4,6 +4,7 @@ import 'package:mybrary/constants/color.dart';
 class LoginInput extends StatelessWidget {
   final String hintText;
   final String initialValue;
+  final String? suffixText;
   final FormFieldSetter<String> onSaved;
   final FormFieldValidator<String> validator;
 
@@ -12,6 +13,7 @@ class LoginInput extends StatelessWidget {
     required this.validator,
     required this.initialValue,
     required this.onSaved,
+    this.suffixText,
     Key? key,
   }) : super(key: key);
 
@@ -23,6 +25,10 @@ class LoginInput extends StatelessWidget {
       validator: validator,
       cursorColor: ORANGE_COLOR,
       decoration: InputDecoration(
+        suffixIcon: Padding(
+          padding: EdgeInsets.all(15.0),
+          child: suffixText != null ? Text('$suffixText') : null,
+        ),
         hintText: hintText,
         contentPadding: const EdgeInsets.symmetric(vertical: 16.0),
         focusedBorder: loginInputBorderStyle(),

--- a/frontend/lib/components/login/login_input_component.dart
+++ b/frontend/lib/components/login/login_input_component.dart
@@ -5,6 +5,7 @@ class LoginInput extends StatelessWidget {
   final String hintText;
   final String initialValue;
   final String? suffixText;
+  final bool? isEnabled;
   final FormFieldSetter<String> onSaved;
   final FormFieldValidator<String> validator;
 
@@ -14,12 +15,14 @@ class LoginInput extends StatelessWidget {
     required this.initialValue,
     required this.onSaved,
     this.suffixText,
+    this.isEnabled,
     Key? key,
   }) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
     return TextFormField(
+      enabled: isEnabled,
       onSaved: onSaved,
       initialValue: initialValue,
       validator: validator,

--- a/frontend/lib/components/login/login_input_component.dart
+++ b/frontend/lib/components/login/login_input_component.dart
@@ -4,7 +4,6 @@ import 'package:mybrary/constants/color.dart';
 class LoginInput extends StatelessWidget {
   final String hintText;
   final String initialValue;
-  final String? suffixText;
   final bool? isEnabled;
   final FormFieldSetter<String> onSaved;
   final FormFieldValidator<String> validator;
@@ -14,7 +13,6 @@ class LoginInput extends StatelessWidget {
     required this.validator,
     required this.initialValue,
     required this.onSaved,
-    this.suffixText,
     this.isEnabled,
     Key? key,
   }) : super(key: key);
@@ -28,10 +26,6 @@ class LoginInput extends StatelessWidget {
       validator: validator,
       cursorColor: ORANGE_COLOR,
       decoration: InputDecoration(
-        suffixIcon: Padding(
-          padding: EdgeInsets.all(15.0),
-          child: suffixText != null ? Text('$suffixText') : null,
-        ),
         hintText: hintText,
         contentPadding: const EdgeInsets.symmetric(vertical: 16.0),
         focusedBorder: loginInputBorderStyle(),

--- a/frontend/lib/components/login/login_logo_component.dart
+++ b/frontend/lib/components/login/login_logo_component.dart
@@ -9,14 +9,17 @@ class Logo extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Center(
-      child: Text(
-        logoText,
-        style: TextStyle(
-          fontSize: 30.0,
-          fontWeight: FontWeight.w700,
+    return Container(
+      height: 100,
+      child: Center(
+        child: Text(
+          logoText,
+          style: TextStyle(
+            fontSize: 30.0,
+            fontWeight: FontWeight.w700,
+          ),
+          textAlign: TextAlign.center,
         ),
-        textAlign: TextAlign.center,
       ),
     );
   }

--- a/frontend/lib/constants/color.dart
+++ b/frontend/lib/constants/color.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 const Color LESS_BLACK_COLOR = Color(0xFF313333);
 const Color BLACK_COLOR = Color(0xFF000000);
 const Color ORANGE_COLOR = Color(0xFFFF9800);
+const Color DISABLED_COLOR = Color(0x6B000000);
 
 // Login Color
 const Color LOGIN_PRIMARY_COLOR = Color(0xFFCDE7BE);

--- a/frontend/lib/constants/color.dart
+++ b/frontend/lib/constants/color.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 
 // Common Color
 const Color LESS_BLACK_COLOR = Color(0xFF313333);
+const Color WHITE_COLOR = Color(0xFFFFFFFF);
 const Color BLACK_COLOR = Color(0xFF000000);
 const Color ORANGE_COLOR = Color(0xFFFF9800);
 const Color DISABLED_COLOR = Color(0x6B000000);
@@ -10,6 +11,7 @@ const Color DISABLED_COLOR = Color(0x6B000000);
 const Color LOGIN_PRIMARY_COLOR = Color(0xFFCDE7BE);
 const Color LOGIN_BACKGROUND_COLOR = Color(0xFF313333);
 const Color LOGIN_INPUT_COLOR = Color(0xFFEAF4F4);
+const Color LOGIN_ERROR_COLOR = Color(0xFFE0351C);
 const Color GOOGLE_COLOR = Color(0xFFD0422A);
 const Color NAVER_COLOR = Color(0xFF0AC75A);
 const Color KAKAO_COLOR = Color(0xFFFFE502);

--- a/frontend/lib/data/network/service/auth_apis.dart
+++ b/frontend/lib/data/network/service/auth_apis.dart
@@ -1,0 +1,62 @@
+import 'package:flutter_web_auth/flutter_web_auth.dart';
+
+enum OAuthType { naver, kakao, google }
+
+const APP_DOMAIN_URI =
+    "https://48d7-211-47-82-177.ngrok-free.app/oauth2/authorization";
+const APP_LOGIN_URI =
+    "https://48d7-211-47-82-177.ngrok-free.app/login/oauth2/code";
+const APP_REDIRECT_URI = "app.ngrok-free.48d7-211-47-82-177";
+
+Future<void> signInOAuth({required OAuthType oAuthType}) async {
+  Uri? url;
+
+  // 함수를 실행하는 타입에 맞추어 Uri를 생성합니다. (naver, kakao, google)
+  switch (oAuthType) {
+    case OAuthType.naver:
+      url = Uri.parse('$APP_DOMAIN_URI/naver');
+      break;
+    case OAuthType.kakao:
+      url = Uri.parse('$APP_DOMAIN_URI/kakao');
+      break;
+    case OAuthType.google:
+      url = Uri.parse('$APP_DOMAIN_URI/google');
+      break;
+    default:
+      break;
+  }
+
+  /*
+  * 로그인 이후에 callback 데이터 반환을 받아 처리해야하는데,
+  * callbackUrlScheme의 정규표현식에서 ngrok api가 유효하지 않은 것 같습니다.
+  * nid.naver.com/~~~&redirect_url=~~ 부분에 대해 논의가 필요할 것 같습니다.
+  * */
+  final result = await FlutterWebAuth.authenticate(
+      url: url.toString(), callbackUrlScheme: APP_REDIRECT_URI);
+
+  print(result);
+
+  // redirectUrl로부터 데이터를 받아 access/refresh token을 추출 가능
+  // final accessToken = Uri.parse(result).queryParameters['Authorization'];
+  // final refreshToken = Uri.parse(result).queryParameters['refresh-token'];
+}
+
+// Future authenticateWithOAuth2Naver() async {
+//   const clientId = '8vGIEXZZlCtez_85OGb4';
+//   const redirectUri =
+//       'https://48d7-211-47-82-177.ngrok-free.app/login/oauth2/code/naver';
+//   const authorizeUrl =
+//       'https://48d7-211-47-82-177.ngrok-free.app/oauth2/authorization/naver';
+//   // const tokenUrl =
+//   //     'https://48d7-211-47-82-177.ngrok-free.app/login/oauth2/code/naver';
+//
+//   final authUrl = Uri.parse('$authorizeUrl?'
+//       'client_id=$clientId&'
+//       'redirect_uri=$redirectUri&'
+//       'response_type=code');
+//
+//   final result = await FlutterWebAuth.authenticate(
+//     url: authUrl.toString(),
+//     callbackUrlScheme: redirectUri,
+//   );
+// }

--- a/frontend/lib/data/network/service/auth_apis.dart
+++ b/frontend/lib/data/network/service/auth_apis.dart
@@ -2,11 +2,9 @@ import 'package:flutter_web_auth/flutter_web_auth.dart';
 
 enum OAuthType { naver, kakao, google }
 
-const APP_DOMAIN_URI =
-    "https://48d7-211-47-82-177.ngrok-free.app/oauth2/authorization";
-const APP_LOGIN_URI =
-    "https://48d7-211-47-82-177.ngrok-free.app/login/oauth2/code";
-const APP_REDIRECT_URI = "app.ngrok-free.48d7-211-47-82-177";
+// 추후, 서버 api 주소가 나오면 코드 리팩터링 진행하겠습니다.
+const APP_DOMAIN_URI = "https://{서버_api_주소}/oauth2/authorization";
+const APP_REDIRECT_URI = "kr.mybrary";
 
 Future<void> signInOAuth({required OAuthType oAuthType}) async {
   Uri? url;
@@ -14,49 +12,34 @@ Future<void> signInOAuth({required OAuthType oAuthType}) async {
   // 함수를 실행하는 타입에 맞추어 Uri를 생성합니다. (naver, kakao, google)
   switch (oAuthType) {
     case OAuthType.naver:
-      url = Uri.parse('$APP_DOMAIN_URI/naver');
+      url = Uri.parse('$APP_DOMAIN_URI/naver?redirect_url=$APP_REDIRECT_URI');
       break;
     case OAuthType.kakao:
-      url = Uri.parse('$APP_DOMAIN_URI/kakao');
+      url = Uri.parse('$APP_DOMAIN_URI/kakao?redirect_url=$APP_REDIRECT_URI');
       break;
     case OAuthType.google:
-      url = Uri.parse('$APP_DOMAIN_URI/google');
+      url = Uri.parse('$APP_DOMAIN_URI/google?redirect_url=$APP_REDIRECT_URI');
       break;
     default:
       break;
   }
+
+  print('로그인 클릭');
 
   /*
   * 로그인 이후에 callback 데이터 반환을 받아 처리해야하는데,
   * callbackUrlScheme의 정규표현식에서 ngrok api가 유효하지 않은 것 같습니다.
   * nid.naver.com/~~~&redirect_url=~~ 부분에 대해 논의가 필요할 것 같습니다.
   * */
+
   final result = await FlutterWebAuth.authenticate(
       url: url.toString(), callbackUrlScheme: APP_REDIRECT_URI);
 
-  print(result);
-
   // redirectUrl로부터 데이터를 받아 access/refresh token을 추출 가능
-  // final accessToken = Uri.parse(result).queryParameters['Authorization'];
-  // final refreshToken = Uri.parse(result).queryParameters['refresh-token'];
-}
+  final accessToken = Uri.parse(result).queryParameters['Authorization'];
+  final refreshToken =
+      Uri.parse(result).queryParameters['Authorization-Refresh'];
 
-// Future authenticateWithOAuth2Naver() async {
-//   const clientId = '8vGIEXZZlCtez_85OGb4';
-//   const redirectUri =
-//       'https://48d7-211-47-82-177.ngrok-free.app/login/oauth2/code/naver';
-//   const authorizeUrl =
-//       'https://48d7-211-47-82-177.ngrok-free.app/oauth2/authorization/naver';
-//   // const tokenUrl =
-//   //     'https://48d7-211-47-82-177.ngrok-free.app/login/oauth2/code/naver';
-//
-//   final authUrl = Uri.parse('$authorizeUrl?'
-//       'client_id=$clientId&'
-//       'redirect_uri=$redirectUri&'
-//       'response_type=code');
-//
-//   final result = await FlutterWebAuth.authenticate(
-//     url: authUrl.toString(),
-//     callbackUrlScheme: redirectUri,
-//   );
-// }
+  print('accessToken: $accessToken');
+  print('refreshToken: $refreshToken');
+}

--- a/frontend/lib/main.dart
+++ b/frontend/lib/main.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:mybrary/screens/auth/find_password_screen.dart';
 import 'package:mybrary/screens/auth/login_screen.dart';
-import 'package:mybrary/screens/auth/reset_verify_screen.dart';
 import 'package:mybrary/screens/auth/sign_up_screen.dart';
 import 'package:mybrary/screens/auth/sign_up_verify_screen.dart';
 import 'package:mybrary/screens/home_screen.dart';
@@ -27,7 +27,7 @@ class MyApp extends StatelessWidget {
       initialRoute: '/login',
       routes: {
         '/login': (context) => LoginScreen(),
-        '/login/verify': (context) => ResetVerifyScreen(),
+        '/login/findpw': (context) => FindPasswordScreen(),
         '/signup': (context) => SignUpScreen(),
         '/signup/verify': (context) => SignUpVerifyScreen(),
         '/home': (context) => HomeScreen(),

--- a/frontend/lib/main.dart
+++ b/frontend/lib/main.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:mybrary/screens/auth/login_screen.dart';
+import 'package:mybrary/screens/auth/reset_verify_screen.dart';
 import 'package:mybrary/screens/auth/sign_up_screen.dart';
 import 'package:mybrary/screens/auth/sign_up_verify_screen.dart';
 import 'package:mybrary/screens/home_screen.dart';
@@ -23,9 +24,10 @@ class MyApp extends StatelessWidget {
           systemOverlayStyle: SystemUiOverlayStyle.dark,
         ),
       ),
-      initialRoute: '/',
+      initialRoute: '/login',
       routes: {
-        '/': (context) => LoginScreen(),
+        '/login': (context) => LoginScreen(),
+        '/login/verify': (context) => ResetVerifyScreen(),
         '/signup': (context) => SignUpScreen(),
         '/signup/verify': (context) => SignUpVerifyScreen(),
         '/home': (context) => HomeScreen(),

--- a/frontend/lib/screens/auth/find_password_screen.dart
+++ b/frontend/lib/screens/auth/find_password_screen.dart
@@ -202,7 +202,9 @@ class _IdVerifyForm extends StatelessWidget {
           // 추후 토스트 메세지로 변경 예정입니다.
           Text(
             '존재하지 않는 아이디입니다.',
-            style: TextStyle(color: Colors.red[500]),
+            style: TextStyle(
+              color: LOGIN_ERROR_COLOR,
+            ),
           ),
       ],
     );

--- a/frontend/lib/screens/auth/find_password_screen.dart
+++ b/frontend/lib/screens/auth/find_password_screen.dart
@@ -3,9 +3,9 @@ import 'package:mybrary/components/login/login_button_component.dart';
 import 'package:mybrary/components/login/login_input_component.dart';
 import 'package:mybrary/components/login/login_logo_component.dart';
 import 'package:mybrary/constants/color.dart';
+import 'package:mybrary/utilities/regexps.dart';
 
-const String RESET_VERIFY_TEST_ID = 'test123';
-const String RESET_VERIFY_TEST_CODE = 'abcdef';
+const String FIND_PASSWORD_TEST_ID = 'test123';
 
 class FindPasswordScreen extends StatefulWidget {
   const FindPasswordScreen({super.key});
@@ -77,7 +77,7 @@ class _FindPasswordScreenState extends State<FindPasswordScreen> {
 
     if (resetVerifyKey.currentState!.validate()) {
       resetVerifyKey.currentState!.save();
-      if (loginId == RESET_VERIFY_TEST_ID) {
+      if (loginId == FIND_PASSWORD_TEST_ID) {
         setState(() {
           _isValid = true;
           _isValidLoginId = true;
@@ -184,14 +184,13 @@ class _IdVerifyForm extends StatelessWidget {
               return '아이디를 입력해 주세요.';
             }
 
-            // 영어 소문자와 숫자를 포함, 영어 대문자와 특수문자를 포함하지 않는 6~20자의 문자열
-            RegExp regExp = RegExp(r'^(?=.*[a-z])(?=.*\d)(?!.*[A-Z!@#$&*])');
-            if (val.length < 6 || val.length > 20 || !(regExp.hasMatch(val))) {
+            if (val.length < 6 ||
+                val.length > 20 ||
+                !(LoginRegExp.idRegExp.hasMatch(val))) {
               return '아이디는 영소문자/숫자 혼합 6자 이상으로 입력해 주세요.';
             }
 
             // 존재하지 않는 아이디입니다에 대한 로직 추가 예정
-
             return null;
           },
         ),

--- a/frontend/lib/screens/auth/find_password_screen.dart
+++ b/frontend/lib/screens/auth/find_password_screen.dart
@@ -21,6 +21,7 @@ class _FindPasswordScreenState extends State<FindPasswordScreen> {
   String? code;
   bool? _isValid;
   bool? _isFormValid;
+  bool? _isValidLoginId;
 
   @override
   Widget build(BuildContext context) {
@@ -47,6 +48,7 @@ class _FindPasswordScreenState extends State<FindPasswordScreen> {
                 Expanded(
                   child: _FindPasswordForm(
                     isValid: _isValid ?? false,
+                    isValidLoginId: _isValidLoginId ?? false,
                     loginId: loginId ?? '',
                     code: code ?? '',
                     onSignUpSaved: (String? val) {
@@ -78,9 +80,13 @@ class _FindPasswordScreenState extends State<FindPasswordScreen> {
       if (loginId == RESET_VERIFY_TEST_ID) {
         setState(() {
           _isValid = true;
+          _isValidLoginId = true;
         });
       } else {
-        print('아이디가 일치하지 않습니다.');
+        setState(() {
+          _isValid = true;
+          _isValidLoginId = false;
+        });
       }
     } else {
       print('에러가 있습니다.');
@@ -94,6 +100,7 @@ class _FindPasswordForm extends StatelessWidget {
   final FormFieldSetter<String> onSignUpSaved;
   final bool isValid;
   final bool isVerifyEnabled;
+  final bool isValidLoginId;
   final VoidCallback onIdVerifyPressed;
   final VoidCallback onConfirmPressed;
 
@@ -105,6 +112,7 @@ class _FindPasswordForm extends StatelessWidget {
     required this.isVerifyEnabled,
     required this.onIdVerifyPressed,
     required this.onConfirmPressed,
+    required this.isValidLoginId,
     Key? key,
   }) : super(key: key);
 
@@ -119,14 +127,17 @@ class _FindPasswordForm extends StatelessWidget {
           code: code,
           onSignUpSaved: onSignUpSaved,
           isValid: isValid,
+          isValidLoginId: isValidLoginId,
         ),
         Padding(
           padding: const EdgeInsets.only(bottom: 16.0),
           child: LoginButton(
-            onPressed: isValid ? onConfirmPressed : onIdVerifyPressed,
+            onPressed: isValid && isValidLoginId
+                ? onConfirmPressed
+                : onIdVerifyPressed,
             isEnabled: isVerifyEnabled,
             isOAuth: false,
-            btnText: isValid ? '확인' : '임시 비밀번호 받기',
+            btnText: isValid && isValidLoginId ? '확인' : '임시 비밀번호 받기',
             btnBackgroundColor: LOGIN_PRIMARY_COLOR,
             textColor: BLACK_COLOR,
           ),
@@ -141,12 +152,14 @@ class _IdVerifyForm extends StatelessWidget {
   final String code;
   final FormFieldSetter<String> onSignUpSaved;
   final bool isValid;
+  final bool isValidLoginId;
 
   const _IdVerifyForm({
     required this.loginId,
     required this.onSignUpSaved,
     required this.isValid,
     required this.code,
+    required this.isValidLoginId,
     Key? key,
   }) : super(key: key);
 
@@ -158,11 +171,11 @@ class _IdVerifyForm extends StatelessWidget {
         Text(
           '아이디',
           style: TextStyle(
-            color: !isValid ? BLACK_COLOR : DISABLED_COLOR,
+            color: !(isValid && isValidLoginId) ? BLACK_COLOR : DISABLED_COLOR,
           ),
         ),
         LoginInput(
-          isEnabled: !isValid,
+          isEnabled: !(isValid && isValidLoginId),
           initialValue: loginId,
           onSaved: onSignUpSaved,
           hintText: '가입하신 아이디를 입력해주세요.',
@@ -183,9 +196,15 @@ class _IdVerifyForm extends StatelessWidget {
           },
         ),
         SizedBox(
-          height: 30.0,
+          height: isValid && !isValidLoginId ? 15.0 : 30.0,
         ),
-        if (isValid) _ConfirmNotification(),
+        if (isValid && isValidLoginId) _ConfirmNotification(),
+        if (isValid && !isValidLoginId)
+          // 추후 토스트 메세지로 변경 예정입니다.
+          Text(
+            '존재하지 않는 아이디입니다.',
+            style: TextStyle(color: Colors.red[500]),
+          ),
       ],
     );
   }

--- a/frontend/lib/screens/auth/find_password_screen.dart
+++ b/frontend/lib/screens/auth/find_password_screen.dart
@@ -7,14 +7,14 @@ import 'package:mybrary/constants/color.dart';
 const String RESET_VERIFY_TEST_ID = 'test123';
 const String RESET_VERIFY_TEST_CODE = 'abcdef';
 
-class ResetVerifyScreen extends StatefulWidget {
-  const ResetVerifyScreen({super.key});
+class FindPasswordScreen extends StatefulWidget {
+  const FindPasswordScreen({super.key});
 
   @override
-  State<ResetVerifyScreen> createState() => _ResetVerifyScreenState();
+  State<FindPasswordScreen> createState() => _FindPasswordScreenState();
 }
 
-class _ResetVerifyScreenState extends State<ResetVerifyScreen> {
+class _FindPasswordScreenState extends State<FindPasswordScreen> {
   final GlobalKey<FormState> resetVerifyKey = GlobalKey();
 
   String? loginId;
@@ -42,10 +42,10 @@ class _ResetVerifyScreenState extends State<ResetVerifyScreen> {
             child: Column(
               children: [
                 Logo(
-                  logoText: '비밀번호 재설정',
+                  logoText: '비밀번호 찾기',
                 ),
                 Expanded(
-                  child: _ResetVerifyForm(
+                  child: _FindPasswordForm(
                     isValid: _isValid ?? false,
                     loginId: loginId ?? '',
                     code: code ?? '',
@@ -54,6 +54,9 @@ class _ResetVerifyScreenState extends State<ResetVerifyScreen> {
                     },
                     isVerifyEnabled: _isFormValid ?? false,
                     onIdVerifyPressed: onIdVerifyPressed,
+                    onConfirmPressed: () {
+                      Navigator.of(context).pop();
+                    },
                   ),
                 ),
               ],
@@ -85,21 +88,23 @@ class _ResetVerifyScreenState extends State<ResetVerifyScreen> {
   }
 }
 
-class _ResetVerifyForm extends StatelessWidget {
+class _FindPasswordForm extends StatelessWidget {
   final String loginId;
   final String code;
   final FormFieldSetter<String> onSignUpSaved;
   final bool isValid;
   final bool isVerifyEnabled;
   final VoidCallback onIdVerifyPressed;
+  final VoidCallback onConfirmPressed;
 
-  const _ResetVerifyForm({
+  const _FindPasswordForm({
     required this.loginId,
     required this.code,
     required this.onSignUpSaved,
     required this.isValid,
     required this.isVerifyEnabled,
     required this.onIdVerifyPressed,
+    required this.onConfirmPressed,
     Key? key,
   }) : super(key: key);
 
@@ -118,10 +123,10 @@ class _ResetVerifyForm extends StatelessWidget {
         Padding(
           padding: const EdgeInsets.only(bottom: 16.0),
           child: LoginButton(
-            onPressed: onIdVerifyPressed,
-            isEnabled: isValid ? false : isVerifyEnabled,
+            onPressed: isValid ? onConfirmPressed : onIdVerifyPressed,
+            isEnabled: isVerifyEnabled,
             isOAuth: false,
-            btnText: isValid ? '인증하기' : '인증번호 발송',
+            btnText: isValid ? '확인' : '임시 비밀번호 받기',
             btnBackgroundColor: LOGIN_PRIMARY_COLOR,
             textColor: BLACK_COLOR,
           ),
@@ -150,8 +155,14 @@ class _IdVerifyForm extends StatelessWidget {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        Text('아이디'),
+        Text(
+          '아이디',
+          style: TextStyle(
+            color: !isValid ? BLACK_COLOR : DISABLED_COLOR,
+          ),
+        ),
         LoginInput(
+          isEnabled: !isValid,
           initialValue: loginId,
           onSaved: onSignUpSaved,
           hintText: '가입하신 아이디를 입력해주세요.',
@@ -172,71 +183,116 @@ class _IdVerifyForm extends StatelessWidget {
           },
         ),
         SizedBox(
-          height: 20.0,
+          height: 30.0,
         ),
-        if (isValid)
-          _VerifyForm(
-            code: code,
-            onSignUpSaved: onSignUpSaved,
-          ),
+        if (isValid) _ConfirmNotification(),
       ],
     );
   }
 }
 
-class _VerifyForm extends StatelessWidget {
-  final String code;
-  final FormFieldSetter<String> onSignUpSaved;
-  const _VerifyForm({
-    required this.onSignUpSaved,
-    required this.code,
-    Key? key,
-  }) : super(key: key);
+class _ConfirmNotification extends StatelessWidget {
+  const _ConfirmNotification({super.key});
 
   @override
   Widget build(BuildContext context) {
-    final boxDecorationStyle = BoxDecoration(
-      border: Border(
-        bottom: BorderSide(
-          color: LESS_BLACK_COLOR,
-          width: 0.5,
-        ),
-      ),
-    );
-
     return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
+      crossAxisAlignment: CrossAxisAlignment.end,
       children: [
-        Text('인증코드'),
-        LoginInput(
-          suffixText: '02:00',
-          initialValue: code,
-          onSaved: onSignUpSaved,
-          hintText: '이메일로 전송된 인증코드를 입력해주세요.',
-          validator: (String? val) {
-            // 인증코드는 숫자로만? 영문/숫자 혼합?
-            // 추후 검증 로직이 추가될 예정입니다.
-            return null;
-          },
-        ),
-        SizedBox(height: 15.0),
         Row(
           mainAxisAlignment: MainAxisAlignment.end,
           children: [
-            Container(
-              padding: EdgeInsets.symmetric(vertical: 5.0),
-              decoration: boxDecorationStyle,
-              child: Text(
-                '인증코드 재발송',
-                style: TextStyle(
-                  color: LESS_BLACK_COLOR,
-                ),
-                textAlign: TextAlign.right,
-              ),
+            _notificationText('가입하신 이메일로 '),
+            _notificationText(
+              '임시 비밀번호를 발송',
+              isBold: true,
             ),
+            _notificationText('했습니다.'),
+          ],
+        ),
+        SizedBox(
+          height: 5.0,
+        ),
+        Row(
+          mainAxisAlignment: MainAxisAlignment.end,
+          children: [
+            _notificationText('임시 비밀번호로 로그인 후, '),
+            _notificationText(
+              '비밀번호를 변경',
+              isBold: true,
+            ),
+            _notificationText('해주세요.'),
           ],
         ),
       ],
     );
   }
+
+  Text _notificationText(String text, {bool isBold = false}) {
+    return Text(
+      text,
+      style: TextStyle(
+        fontSize: 16.0,
+        fontWeight: isBold ? FontWeight.w700 : FontWeight.w500,
+      ),
+    );
+  }
 }
+
+// 추후 비밀번호 재설정 관련해서 논의 후 재사용 예정
+// class _VerifyForm extends StatelessWidget {
+//   final String code;
+//   final FormFieldSetter<String> onSignUpSaved;
+//   const _VerifyForm({
+//     required this.onSignUpSaved,
+//     required this.code,
+//     Key? key,
+//   }) : super(key: key);
+//
+//   @override
+//   Widget build(BuildContext context) {
+//     final boxDecorationStyle = BoxDecoration(
+//       border: Border(
+//         bottom: BorderSide(
+//           color: LESS_BLACK_COLOR,
+//           width: 0.5,
+//         ),
+//       ),
+//     );
+//
+//     return Column(
+//       crossAxisAlignment: CrossAxisAlignment.start,
+//       children: [
+//         Text('인증코드'),
+//         LoginInput(
+//           suffixText: '02:00',
+//           initialValue: code,
+//           onSaved: onSignUpSaved,
+//           hintText: '이메일로 전송된 인증코드를 입력해주세요.',
+//           validator: (String? val) {
+//             // 인증코드는 숫자로만? 영문/숫자 혼합?
+//             // 추후 검증 로직이 추가될 예정입니다.
+//             return null;
+//           },
+//         ),
+//         SizedBox(height: 15.0),
+//         Row(
+//           mainAxisAlignment: MainAxisAlignment.end,
+//           children: [
+//             Container(
+//               padding: EdgeInsets.symmetric(vertical: 5.0),
+//               decoration: boxDecorationStyle,
+//               child: Text(
+//                 '인증코드 재발송',
+//                 style: TextStyle(
+//                   color: LESS_BLACK_COLOR,
+//                 ),
+//                 textAlign: TextAlign.right,
+//               ),
+//             ),
+//           ],
+//         ),
+//       ],
+//     );
+//   }
+// }

--- a/frontend/lib/screens/auth/find_password_screen.dart
+++ b/frontend/lib/screens/auth/find_password_screen.dart
@@ -19,7 +19,7 @@ class _FindPasswordScreenState extends State<FindPasswordScreen> {
 
   String? loginId;
   String? code;
-  bool? _isValid;
+  bool? _isInputValid;
   bool? _isFormValid;
   bool? _isValidLoginId;
 
@@ -47,7 +47,7 @@ class _FindPasswordScreenState extends State<FindPasswordScreen> {
                 ),
                 Expanded(
                   child: _FindPasswordForm(
-                    isValid: _isValid ?? false,
+                    isInputValid: _isInputValid ?? false,
                     isValidLoginId: _isValidLoginId ?? false,
                     loginId: loginId ?? '',
                     code: code ?? '',
@@ -79,17 +79,17 @@ class _FindPasswordScreenState extends State<FindPasswordScreen> {
       resetVerifyKey.currentState!.save();
       if (loginId == FIND_PASSWORD_TEST_ID) {
         setState(() {
-          _isValid = true;
+          _isInputValid = true;
           _isValidLoginId = true;
         });
       } else {
         setState(() {
-          _isValid = true;
+          _isInputValid = true;
           _isValidLoginId = false;
         });
       }
     } else {
-      print('에러가 있습니다.');
+      print('Log: 서버 에러');
     }
   }
 }
@@ -98,7 +98,7 @@ class _FindPasswordForm extends StatelessWidget {
   final String loginId;
   final String code;
   final FormFieldSetter<String> onSignUpSaved;
-  final bool isValid;
+  final bool isInputValid;
   final bool isVerifyEnabled;
   final bool isValidLoginId;
   final VoidCallback onIdVerifyPressed;
@@ -108,7 +108,7 @@ class _FindPasswordForm extends StatelessWidget {
     required this.loginId,
     required this.code,
     required this.onSignUpSaved,
-    required this.isValid,
+    required this.isInputValid,
     required this.isVerifyEnabled,
     required this.onIdVerifyPressed,
     required this.onConfirmPressed,
@@ -126,18 +126,18 @@ class _FindPasswordForm extends StatelessWidget {
           loginId: loginId,
           code: code,
           onSignUpSaved: onSignUpSaved,
-          isValid: isValid,
+          isInputValid: isInputValid,
           isValidLoginId: isValidLoginId,
         ),
         Padding(
           padding: const EdgeInsets.only(bottom: 16.0),
           child: LoginButton(
-            onPressed: isValid && isValidLoginId
+            onPressed: isInputValid && isValidLoginId
                 ? onConfirmPressed
                 : onIdVerifyPressed,
             isEnabled: isVerifyEnabled,
             isOAuth: false,
-            btnText: isValid && isValidLoginId ? '확인' : '임시 비밀번호 받기',
+            btnText: isInputValid && isValidLoginId ? '확인' : '임시 비밀번호 받기',
             btnBackgroundColor: LOGIN_PRIMARY_COLOR,
             textColor: BLACK_COLOR,
           ),
@@ -151,13 +151,13 @@ class _IdVerifyForm extends StatelessWidget {
   final String loginId;
   final String code;
   final FormFieldSetter<String> onSignUpSaved;
-  final bool isValid;
+  final bool isInputValid;
   final bool isValidLoginId;
 
   const _IdVerifyForm({
     required this.loginId,
     required this.onSignUpSaved,
-    required this.isValid,
+    required this.isInputValid,
     required this.code,
     required this.isValidLoginId,
     Key? key,
@@ -171,11 +171,13 @@ class _IdVerifyForm extends StatelessWidget {
         Text(
           '아이디',
           style: TextStyle(
-            color: !(isValid && isValidLoginId) ? BLACK_COLOR : DISABLED_COLOR,
+            color: !(isInputValid && isValidLoginId)
+                ? BLACK_COLOR
+                : DISABLED_COLOR,
           ),
         ),
         LoginInput(
-          isEnabled: !(isValid && isValidLoginId),
+          isEnabled: !(isInputValid && isValidLoginId),
           initialValue: loginId,
           onSaved: onSignUpSaved,
           hintText: '가입하신 아이디를 입력해주세요.',
@@ -195,10 +197,10 @@ class _IdVerifyForm extends StatelessWidget {
           },
         ),
         SizedBox(
-          height: isValid && !isValidLoginId ? 15.0 : 30.0,
+          height: isInputValid && !isValidLoginId ? 15.0 : 30.0,
         ),
-        if (isValid && isValidLoginId) _ConfirmNotification(),
-        if (isValid && !isValidLoginId)
+        if (isInputValid && isValidLoginId) _ConfirmNotification(),
+        if (isInputValid && !isValidLoginId)
           // 추후 토스트 메세지로 변경 예정입니다.
           Text(
             '존재하지 않는 아이디입니다.',

--- a/frontend/lib/screens/auth/login_screen.dart
+++ b/frontend/lib/screens/auth/login_screen.dart
@@ -235,7 +235,7 @@ class _OAuthLogin extends StatelessWidget {
           ),
           btnText: 'Google로 시작하기',
           btnBackgroundColor: GOOGLE_COLOR,
-          textColor: Colors.white,
+          textColor: WHITE_COLOR,
         ),
         SizedBox(
           height: 10.0,
@@ -251,7 +251,7 @@ class _OAuthLogin extends StatelessWidget {
           ),
           btnText: 'Naver로 시작하기',
           btnBackgroundColor: NAVER_COLOR,
-          textColor: Colors.white,
+          textColor: WHITE_COLOR,
         ),
         SizedBox(
           height: 10.0,
@@ -267,7 +267,7 @@ class _OAuthLogin extends StatelessWidget {
           ),
           btnText: 'Kakao로 시작하기',
           btnBackgroundColor: KAKAO_COLOR,
-          textColor: Colors.black,
+          textColor: WHITE_COLOR,
         ),
         SizedBox(
           height: 25.0,

--- a/frontend/lib/screens/auth/login_screen.dart
+++ b/frontend/lib/screens/auth/login_screen.dart
@@ -104,7 +104,7 @@ class _LoginScreenState extends State<LoginScreen> {
         print('아이디 또는 비밀번호가 틀렸습니다.');
       }
     } else {
-      print('에러가 있습니다.');
+      print('Log: 서버 에러');
     }
   }
 }

--- a/frontend/lib/screens/auth/login_screen.dart
+++ b/frontend/lib/screens/auth/login_screen.dart
@@ -30,48 +30,44 @@ class _LoginScreenState extends State<LoginScreen> {
           padding: EdgeInsets.symmetric(horizontal: 16.0),
           child: Column(
             children: [
-              SizedBox(
-                height: 50.0,
-              ),
               Logo(
                 logoText: '마이브러리',
               ),
-              SizedBox(
-                height: 50.0,
-              ),
-              Form(
-                key: formKey,
-                onChanged: () {
-                  final isValid = formKey.currentState!.validate();
-                  if (isValid != _isValid) {
-                    setState(() {
-                      _isValid = isValid;
-                    });
-                  }
-                },
-                child: Column(
-                  children: [
-                    _SelfLogin(
-                      onSavePressed: onSavePressed,
-                      loginIdInitialValue: loginId ?? '',
-                      loginPasswordInitialValue: loginPassword ?? '',
-                      onLoginIdSaved: (String? val) {
-                        loginId = val;
-                      },
-                      onLoginPasswordSaved: (String? val) {
-                        loginPassword = val;
-                      },
-                      isEnabledLogin: _isValid ?? false,
-                    ),
-                    SizedBox(
-                      height: 20.0,
-                    ),
-                    _DividerLogin(),
-                    SizedBox(
-                      height: 20.0,
-                    ),
-                    _OAuthLogin(),
-                  ],
+              Expanded(
+                child: Form(
+                  key: formKey,
+                  onChanged: () {
+                    final isValid = formKey.currentState!.validate();
+                    if (isValid != _isValid) {
+                      setState(() {
+                        _isValid = isValid;
+                      });
+                    }
+                  },
+                  child: Column(
+                    children: [
+                      _SelfLogin(
+                        onSavePressed: onSavePressed,
+                        loginIdInitialValue: loginId ?? '',
+                        loginPasswordInitialValue: loginPassword ?? '',
+                        onLoginIdSaved: (String? val) {
+                          loginId = val;
+                        },
+                        onLoginPasswordSaved: (String? val) {
+                          loginPassword = val;
+                        },
+                        isEnabledLogin: _isValid ?? false,
+                      ),
+                      SizedBox(
+                        height: 20.0,
+                      ),
+                      _DividerLogin(),
+                      SizedBox(
+                        height: 20.0,
+                      ),
+                      _OAuthLogin(),
+                    ],
+                  ),
                 ),
               ),
             ],
@@ -190,9 +186,14 @@ class _SelfLogin extends StatelessWidget {
         SizedBox(
           height: 25.0,
         ),
-        _ForgotText(
-          forgotText: '비밀번호를 잊으셨나요?',
-          fontWeight: FontWeight.w600,
+        GestureDetector(
+          onTap: () {
+            Navigator.of(context).pushNamed('/login/verify');
+          },
+          child: _ForgotText(
+            forgotText: '비밀번호를 잊으셨나요?',
+            fontWeight: FontWeight.w600,
+          ),
         ),
       ],
     );

--- a/frontend/lib/screens/auth/login_screen.dart
+++ b/frontend/lib/screens/auth/login_screen.dart
@@ -226,7 +226,7 @@ class _OAuthLogin extends StatelessWidget {
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
         LoginButton(
-          onPressed: () {
+          onPressed: () async {
             signInOAuth(oAuthType: OAuthType.google);
           },
           isOAuth: true,
@@ -262,7 +262,7 @@ class _OAuthLogin extends StatelessWidget {
           height: 10.0,
         ),
         LoginButton(
-          onPressed: () {
+          onPressed: () async {
             signInOAuth(oAuthType: OAuthType.kakao);
           },
           isOAuth: true,

--- a/frontend/lib/screens/auth/login_screen.dart
+++ b/frontend/lib/screens/auth/login_screen.dart
@@ -3,6 +3,7 @@ import 'package:mybrary/components/login/login_button_component.dart';
 import 'package:mybrary/components/login/login_input_component.dart';
 import 'package:mybrary/components/login/login_logo_component.dart';
 import 'package:mybrary/constants/color.dart';
+import 'package:mybrary/data/network/service/auth_apis.dart';
 import 'package:mybrary/utilities/regexps.dart';
 
 const LOGIN_TEST_ID = 'test123';
@@ -225,7 +226,9 @@ class _OAuthLogin extends StatelessWidget {
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
         LoginButton(
-          onPressed: () {},
+          onPressed: () {
+            signInOAuth(oAuthType: OAuthType.google);
+          },
           isOAuth: true,
           isEnabled: true,
           btnIcon: Image.asset(
@@ -241,7 +244,9 @@ class _OAuthLogin extends StatelessWidget {
           height: 10.0,
         ),
         LoginButton(
-          onPressed: () {},
+          onPressed: () {
+            signInOAuth(oAuthType: OAuthType.naver);
+          },
           isOAuth: true,
           isEnabled: true,
           btnIcon: Image.asset(
@@ -257,7 +262,9 @@ class _OAuthLogin extends StatelessWidget {
           height: 10.0,
         ),
         LoginButton(
-          onPressed: () {},
+          onPressed: () {
+            signInOAuth(oAuthType: OAuthType.kakao);
+          },
           isOAuth: true,
           isEnabled: true,
           btnIcon: Image.asset(
@@ -267,7 +274,7 @@ class _OAuthLogin extends StatelessWidget {
           ),
           btnText: 'Kakao로 시작하기',
           btnBackgroundColor: KAKAO_COLOR,
-          textColor: WHITE_COLOR,
+          textColor: BLACK_COLOR,
         ),
         SizedBox(
           height: 25.0,

--- a/frontend/lib/screens/auth/login_screen.dart
+++ b/frontend/lib/screens/auth/login_screen.dart
@@ -3,6 +3,7 @@ import 'package:mybrary/components/login/login_button_component.dart';
 import 'package:mybrary/components/login/login_input_component.dart';
 import 'package:mybrary/components/login/login_logo_component.dart';
 import 'package:mybrary/constants/color.dart';
+import 'package:mybrary/utilities/regexps.dart';
 
 const LOGIN_TEST_ID = 'test123';
 const LOGIN_TEST_PASSWORD = 'test123!@';
@@ -141,9 +142,9 @@ class _SelfLogin extends StatelessWidget {
               return '아이디를 입력해 주세요.';
             }
 
-            // 영어 소문자와 숫자를 포함, 영어 대문자와 특수문자를 포함하지 않는 6~20자의 문자열
-            RegExp regExp = RegExp(r'^(?=.*[a-z])(?=.*\d)(?!.*[A-Z!@#$&*])');
-            if (val.length < 6 || val.length > 20 || !(regExp.hasMatch(val))) {
+            if (val.length < 6 ||
+                val.length > 20 ||
+                !(LoginRegExp.idRegExp.hasMatch(val))) {
               return '아이디는 영소문자/숫자 혼합 6자 이상으로 입력해 주세요.';
             }
 
@@ -163,9 +164,9 @@ class _SelfLogin extends StatelessWidget {
               return '비밀번호를 입력해 주세요.';
             }
 
-            // 영문, 숫자, 특수문자를 포함하는 8~16자의 문자열
-            RegExp regExp = RegExp(r'^(?=.*[a-z])(?=.*\d)(?=.*[A-Z!@#$&*])');
-            if (val.length < 8 || val.length > 16 || !(regExp.hasMatch(val))) {
+            if (val.length < 8 ||
+                val.length > 16 ||
+                !(LoginRegExp.passwordRegExp.hasMatch(val))) {
               return '비밀번호는 영문/숫자/특수문자 혼합 8자 이상으로 입력해 주세요.';
             }
 

--- a/frontend/lib/screens/auth/login_screen.dart
+++ b/frontend/lib/screens/auth/login_screen.dart
@@ -188,7 +188,7 @@ class _SelfLogin extends StatelessWidget {
         ),
         GestureDetector(
           onTap: () {
-            Navigator.of(context).pushNamed('/login/verify');
+            Navigator.of(context).pushNamed('/login/findpw');
           },
           child: _ForgotText(
             forgotText: '비밀번호를 잊으셨나요?',

--- a/frontend/lib/screens/auth/reset_verify_screen.dart
+++ b/frontend/lib/screens/auth/reset_verify_screen.dart
@@ -1,0 +1,242 @@
+import 'package:flutter/material.dart';
+import 'package:mybrary/components/login/login_button_component.dart';
+import 'package:mybrary/components/login/login_input_component.dart';
+import 'package:mybrary/components/login/login_logo_component.dart';
+import 'package:mybrary/constants/color.dart';
+
+const String RESET_VERIFY_TEST_ID = 'test123';
+const String RESET_VERIFY_TEST_CODE = 'abcdef';
+
+class ResetVerifyScreen extends StatefulWidget {
+  const ResetVerifyScreen({super.key});
+
+  @override
+  State<ResetVerifyScreen> createState() => _ResetVerifyScreenState();
+}
+
+class _ResetVerifyScreenState extends State<ResetVerifyScreen> {
+  final GlobalKey<FormState> resetVerifyKey = GlobalKey();
+
+  String? loginId;
+  String? code;
+  bool? _isValid;
+  bool? _isFormValid;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      resizeToAvoidBottomInset: false,
+      body: SafeArea(
+        child: Padding(
+          padding: EdgeInsets.symmetric(horizontal: 16.0),
+          child: Form(
+            key: resetVerifyKey,
+            onChanged: () {
+              final isFormValid = resetVerifyKey.currentState!.validate();
+              if (isFormValid != _isFormValid) {
+                setState(() {
+                  _isFormValid = isFormValid;
+                });
+              }
+            },
+            child: Column(
+              children: [
+                Logo(
+                  logoText: '비밀번호 재설정',
+                ),
+                Expanded(
+                  child: _ResetVerifyForm(
+                    isValid: _isValid ?? false,
+                    loginId: loginId ?? '',
+                    code: code ?? '',
+                    onSignUpSaved: (String? val) {
+                      loginId = val;
+                    },
+                    isVerifyEnabled: _isFormValid ?? false,
+                    onIdVerifyPressed: onIdVerifyPressed,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  void onIdVerifyPressed() async {
+    // formKey는 생성을 했는데, Form 위젯과 결합을 안했을 때는 null
+    if (resetVerifyKey.currentState == null) {
+      return;
+    }
+
+    if (resetVerifyKey.currentState!.validate()) {
+      resetVerifyKey.currentState!.save();
+      if (loginId == RESET_VERIFY_TEST_ID) {
+        setState(() {
+          _isValid = true;
+        });
+      } else {
+        print('아이디가 일치하지 않습니다.');
+      }
+    } else {
+      print('에러가 있습니다.');
+    }
+  }
+}
+
+class _ResetVerifyForm extends StatelessWidget {
+  final String loginId;
+  final String code;
+  final FormFieldSetter<String> onSignUpSaved;
+  final bool isValid;
+  final bool isVerifyEnabled;
+  final VoidCallback onIdVerifyPressed;
+
+  const _ResetVerifyForm({
+    required this.loginId,
+    required this.code,
+    required this.onSignUpSaved,
+    required this.isValid,
+    required this.isVerifyEnabled,
+    required this.onIdVerifyPressed,
+    Key? key,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        _IdVerifyForm(
+          loginId: loginId,
+          code: code,
+          onSignUpSaved: onSignUpSaved,
+          isValid: isValid,
+        ),
+        Padding(
+          padding: const EdgeInsets.only(bottom: 16.0),
+          child: LoginButton(
+            onPressed: onIdVerifyPressed,
+            isEnabled: isValid ? false : isVerifyEnabled,
+            isOAuth: false,
+            btnText: isValid ? '인증하기' : '인증번호 발송',
+            btnBackgroundColor: LOGIN_PRIMARY_COLOR,
+            textColor: BLACK_COLOR,
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _IdVerifyForm extends StatelessWidget {
+  final String loginId;
+  final String code;
+  final FormFieldSetter<String> onSignUpSaved;
+  final bool isValid;
+
+  const _IdVerifyForm({
+    required this.loginId,
+    required this.onSignUpSaved,
+    required this.isValid,
+    required this.code,
+    Key? key,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text('아이디'),
+        LoginInput(
+          initialValue: loginId,
+          onSaved: onSignUpSaved,
+          hintText: '가입하신 아이디를 입력해주세요.',
+          validator: (String? val) {
+            if (val == null || val.isEmpty) {
+              return '아이디를 입력해 주세요.';
+            }
+
+            // 영어 소문자와 숫자를 포함, 영어 대문자와 특수문자를 포함하지 않는 6~20자의 문자열
+            RegExp regExp = RegExp(r'^(?=.*[a-z])(?=.*\d)(?!.*[A-Z!@#$&*])');
+            if (val.length < 6 || val.length > 20 || !(regExp.hasMatch(val))) {
+              return '아이디는 영소문자/숫자 혼합 6자 이상으로 입력해 주세요.';
+            }
+
+            // 존재하지 않는 아이디입니다에 대한 로직 추가 예정
+
+            return null;
+          },
+        ),
+        SizedBox(
+          height: 20.0,
+        ),
+        if (isValid)
+          _VerifyForm(
+            code: code,
+            onSignUpSaved: onSignUpSaved,
+          ),
+      ],
+    );
+  }
+}
+
+class _VerifyForm extends StatelessWidget {
+  final String code;
+  final FormFieldSetter<String> onSignUpSaved;
+  const _VerifyForm({
+    required this.onSignUpSaved,
+    required this.code,
+    Key? key,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    final boxDecorationStyle = BoxDecoration(
+      border: Border(
+        bottom: BorderSide(
+          color: LESS_BLACK_COLOR,
+          width: 0.5,
+        ),
+      ),
+    );
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text('인증코드'),
+        LoginInput(
+          suffixText: '02:00',
+          initialValue: code,
+          onSaved: onSignUpSaved,
+          hintText: '이메일로 전송된 인증코드를 입력해주세요.',
+          validator: (String? val) {
+            // 인증코드는 숫자로만? 영문/숫자 혼합?
+            // 추후 검증 로직이 추가될 예정입니다.
+            return null;
+          },
+        ),
+        SizedBox(height: 15.0),
+        Row(
+          mainAxisAlignment: MainAxisAlignment.end,
+          children: [
+            Container(
+              padding: EdgeInsets.symmetric(vertical: 5.0),
+              decoration: boxDecorationStyle,
+              child: Text(
+                '인증코드 재발송',
+                style: TextStyle(
+                  color: LESS_BLACK_COLOR,
+                ),
+                textAlign: TextAlign.right,
+              ),
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+}

--- a/frontend/lib/screens/auth/sign_up_screen.dart
+++ b/frontend/lib/screens/auth/sign_up_screen.dart
@@ -3,6 +3,7 @@ import 'package:mybrary/components/login/login_button_component.dart';
 import 'package:mybrary/components/login/login_input_component.dart';
 import 'package:mybrary/components/login/login_logo_component.dart';
 import 'package:mybrary/constants/color.dart';
+import 'package:mybrary/utilities/regexps.dart';
 
 class SignUpScreen extends StatefulWidget {
   const SignUpScreen({Key? key}) : super(key: key);
@@ -140,10 +141,10 @@ class _SignUpForm extends StatelessWidget {
               return '아이디를 입력해 주세요.';
             }
 
-            // 영어 소문자와 숫자를 포함, 영어 대문자와 특수문자를 포함하지 않는 6~20자의 문자열
-            RegExp regExp = RegExp(r'^(?=.*[a-z])(?=.*\d)(?!.*[A-Z!@#$&*])');
-            if (val.length < 6 || val.length > 20 || !(regExp.hasMatch(val))) {
-              return '아이디는 영소문자/숫자 혼합 6자 이상으로 입력해 주세요.';
+            if (val.length < 6 ||
+                val.length > 20 ||
+                !(LoginRegExp.idRegExp.hasMatch(val))) {
+              return '아이디는 영문/숫자 포함 6자 이상으로 입력해 주세요.';
             }
 
             return null;
@@ -162,11 +163,9 @@ class _SignUpForm extends StatelessWidget {
               return '이메일을 입력해 주세요.';
             }
 
-            // 영문/숫자/하이픈 검증 + @ + 도메인 검증 (최소 2자, 최대 7자)
-            // 이메일은 최소 7자에서 최대 40자까지 입력 가능
-            RegExp regExp =
-                RegExp(r'^[\w-]+(\.[\w-]+)*@([\w-]+\.)+[a-zA-Z]{2,7}$');
-            if (val.length < 7 || val.length > 40 || !(regExp.hasMatch(val))) {
+            if (val.length < 7 ||
+                val.length > 40 ||
+                !(LoginRegExp.emailRegExp.hasMatch(val))) {
               return '이메일 형식으로 입력해 주세요.';
             }
 
@@ -186,9 +185,9 @@ class _SignUpForm extends StatelessWidget {
               return '비밀번호를 입력해 주세요.';
             }
 
-            // 영문, 숫자, 특수문자를 포함하는 8~16자의 문자열
-            RegExp regExp = RegExp(r'^(?=.*[a-z])(?=.*\d)(?=.*[A-Z!@#$&*])');
-            if (val.length < 8 || val.length > 16 || !(regExp.hasMatch(val))) {
+            if (val.length < 8 ||
+                val.length > 16 ||
+                !(LoginRegExp.passwordRegExp.hasMatch(val))) {
               return '비밀번호는 영문/숫자/특수문자 혼합 8자 이상으로 입력해 주세요.';
             }
 
@@ -226,9 +225,9 @@ class _SignUpForm extends StatelessWidget {
               return '닉네임을 입력해 주세요.';
             }
 
-            // 영문, 숫자, 특수문자를 포함하는 6~20자 이상의 문자열
-            RegExp regExp = RegExp(r'^[a-zA-Z0-9가-힣]+$');
-            if (val.length < 6 || val.length > 20 || !(regExp.hasMatch(val))) {
+            if (val.length < 6 ||
+                val.length > 20 ||
+                !(LoginRegExp.nicknameRegExp.hasMatch(val))) {
               return '닉네임은 특수문자 제외 6자 이상으로 입력해 주세요.';
             }
 

--- a/frontend/lib/screens/auth/sign_up_screen.dart
+++ b/frontend/lib/screens/auth/sign_up_screen.dart
@@ -3,6 +3,7 @@ import 'package:mybrary/components/login/login_button_component.dart';
 import 'package:mybrary/components/login/login_input_component.dart';
 import 'package:mybrary/components/login/login_logo_component.dart';
 import 'package:mybrary/constants/color.dart';
+import 'package:mybrary/utilities/logic.dart';
 import 'package:mybrary/utilities/regexps.dart';
 
 class SignUpScreen extends StatefulWidget {
@@ -91,7 +92,7 @@ class _SignUpScreenState extends State<SignUpScreen> {
         arguments: signUpEmail,
       );
     } else {
-      print('에러가 있습니다.');
+      print('Log: 서버 에러');
     }
   }
 }
@@ -141,9 +142,8 @@ class _SignUpForm extends StatelessWidget {
               return '아이디를 입력해 주세요.';
             }
 
-            if (val.length < 6 ||
-                val.length > 20 ||
-                !(LoginRegExp.idRegExp.hasMatch(val))) {
+            // 아이디의 길이는 6~20자 입니다.
+            if (valueRegExpValidation(val, LoginRegExp.idRegExp, 6, 20)) {
               return '아이디는 영문/숫자 포함 6자 이상으로 입력해 주세요.';
             }
 
@@ -163,9 +163,8 @@ class _SignUpForm extends StatelessWidget {
               return '이메일을 입력해 주세요.';
             }
 
-            if (val.length < 7 ||
-                val.length > 40 ||
-                !(LoginRegExp.emailRegExp.hasMatch(val))) {
+            // 이메일의 길이는 10~40자 입니다.
+            if (valueRegExpValidation(val, LoginRegExp.emailRegExp, 10, 40)) {
               return '이메일 형식으로 입력해 주세요.';
             }
 
@@ -185,9 +184,8 @@ class _SignUpForm extends StatelessWidget {
               return '비밀번호를 입력해 주세요.';
             }
 
-            if (val.length < 8 ||
-                val.length > 16 ||
-                !(LoginRegExp.passwordRegExp.hasMatch(val))) {
+            // 비밀번호의 길이는 8~16자 입니다.
+            if (valueRegExpValidation(val, LoginRegExp.passwordRegExp, 8, 16)) {
               return '비밀번호는 영문/숫자/특수문자 혼합 8자 이상으로 입력해 주세요.';
             }
 
@@ -225,9 +223,8 @@ class _SignUpForm extends StatelessWidget {
               return '닉네임을 입력해 주세요.';
             }
 
-            if (val.length < 6 ||
-                val.length > 20 ||
-                !(LoginRegExp.nicknameRegExp.hasMatch(val))) {
+            // 닉네임의 길이는 2~20자 입니다.
+            if (valueRegExpValidation(val, LoginRegExp.nicknameRegExp, 2, 20)) {
               return '닉네임은 특수문자 제외 6자 이상으로 입력해 주세요.';
             }
 

--- a/frontend/lib/screens/auth/sign_up_screen.dart
+++ b/frontend/lib/screens/auth/sign_up_screen.dart
@@ -30,14 +30,8 @@ class _SignUpScreenState extends State<SignUpScreen> {
             padding: EdgeInsets.symmetric(horizontal: 16.0),
             child: Column(
               children: [
-                SizedBox(
-                  height: 50.0,
-                ),
                 Logo(
                   logoText: '회원가입',
-                ),
-                SizedBox(
-                  height: 50.0,
                 ),
                 Form(
                   key: signUpKey,
@@ -244,13 +238,16 @@ class _SignUpForm extends StatelessWidget {
         SizedBox(
           height: 30.0,
         ),
-        LoginButton(
-          onPressed: onVerifyPressed,
-          isOAuth: false,
-          isEnabled: isEnabledSignUp,
-          btnText: '인증번호 발송',
-          btnBackgroundColor: LOGIN_PRIMARY_COLOR,
-          textColor: BLACK_COLOR,
+        Padding(
+          padding: const EdgeInsets.only(bottom: 16.0),
+          child: LoginButton(
+            onPressed: onVerifyPressed,
+            isOAuth: false,
+            isEnabled: isEnabledSignUp,
+            btnText: '인증번호 발송',
+            btnBackgroundColor: LOGIN_PRIMARY_COLOR,
+            textColor: BLACK_COLOR,
+          ),
         ),
       ],
     );

--- a/frontend/lib/screens/auth/sign_up_verify_screen.dart
+++ b/frontend/lib/screens/auth/sign_up_verify_screen.dart
@@ -23,21 +23,17 @@ class _SignUpVerifyScreenState extends State<SignUpVerifyScreen> {
           padding: EdgeInsets.symmetric(horizontal: 16.0),
           child: Column(
             children: [
-              SizedBox(
-                height: 50.0,
-              ),
               Logo(
                 logoText: '회원가입',
               ),
-              SizedBox(
-                height: 140.0,
-              ),
-              _SignUpVerifyForm(
-                emailCode: emailCode ?? '',
-                onSignUpSaved: (String? val) {
-                  emailCode = val;
-                },
-                isVerifyEnabled: false,
+              Expanded(
+                child: _SignUpVerifyForm(
+                  emailCode: emailCode ?? '',
+                  onSignUpSaved: (String? val) {
+                    emailCode = val;
+                  },
+                  isVerifyEnabled: false,
+                ),
               ),
             ],
           ),
@@ -64,50 +60,76 @@ class _SignUpVerifyForm extends StatelessWidget {
     final email = ModalRoute.of(context)!.settings.arguments;
     return Form(
       child: Column(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
-          Text('이메일'),
-          Container(
-            padding: EdgeInsets.symmetric(vertical: 16.0),
-            decoration: BoxDecoration(
-              border: Border(
-                bottom: BorderSide(
-                  color: BLACK_COLOR,
-                  width: 1.0,
-                ),
-              ),
+          _VerifyForm(
+            emailCode: emailCode,
+            onSignUpSaved: onSignUpSaved,
+          ),
+          Padding(
+            padding: const EdgeInsets.only(bottom: 16.0),
+            child: LoginButton(
+              onPressed: () {},
+              isEnabled: isVerifyEnabled,
+              isOAuth: false,
+              btnText: '가입하기',
+              btnBackgroundColor: LOGIN_PRIMARY_COLOR,
+              textColor: BLACK_COLOR,
             ),
-            child: Text(
-              email.toString(),
-            ),
-          ),
-          SizedBox(
-            height: 20.0,
-          ),
-          Text('인증코드'),
-          LoginInput(
-            initialValue: emailCode,
-            onSaved: onSignUpSaved,
-            hintText: '이메일로 전송된 인증코드를 입력해주세요.',
-            validator: (String? val) {
-              // 인증코드는 숫자로만? 영문/숫자 혼합?
-              // 추후 검증 로직이 추가될 예정입니다.
-              return null;
-            },
-          ),
-          SizedBox(
-            height: 30.0,
-          ),
-          LoginButton(
-            onPressed: () {},
-            isEnabled: isVerifyEnabled,
-            isOAuth: false,
-            btnText: '가입하기',
-            btnBackgroundColor: LOGIN_PRIMARY_COLOR,
-            textColor: BLACK_COLOR,
           ),
         ],
       ),
+    );
+  }
+}
+
+class _VerifyForm extends StatelessWidget {
+  final String emailCode;
+  final FormFieldSetter<String> onSignUpSaved;
+
+  const _VerifyForm({
+    required this.emailCode,
+    required this.onSignUpSaved,
+    Key? key,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    final email = ModalRoute.of(context)!.settings.arguments;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Text('이메일'),
+        Container(
+          padding: EdgeInsets.symmetric(vertical: 16.0),
+          decoration: BoxDecoration(
+            border: Border(
+              bottom: BorderSide(
+                color: BLACK_COLOR,
+                width: 1.0,
+              ),
+            ),
+          ),
+          child: Text(
+            email.toString(),
+          ),
+        ),
+        SizedBox(
+          height: 20.0,
+        ),
+        Text('인증코드'),
+        LoginInput(
+          initialValue: emailCode,
+          onSaved: onSignUpSaved,
+          hintText: '이메일로 전송된 인증코드를 입력해주세요.',
+          validator: (String? val) {
+            // 인증코드는 숫자로만? 영문/숫자 혼합?
+            // 추후 검증 로직이 추가될 예정입니다.
+            return null;
+          },
+        ),
+      ],
     );
   }
 }

--- a/frontend/lib/screens/home_screen.dart
+++ b/frontend/lib/screens/home_screen.dart
@@ -12,7 +12,7 @@ class _HomeScreenState extends State<HomeScreen> {
   Widget build(BuildContext context) {
     return const Scaffold(
       body: Center(
-        child: Text('My brary'),
+        child: Text('마이브러리 메인 화면입니다.'),
       ),
     );
   }

--- a/frontend/lib/utilities/logic.dart
+++ b/frontend/lib/utilities/logic.dart
@@ -1,0 +1,10 @@
+bool valueRegExpValidation(
+  String val,
+  RegExp regExp,
+  int minLength,
+  int maxLength,
+) {
+  return val.length < minLength ||
+      val.length > maxLength ||
+      !(regExp.hasMatch(val));
+}

--- a/frontend/lib/utilities/regexps.dart
+++ b/frontend/lib/utilities/regexps.dart
@@ -1,16 +1,16 @@
 class LoginRegExp {
-  // 영어 소문자와 숫자를 포함, 영어 대문자와 특수문자를 포함하지 않는 6~20자의 문자열
+  // 적어도 하나의 영어 소문자와 숫자를 포함합니다.
+  // 영어 대문자와 특수문자는 포함하지 않습니다.
   static RegExp idRegExp = RegExp(r'^(?=.*[a-z])(?=.*\d)(?!.*[A-Z!@#$&*])');
 
-  // 영문/숫자/하이픈 검증 + @ + 도메인 검증 (최소 2자, 최대 7자)
-  // 이메일은 최소 7자에서 최대 40자까지 입력 가능
-  static RegExp emailRegExp =
-      RegExp(r'^[\w-]+(\.[\w-]+)*@([\w-]+\.)+[a-zA-Z]{2,7}$');
+  // 영문/숫자/하이픈 검증 + @ + 도메인 검증으로 이루어져있습니다.
+  static RegExp emailRegExp = RegExp(
+      r"^[a-zA-Z\d.a-zA-Z\d.!#$%&'*+-/=?^_`{|}~]+@[a-zA-Z\d]+\.[a-zA-Z]+");
 
-  // 영문, 숫자, 특수문자를 포함하는 8~16자의 문자열
+  // 적어도 하나의 영문, 숫자, 특수문자를 포함합니다.
   static RegExp passwordRegExp =
       RegExp(r'^(?=.*[a-z])(?=.*\d)(?=.*[A-Z!@#$&*])');
 
-  // 특수문자 제외 영문, 숫자, 한글을 포함하는 6~20자 이상의 문자열
-  static RegExp nicknameRegExp = RegExp(r'^[a-zA-Z0-9가-힣]+$');
+  // 특수문자를 제외한 영문, 숫자, 한글을 포함합니다.
+  static RegExp nicknameRegExp = RegExp(r'^[a-zA-Z\d가-힣]+$');
 }

--- a/frontend/lib/utilities/regexps.dart
+++ b/frontend/lib/utilities/regexps.dart
@@ -11,6 +11,6 @@ class LoginRegExp {
   static RegExp passwordRegExp =
       RegExp(r'^(?=.*[a-z])(?=.*\d)(?=.*[A-Z!@#$&*])');
 
-  // 영문, 숫자, 특수문자를 포함하는 6~20자 이상의 문자열
+  // 특수문자 제외 영문, 숫자, 한글을 포함하는 6~20자 이상의 문자열
   static RegExp nicknameRegExp = RegExp(r'^[a-zA-Z0-9가-힣]+$');
 }

--- a/frontend/lib/utilities/regexps.dart
+++ b/frontend/lib/utilities/regexps.dart
@@ -1,0 +1,16 @@
+class LoginRegExp {
+  // 영어 소문자와 숫자를 포함, 영어 대문자와 특수문자를 포함하지 않는 6~20자의 문자열
+  static RegExp idRegExp = RegExp(r'^(?=.*[a-z])(?=.*\d)(?!.*[A-Z!@#$&*])');
+
+  // 영문/숫자/하이픈 검증 + @ + 도메인 검증 (최소 2자, 최대 7자)
+  // 이메일은 최소 7자에서 최대 40자까지 입력 가능
+  static RegExp emailRegExp =
+      RegExp(r'^[\w-]+(\.[\w-]+)*@([\w-]+\.)+[a-zA-Z]{2,7}$');
+
+  // 영문, 숫자, 특수문자를 포함하는 8~16자의 문자열
+  static RegExp passwordRegExp =
+      RegExp(r'^(?=.*[a-z])(?=.*\d)(?=.*[A-Z!@#$&*])');
+
+  // 영문, 숫자, 특수문자를 포함하는 6~20자 이상의 문자열
+  static RegExp nicknameRegExp = RegExp(r'^[a-zA-Z0-9가-힣]+$');
+}

--- a/frontend/pubspec.lock
+++ b/frontend/pubspec.lock
@@ -75,6 +75,19 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_web_plugins:
+    dependency: transitive
+    description: flutter
+    source: sdk
+    version: "0.0.0"
+  fluttertoast:
+    dependency: "direct main"
+    description:
+      name: fluttertoast
+      sha256: "474f7d506230897a3cd28c965ec21c5328ae5605fc9c400cd330e9e9d6ac175c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "8.2.2"
   js:
     dependency: transitive
     description:
@@ -186,3 +199,4 @@ packages:
     version: "2.1.4"
 sdks:
   dart: ">=3.0.3 <4.0.0"
+  flutter: ">=1.10.0"

--- a/frontend/pubspec.lock
+++ b/frontend/pubspec.lock
@@ -75,6 +75,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_web_auth:
+    dependency: "direct main"
+    description:
+      name: flutter_web_auth
+      sha256: a69fa8f43b9e4d86ac72176bf747b735e7b977dd7cf215076d95b87cb05affdd
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.5.0"
   flutter_web_plugins:
     dependency: transitive
     description: flutter
@@ -88,6 +96,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "8.2.2"
+  http:
+    dependency: "direct main"
+    description:
+      name: http
+      sha256: "759d1a329847dd0f39226c688d3e06a6b8679668e350e2891a6474f8b4bb8525"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.0"
+  http_parser:
+    dependency: transitive
+    description:
+      name: http_parser
+      sha256: "2aa08ce0341cc9b354a498388e30986515406668dbcc4f7c950c3e715496693b"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.0.2"
   js:
     dependency: transitive
     description:
@@ -189,6 +213,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.5.1"
+  typed_data:
+    dependency: transitive
+    description:
+      name: typed_data
+      sha256: facc8d6582f16042dd49f2463ff1bd6e2c9ef9f3d5da3d9b087e244a7b564b3c
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.3.2"
   vector_math:
     dependency: transitive
     description:
@@ -199,4 +231,4 @@ packages:
     version: "2.1.4"
 sdks:
   dart: ">=3.0.3 <4.0.0"
-  flutter: ">=1.10.0"
+  flutter: ">=3.0.0"

--- a/frontend/pubspec.yaml
+++ b/frontend/pubspec.yaml
@@ -35,6 +35,7 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.2
+  fluttertoast: ^8.2.2
 
 dev_dependencies:
   flutter_test:

--- a/frontend/pubspec.yaml
+++ b/frontend/pubspec.yaml
@@ -36,6 +36,8 @@ dependencies:
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.2
   fluttertoast: ^8.2.2
+  flutter_web_auth: ^0.5.0
+  http: ^1.1.0
 
 dev_dependencies:
   flutter_test:

--- a/frontend/test/shared/res/regexps_test.dart
+++ b/frontend/test/shared/res/regexps_test.dart
@@ -1,0 +1,243 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mybrary/utilities/logic.dart';
+import 'package:mybrary/utilities/regexps.dart';
+
+const CORRECT_ID = 'test123';
+const CORRECT_PASSWORD = 'test123!@';
+const CORRECT_EMAIL = 'test1@test.com';
+const CORRECT_NICKNAME = '마이브러리ab12';
+
+void main() {
+  group('회원가입 요청 시 id 유효성 시나리오', () {
+    test('회원가입 요청 시 인증 성공', () {
+      // given
+
+      // when
+      bool result = signUpFormValidatorTest(
+          CORRECT_ID, CORRECT_PASSWORD, CORRECT_EMAIL, CORRECT_NICKNAME);
+      // then
+      expect(result, true);
+    });
+
+    test('아이디의 길이가 6자 미만이면, 인증 실패', () {
+      // given
+      String loginId = 'test1';
+      // when
+      bool result = signUpFormValidatorTest(
+          loginId, CORRECT_PASSWORD, CORRECT_EMAIL, CORRECT_NICKNAME);
+      // then
+      expect(result, false);
+    });
+
+    test('아이디의 길이가 20자 초과면, 인증 실패', () {
+      // given
+      String loginId = 'testtestte1234567890t';
+      // when
+      bool result = signUpFormValidatorTest(
+          loginId, CORRECT_PASSWORD, CORRECT_EMAIL, CORRECT_NICKNAME);
+      // then
+      expect(result, false);
+    });
+
+    test('아이디에 영어 대문자가 포함되면, 인증 실패', () {
+      // given
+      String loginId = 'Test123';
+      // when
+      bool result = signUpFormValidatorTest(
+          loginId, CORRECT_PASSWORD, CORRECT_EMAIL, CORRECT_NICKNAME);
+      // then
+      expect(result, false);
+    });
+
+    test('아이디에 특수 문자가 포함되면, 인증 실패', () {
+      // given
+      String loginId = 'test123!';
+      // when
+      bool result = signUpFormValidatorTest(
+          loginId, CORRECT_PASSWORD, CORRECT_EMAIL, CORRECT_NICKNAME);
+      // then
+      expect(result, false);
+    });
+  });
+
+  group('회원가입 요청 시 pw 유효성 시나리오', () {
+    test('회원가입 요청 시 인증 성공', () {
+      // given
+
+      // when
+      bool result = signUpFormValidatorTest(
+          CORRECT_ID, CORRECT_PASSWORD, CORRECT_EMAIL, CORRECT_NICKNAME);
+      // then
+      expect(result, true);
+    });
+
+    test('패스워드의 길이가 8자 미만이면, 인증 실패', () {
+      // given
+      String loginPassword = 't123!@';
+      // when
+      bool result = signUpFormValidatorTest(
+          CORRECT_ID, loginPassword, CORRECT_EMAIL, CORRECT_NICKNAME);
+      // then
+      expect(result, false);
+    });
+
+    test('패스워드의 길이가 16자 초과면, 인증 실패', () {
+      // given
+      String loginPassword = 'testtest12341234!@#';
+      // when
+      bool result = signUpFormValidatorTest(
+          CORRECT_ID, loginPassword, CORRECT_EMAIL, CORRECT_NICKNAME);
+      // then
+      expect(result, false);
+    });
+
+    test('패스워드에 특수 문자를 포함하지 않으면, 인증 실패', () {
+      // given
+      String loginPassword = 'test1234';
+      // when
+      bool result = signUpFormValidatorTest(
+          CORRECT_ID, loginPassword, CORRECT_EMAIL, CORRECT_NICKNAME);
+      // then
+      expect(result, false);
+    });
+
+    test('패스워드에 숫자를 포함하지 않으면, 인증 실패', () {
+      // given
+      String loginPassword = 'testtest!@';
+      // when
+      bool result = signUpFormValidatorTest(
+          CORRECT_ID, loginPassword, CORRECT_EMAIL, CORRECT_NICKNAME);
+      // then
+      expect(result, false);
+    });
+
+    test('패스워드에 영어를 포함하지 않으면, 인증 실패', () {
+      // given
+      String loginPassword = '12341234!@';
+      // when
+      bool result = signUpFormValidatorTest(
+          CORRECT_ID, loginPassword, CORRECT_EMAIL, CORRECT_NICKNAME);
+      // then
+      expect(result, false);
+    });
+  });
+
+  group('회원가입 요청 시 email 유효성 시나리오', () {
+    test('회원가입 요청 시 로그인 성공', () {
+      // given
+
+      // when
+      bool result = signUpFormValidatorTest(
+          CORRECT_ID, CORRECT_PASSWORD, CORRECT_EMAIL, CORRECT_NICKNAME);
+      // then
+      expect(result, true);
+    });
+
+    test('이메일이 10자 미만이면, 인증 실패', () {
+      // given
+      String loginEmail = 'te@st.co';
+      // when
+      bool result = signUpFormValidatorTest(
+          CORRECT_ID, CORRECT_PASSWORD, loginEmail, CORRECT_NICKNAME);
+      // then
+      expect(result, false);
+    });
+
+    test('이메일이 40자 초과면, 인증 실패', () {
+      // given
+      String loginEmail = 'test1test1test1test1@test1test1.comcomcom';
+      // when
+      bool result = signUpFormValidatorTest(
+          CORRECT_ID, CORRECT_PASSWORD, loginEmail, CORRECT_NICKNAME);
+      // then
+      expect(result, false);
+    });
+
+    test('이메일 형식에 일치하지 않으면(@미포함), 인증 실패', () {
+      // given
+      String loginEmail = 'test.com';
+      // when
+      bool result = signUpFormValidatorTest(
+          CORRECT_ID, CORRECT_PASSWORD, loginEmail, CORRECT_NICKNAME);
+      // then
+      expect(result, false);
+    });
+
+    test('이메일 형식이 일치하지 않으면(도메인), 인증 실패', () {
+      // given
+      String loginEmail = 'test1@gmail.';
+      // when
+      bool result = signUpFormValidatorTest(
+          CORRECT_ID, CORRECT_PASSWORD, loginEmail, CORRECT_NICKNAME);
+      // then
+      expect(result, false);
+    });
+  });
+
+  group('회원가입 요청 시 nickname 유효성 시나리오', () {
+    test('회원가입 요청 시 로그인 성공', () {
+      // given
+
+      // when
+      bool result = signUpFormValidatorTest(
+          CORRECT_ID, CORRECT_PASSWORD, CORRECT_EMAIL, CORRECT_NICKNAME);
+      // then
+      expect(result, true);
+    });
+
+    test('닉네임이 2자 미만이면, 인증 실패', () {
+      // given
+      String loginNickname = 't';
+      // when
+      bool result = signUpFormValidatorTest(
+          CORRECT_ID, CORRECT_PASSWORD, CORRECT_EMAIL, loginNickname);
+      // then
+      expect(result, false);
+    });
+
+    test('닉네임이 20자 초과면, 인증 실패', () {
+      // given
+      String loginNickname = 'test1test1test1test12';
+      // when
+      bool result = signUpFormValidatorTest(
+          CORRECT_ID, CORRECT_PASSWORD, CORRECT_EMAIL, loginNickname);
+      // then
+      expect(result, false);
+    });
+
+    test('닉네임에 특수 문자가 들어가면, 인증 실패', () {
+      // given
+      String loginNickname = '마이브러리1!@';
+      // when
+      bool result = signUpFormValidatorTest(
+          CORRECT_ID, CORRECT_PASSWORD, CORRECT_EMAIL, loginNickname);
+      // then
+      expect(result, false);
+    });
+  });
+}
+
+bool signUpFormValidatorTest(
+  String loginId,
+  String password,
+  String email,
+  String nickname,
+) {
+  if (valueRegExpValidation(loginId, LoginRegExp.idRegExp, 6, 20)) {
+    return false;
+  }
+
+  if (valueRegExpValidation(email, LoginRegExp.emailRegExp, 10, 40)) {
+    return false;
+  }
+
+  if (valueRegExpValidation(password, LoginRegExp.passwordRegExp, 8, 16)) {
+    return false;
+  }
+
+  if (valueRegExpValidation(nickname, LoginRegExp.nicknameRegExp, 2, 20)) {
+    return false;
+  }
+
+  return true;
+}


### PR DESCRIPTION
## 🧑‍💻 작업 사항

<img src="https://github.com/SWM-IDLE/mybrary/assets/97138841/84849813-a685-4fb3-9f5a-f8a72bcaf18a" alt="" width="310" height="650"/> 
<br><br>

- 패스워드 찾기 페이지 UI 구현 진행
  - 비밀번호를 잊으셨나요? 를 클릭하면 페이지 이동
  - 아이디를 입력하면 가입한 이메일로 임시 비밀번호 발송
  - 아이디 값에 따른 에러 처리 (유효성/존재여부)
  - 성공 후, 임시 비밀번호가 발송되면 아이디 input 비활성화
  
- 세부 작업 사항
  - 유효성 검사에 사용되는 정규표현식은 utilities/regexps 파일에 공통으로 관리
  - 공통 관리되는 정규표현식 및 색상으로 모두 수정

<br><br>

## 🔗 링크

<br><br>

## 🐰 시급한 정도

🐢 천천히 : 급하지 않습니다.

<br><br>

## 📖 참고 사항

- 추후 사용될 토스트 메세지 관련 패키지를 설치하고, 테스트 중에 있습니다.
- 비밀번호 재설정 관련 사용자 시나리오에 대해 다음에 같이 이야기를 나눠보면 좋을 것 같습니다.
- PR이 완료되면, 바로 메인 및 검색 페이지 구현으로 넘어가보도록 하겠습니다.
