### PR TITLE
[IDLE-59] feat: 소셜 로그인 기능 구현

### DIFF
--- a/user-service/.gitignore
+++ b/user-service/.gitignore
@@ -6,8 +6,8 @@ build/
 !**/src/test/**/build/
 
 ### PROPERTIES ###
-src/main/resources/application-oauth.yml
-src/main/resources/application-test.yml
+/src/main/resources/application-oauth.yml
+/src/main/resources/application-test.yml
 
 ### STS ###
 .apt_generated

--- a/user-service/.gitignore
+++ b/user-service/.gitignore
@@ -5,6 +5,10 @@ build/
 !**/src/main/**/build/
 !**/src/test/**/build/
 
+### PROPERTIES ###
+src/main/resources/application-oauth.yml
+src/main/resources/application-test.yml
+
 ### STS ###
 .apt_generated
 .classpath

--- a/user-service/build.gradle
+++ b/user-service/build.gradle
@@ -31,7 +31,7 @@ dependencies {
 	implementation 'org.projectlombok:lombok-mapstruct-binding:0.2.0'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'com.auth0:java-jwt:4.2.1'
-
+	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'

--- a/user-service/build.gradle
+++ b/user-service/build.gradle
@@ -32,6 +32,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'com.auth0:java-jwt:4.2.1'
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+	implementation 'org.apache.commons:commons-lang3'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'

--- a/user-service/http/User.http
+++ b/user-service/http/User.http
@@ -18,5 +18,11 @@ Content-Type: application/json
     "password": "password1!"
 }
 
-### 3. 소셜 로그인
+### 3. 구글 소셜 로그인
 GET http://localhost:8080/oauth2/authorization/google
+
+### 4. 카카오 소셜 로그인
+GET http://localhost:8080/oauth2/authorization/kakao
+
+### 5. 네이버 소셜 로그인
+GET http://localhost:8080/oauth2/authorization/naver

--- a/user-service/http/User.http
+++ b/user-service/http/User.http
@@ -17,3 +17,6 @@ Content-Type: application/json
     "loginId": "id11",
     "password": "password1!"
 }
+
+### 3. 소셜 로그인
+GET http://localhost:8080/oauth2/authorization/google

--- a/user-service/src/main/java/kr/mybrary/userservice/authentication/domain/AuthenticationService.java
+++ b/user-service/src/main/java/kr/mybrary/userservice/authentication/domain/AuthenticationService.java
@@ -2,11 +2,13 @@ package kr.mybrary.userservice.authentication.domain;
 
 import kr.mybrary.userservice.authentication.presentation.dto.response.SignUpResponse;
 import kr.mybrary.userservice.authentication.presentation.dto.request.SignUpRequest;
+import kr.mybrary.userservice.user.persistence.User;
 import org.springframework.security.core.userdetails.UserDetailsService;
 
 public interface AuthenticationService extends UserDetailsService {
 
     public SignUpResponse signUp(SignUpRequest signUpRequest);
 
+    public User authorizeUser(String loginId);
 
 }

--- a/user-service/src/main/java/kr/mybrary/userservice/authentication/domain/impl/AuthenticationServiceImpl.java
+++ b/user-service/src/main/java/kr/mybrary/userservice/authentication/domain/impl/AuthenticationServiceImpl.java
@@ -43,7 +43,7 @@ public class AuthenticationServiceImpl implements AuthenticationService {
     @Override
     public User authorizeUser(String loginId) {
         User findUser = userRepository.findByLoginId(loginId)
-                .orElseThrow(() -> new IllegalArgumentException("해당 유저가 존재하지 않습니다."));
+                .orElseThrow(() -> new UsernameNotFoundException(loginId));
         findUser.authorizeUser();
         return userRepository.save(findUser);
     }

--- a/user-service/src/main/java/kr/mybrary/userservice/authentication/domain/impl/AuthenticationServiceImpl.java
+++ b/user-service/src/main/java/kr/mybrary/userservice/authentication/domain/impl/AuthenticationServiceImpl.java
@@ -33,7 +33,7 @@ public class AuthenticationServiceImpl implements AuthenticationService {
 
         User user = UserMapper.INSTANCE.toEntity(signUpRequest);
         user.updatePassword(passwordEncoder.encode(user.getPassword()));
-        user.authorizeUser();
+        user.grantUserRole();
         SignUpResponse signUpResponse = UserMapper.INSTANCE.toResponse(userRepository.save(user));
 
         return signUpResponse;
@@ -44,7 +44,7 @@ public class AuthenticationServiceImpl implements AuthenticationService {
     public User authorizeUser(String loginId) {
         User findUser = userRepository.findByLoginId(loginId)
                 .orElseThrow(() -> new UsernameNotFoundException(loginId));
-        findUser.authorizeUser();
+        findUser.grantUserRole();
         return userRepository.save(findUser);
     }
 

--- a/user-service/src/main/java/kr/mybrary/userservice/authentication/domain/impl/AuthenticationServiceImpl.java
+++ b/user-service/src/main/java/kr/mybrary/userservice/authentication/domain/impl/AuthenticationServiceImpl.java
@@ -8,7 +8,6 @@ import kr.mybrary.userservice.authentication.domain.exception.DuplicateLoginIdEx
 import kr.mybrary.userservice.authentication.domain.exception.DuplicateNicknameException;
 import kr.mybrary.userservice.authentication.presentation.dto.request.SignUpRequest;
 import kr.mybrary.userservice.authentication.presentation.dto.response.SignUpResponse;
-import kr.mybrary.userservice.user.persistence.Role;
 import kr.mybrary.userservice.user.persistence.User;
 import kr.mybrary.userservice.user.persistence.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -34,11 +33,19 @@ public class AuthenticationServiceImpl implements AuthenticationService {
 
         User user = UserMapper.INSTANCE.toEntity(signUpRequest);
         user.updatePassword(passwordEncoder.encode(user.getPassword()));
-        user.updateRole(Role.USER);
+        user.authorizeUser();
         SignUpResponse signUpResponse = UserMapper.INSTANCE.toResponse(userRepository.save(user));
 
         return signUpResponse;
 
+    }
+
+    @Override
+    public User authorizeUser(String loginId) {
+        User findUser = userRepository.findByLoginId(loginId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 유저가 존재하지 않습니다."));
+        findUser.authorizeUser();
+        return userRepository.save(findUser);
     }
 
     @Override

--- a/user-service/src/main/java/kr/mybrary/userservice/authentication/domain/login/LoginException.java
+++ b/user-service/src/main/java/kr/mybrary/userservice/authentication/domain/login/LoginException.java
@@ -1,0 +1,17 @@
+package kr.mybrary.userservice.authentication.domain.login;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum LoginException {
+
+    LOGIN_ID_NOT_FOUND("U-05", "존재하지 않는 아이디입니다: %s"),
+    PASSWORD_NOT_MATCH("U-06", "비밀번호가 일치하지 않습니다."),
+    CONTENT_TYPE_NOT_JSON("U-07", "지원되지 않는 Content-Type 입니다: %s. JSON 형식으로 요청해주세요.");
+
+    private final String errorCode;
+    private final String errorMessage;
+
+}

--- a/user-service/src/main/java/kr/mybrary/userservice/authentication/domain/login/handler/LoginFailureHandler.java
+++ b/user-service/src/main/java/kr/mybrary/userservice/authentication/domain/login/handler/LoginFailureHandler.java
@@ -1,5 +1,9 @@
 package kr.mybrary.userservice.authentication.domain.login.handler;
 
+import static kr.mybrary.userservice.authentication.domain.login.LoginException.CONTENT_TYPE_NOT_JSON;
+import static kr.mybrary.userservice.authentication.domain.login.LoginException.LOGIN_ID_NOT_FOUND;
+import static kr.mybrary.userservice.authentication.domain.login.LoginException.PASSWORD_NOT_MATCH;
+
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.HttpServletRequest;
@@ -21,12 +25,6 @@ public class LoginFailureHandler extends SimpleUrlAuthenticationFailureHandler {
 
     static final String ENCODING_UTF_8 = "UTF-8";
     static final String CONTENT_TYPE_JSON = "application/json";
-    static final String ERROR_CODE_LOGIN_ID_NOT_FOUND = "U-05";
-    static final String ERROR_CODE_PASSWORD_INCORRECT = "U-06";
-    static final String ERROR_CODE_CONTENT_TYPE_NOT_JSON = "U-07";
-    static final String ERROR_MESSAGE_LOGIN_ID_NOT_FOUND = "존재하지 않는 아이디입니다: %s";
-    static final String ERROR_MESSAGE_PASSWORD_INCORRECT = "비밀번호가 일치하지 않습니다.";
-    static final String ERROR_MESSAGE_CONTENT_TYPE_NOT_JSON = "지원되지 않는 Content-Type 입니다: %s. JSON 형식으로 요청해주세요.";
 
     private static final ObjectMapper objectMapper = new ObjectMapper();
 
@@ -50,26 +48,26 @@ public class LoginFailureHandler extends SimpleUrlAuthenticationFailureHandler {
 
     private String getErrorCode(AuthenticationException exception) {
         if (exception instanceof AuthenticationServiceException) {
-            return ERROR_CODE_CONTENT_TYPE_NOT_JSON;
+            return CONTENT_TYPE_NOT_JSON.getErrorCode();
         }
         if (exception instanceof UsernameNotFoundException) {
-            return ERROR_CODE_LOGIN_ID_NOT_FOUND;
+            return LOGIN_ID_NOT_FOUND.getErrorCode();
         }
         if (exception instanceof BadCredentialsException) {
-            return ERROR_CODE_PASSWORD_INCORRECT;
+            return PASSWORD_NOT_MATCH.getErrorCode();
         }
         return null;
     }
 
     private String getErrorMessage(AuthenticationException exception) {
         if (exception instanceof AuthenticationServiceException) {
-            return String.format(ERROR_MESSAGE_CONTENT_TYPE_NOT_JSON, exception.getMessage());
+            return String.format(CONTENT_TYPE_NOT_JSON.getErrorMessage(), exception.getMessage());
         }
         if (exception instanceof UsernameNotFoundException) {
-            return String.format(ERROR_MESSAGE_LOGIN_ID_NOT_FOUND, exception.getMessage());
+            return String.format(LOGIN_ID_NOT_FOUND.getErrorMessage(), exception.getMessage());
         }
         if (exception instanceof BadCredentialsException) {
-            return ERROR_MESSAGE_PASSWORD_INCORRECT;
+            return PASSWORD_NOT_MATCH.getErrorMessage();
         }
         return exception.getMessage();
     }

--- a/user-service/src/main/java/kr/mybrary/userservice/authentication/domain/login/handler/LoginFailureHandler.java
+++ b/user-service/src/main/java/kr/mybrary/userservice/authentication/domain/login/handler/LoginFailureHandler.java
@@ -11,9 +11,8 @@ import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
-import javax.print.attribute.standard.Media;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.MediaType;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.authentication.AuthenticationServiceException;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.core.AuthenticationException;
@@ -26,7 +25,8 @@ public class LoginFailureHandler extends SimpleUrlAuthenticationFailureHandler {
     static final String ENCODING_UTF_8 = "UTF-8";
     static final String CONTENT_TYPE_JSON = "application/json";
 
-    private static final ObjectMapper objectMapper = new ObjectMapper();
+    @Autowired
+    private ObjectMapper objectMapper;
 
     @Override
     public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response,

--- a/user-service/src/main/java/kr/mybrary/userservice/authentication/domain/oauth2/CustomOAuth2User.java
+++ b/user-service/src/main/java/kr/mybrary/userservice/authentication/domain/oauth2/CustomOAuth2User.java
@@ -1,0 +1,23 @@
+package kr.mybrary.userservice.authentication.domain.oauth2;
+
+import java.util.Collection;
+import java.util.Map;
+import kr.mybrary.userservice.user.persistence.Role;
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+
+@Getter
+public class CustomOAuth2User extends DefaultOAuth2User {
+
+    private String email;
+    private Role role;
+
+    public CustomOAuth2User(Collection<? extends GrantedAuthority> authorities,
+            Map<String, Object> attributes, String nameAttributeKey, String email, Role role) {
+        super(authorities, attributes, nameAttributeKey);
+        this.email = email;
+        this.role = role;
+    }
+
+}

--- a/user-service/src/main/java/kr/mybrary/userservice/authentication/domain/oauth2/CustomOAuth2User.java
+++ b/user-service/src/main/java/kr/mybrary/userservice/authentication/domain/oauth2/CustomOAuth2User.java
@@ -10,13 +10,13 @@ import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
 @Getter
 public class CustomOAuth2User extends DefaultOAuth2User {
 
-    private String email;
+    private String loginId;
     private Role role;
 
     public CustomOAuth2User(Collection<? extends GrantedAuthority> authorities,
-            Map<String, Object> attributes, String nameAttributeKey, String email, Role role) {
+            Map<String, Object> attributes, String nameAttributeKey, String loginId, Role role) {
         super(authorities, attributes, nameAttributeKey);
-        this.email = email;
+        this.loginId = loginId;
         this.role = role;
     }
 

--- a/user-service/src/main/java/kr/mybrary/userservice/authentication/domain/oauth2/OAuth2Exception.java
+++ b/user-service/src/main/java/kr/mybrary/userservice/authentication/domain/oauth2/OAuth2Exception.java
@@ -1,0 +1,15 @@
+package kr.mybrary.userservice.authentication.domain.oauth2;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum OAuth2Exception {
+
+    SOCIAL_LOGIN_FAILED("U-08", "소셜 로그인에 실패하였습니다: %s");
+
+    private final String errorCode;
+    private final String errorMessage;
+
+}

--- a/user-service/src/main/java/kr/mybrary/userservice/authentication/domain/oauth2/OAuthAttributes.java
+++ b/user-service/src/main/java/kr/mybrary/userservice/authentication/domain/oauth2/OAuthAttributes.java
@@ -77,7 +77,7 @@ public class OAuthAttributes {
                 .email(oAuth2UserInfo.getEmail())
                 .nickname(oAuth2UserInfo.getNickname() + RandomStringUtils.randomNumeric(5))
                 .profileImageUrl(oAuth2UserInfo.getImageUrl())
-                .role(Role.GUEST)
+                .role(Role.USER)
                 .build();
     }
 

--- a/user-service/src/main/java/kr/mybrary/userservice/authentication/domain/oauth2/OAuthAttributes.java
+++ b/user-service/src/main/java/kr/mybrary/userservice/authentication/domain/oauth2/OAuthAttributes.java
@@ -3,6 +3,8 @@ package kr.mybrary.userservice.authentication.domain.oauth2;
 import java.util.Map;
 import java.util.UUID;
 import kr.mybrary.userservice.authentication.domain.oauth2.userinfo.GoogleOAuth2UserInfo;
+import kr.mybrary.userservice.authentication.domain.oauth2.userinfo.KakaoOAuth2UserInfo;
+import kr.mybrary.userservice.authentication.domain.oauth2.userinfo.NaverOAuth2UserInfo;
 import kr.mybrary.userservice.authentication.domain.oauth2.userinfo.OAuth2UserInfo;
 import kr.mybrary.userservice.user.persistence.Role;
 import kr.mybrary.userservice.user.persistence.SocialType;
@@ -31,6 +33,12 @@ public class OAuthAttributes { // 소셜 별로 받는 데이터를 분기 처�
         if (socialType == SocialType.GOOGLE) {
             return ofGoogle(userNameAttributeName, attributes);
         }
+        if (socialType == SocialType.KAKAO) {
+            return ofKakao(userNameAttributeName, attributes);
+        }
+        if (socialType == SocialType.NAVER) {
+            return ofNaver(userNameAttributeName, attributes);
+        }
         throw new OAuth2AuthenticationException(SOCIAL_TYPE_NOT_SUPPORTED);
     }
 
@@ -39,6 +47,22 @@ public class OAuthAttributes { // 소셜 별로 받는 데이터를 분기 처�
         return OAuthAttributes.builder()
                 .nameAttributeKey(userNameAttributeName)
                 .oAuth2UserInfo(new GoogleOAuth2UserInfo(attributes))
+                .build();
+    }
+
+    private static OAuthAttributes ofKakao(String userNameAttributeName,
+            Map<String, Object> attributes) {
+        return OAuthAttributes.builder()
+                .nameAttributeKey(userNameAttributeName)
+                .oAuth2UserInfo(new KakaoOAuth2UserInfo(attributes))
+                .build();
+    }
+
+    private static OAuthAttributes ofNaver(String userNameAttributeName,
+            Map<String, Object> attributes) {
+        return OAuthAttributes.builder()
+                .nameAttributeKey(userNameAttributeName)
+                .oAuth2UserInfo(new NaverOAuth2UserInfo(attributes))
                 .build();
     }
 

--- a/user-service/src/main/java/kr/mybrary/userservice/authentication/domain/oauth2/OAuthAttributes.java
+++ b/user-service/src/main/java/kr/mybrary/userservice/authentication/domain/oauth2/OAuthAttributes.java
@@ -1,0 +1,54 @@
+package kr.mybrary.userservice.authentication.domain.oauth2;
+
+import java.util.Map;
+import java.util.UUID;
+import kr.mybrary.userservice.authentication.domain.oauth2.userinfo.GoogleOAuth2UserInfo;
+import kr.mybrary.userservice.authentication.domain.oauth2.userinfo.OAuth2UserInfo;
+import kr.mybrary.userservice.user.persistence.Role;
+import kr.mybrary.userservice.user.persistence.SocialType;
+import kr.mybrary.userservice.user.persistence.User;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class OAuthAttributes { // 소셜 별로 받는 데이터를 분기 처리하는 DTO 클래스
+
+    private String nameAttributeKey; // OAuth2 로그인 진행 시 키가 되는 필드 값
+    private OAuth2UserInfo oAuth2UserInfo;
+
+    @Builder
+    public OAuthAttributes(String nameAttributeKey, OAuth2UserInfo oAuth2UserInfo) {
+        this.nameAttributeKey = nameAttributeKey;
+        this.oAuth2UserInfo = oAuth2UserInfo;
+    }
+
+    public static OAuthAttributes of(SocialType socialType, String userNameAttributeName,
+            Map<String, Object> attributes) {
+        if (socialType == SocialType.GOOGLE) {
+            return ofGoogle(userNameAttributeName, attributes);
+        }
+        throw new IllegalArgumentException("지원하지 않는 소셜 타입입니다.");
+    }
+
+    private static OAuthAttributes ofGoogle(String userNameAttributeName,
+            Map<String, Object> attributes) {
+        return OAuthAttributes.builder()
+                .nameAttributeKey(userNameAttributeName)
+                .oAuth2UserInfo(new GoogleOAuth2UserInfo(attributes))
+                .build();
+    }
+
+    private User toEntity(SocialType socialType, OAuth2UserInfo oAuth2UserInfo) {
+        return User.builder()
+                .socialType(socialType)
+                .socialId(oAuth2UserInfo.getId())
+                .loginId(UUID.randomUUID().toString())
+                .email(UUID.randomUUID() + "@socialUser.com")
+                .nickname(oAuth2UserInfo.getNickname())
+                .profileImageUrl(oAuth2UserInfo.getImageUrl())
+                .role(Role.GUEST)
+                .build();
+    }
+
+
+}

--- a/user-service/src/main/java/kr/mybrary/userservice/authentication/domain/oauth2/OAuthAttributes.java
+++ b/user-service/src/main/java/kr/mybrary/userservice/authentication/domain/oauth2/OAuthAttributes.java
@@ -43,6 +43,7 @@ public class OAuthAttributes { // 소셜 별로 받는 데이터를 분기 처�
                 .socialType(socialType)
                 .socialId(oAuth2UserInfo.getId())
                 .loginId(UUID.randomUUID().toString())
+                .password(UUID.randomUUID().toString())
                 .email(oAuth2UserInfo.getEmail())
                 .nickname(oAuth2UserInfo.getNickname())
                 .profileImageUrl(oAuth2UserInfo.getImageUrl())

--- a/user-service/src/main/java/kr/mybrary/userservice/authentication/domain/oauth2/OAuthAttributes.java
+++ b/user-service/src/main/java/kr/mybrary/userservice/authentication/domain/oauth2/OAuthAttributes.java
@@ -14,10 +14,12 @@ import lombok.Getter;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 
+// 소셜 별로 받는 데이터를 분기 처리하는 DTO 클래스
 @Getter
-public class OAuthAttributes { // 소셜 별로 받는 데이터를 분기 처리하는 DTO 클래스
+public class OAuthAttributes {
 
-    private String nameAttributeKey; // OAuth2 로그인 진행 시 키가 되는 필드 값
+    // OAuth2 로그인 진행 시 키가 되는 필드 값
+    private String nameAttributeKey;
     private OAuth2UserInfo oAuth2UserInfo;
 
     private static final String SOCIAL_TYPE_NOT_SUPPORTED = "지원하지 않는 소셜 로그인입니다.";

--- a/user-service/src/main/java/kr/mybrary/userservice/authentication/domain/oauth2/OAuthAttributes.java
+++ b/user-service/src/main/java/kr/mybrary/userservice/authentication/domain/oauth2/OAuthAttributes.java
@@ -38,12 +38,12 @@ public class OAuthAttributes { // 소셜 별로 받는 데이터를 분기 처�
                 .build();
     }
 
-    private User toEntity(SocialType socialType, OAuth2UserInfo oAuth2UserInfo) {
+    public User toEntity(SocialType socialType, OAuth2UserInfo oAuth2UserInfo) {
         return User.builder()
                 .socialType(socialType)
                 .socialId(oAuth2UserInfo.getId())
                 .loginId(UUID.randomUUID().toString())
-                .email(UUID.randomUUID() + "@socialUser.com")
+                .email(oAuth2UserInfo.getEmail())
                 .nickname(oAuth2UserInfo.getNickname())
                 .profileImageUrl(oAuth2UserInfo.getImageUrl())
                 .role(Role.GUEST)

--- a/user-service/src/main/java/kr/mybrary/userservice/authentication/domain/oauth2/OAuthAttributes.java
+++ b/user-service/src/main/java/kr/mybrary/userservice/authentication/domain/oauth2/OAuthAttributes.java
@@ -10,12 +10,15 @@ import kr.mybrary.userservice.user.persistence.User;
 import lombok.Builder;
 import lombok.Getter;
 import org.apache.commons.lang3.RandomStringUtils;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 
 @Getter
 public class OAuthAttributes { // 소셜 별로 받는 데이터를 분기 처리하는 DTO 클래스
 
     private String nameAttributeKey; // OAuth2 로그인 진행 시 키가 되는 필드 값
     private OAuth2UserInfo oAuth2UserInfo;
+
+    private static final String SOCIAL_TYPE_NOT_SUPPORTED = "지원하지 않는 소셜 로그인입니다.";
 
     @Builder
     public OAuthAttributes(String nameAttributeKey, OAuth2UserInfo oAuth2UserInfo) {
@@ -28,7 +31,7 @@ public class OAuthAttributes { // 소셜 별로 받는 데이터를 분기 처�
         if (socialType == SocialType.GOOGLE) {
             return ofGoogle(userNameAttributeName, attributes);
         }
-        throw new IllegalArgumentException("지원하지 않는 소셜 타입입니다.");
+        throw new OAuth2AuthenticationException(SOCIAL_TYPE_NOT_SUPPORTED);
     }
 
     private static OAuthAttributes ofGoogle(String userNameAttributeName,

--- a/user-service/src/main/java/kr/mybrary/userservice/authentication/domain/oauth2/OAuthAttributes.java
+++ b/user-service/src/main/java/kr/mybrary/userservice/authentication/domain/oauth2/OAuthAttributes.java
@@ -9,6 +9,7 @@ import kr.mybrary.userservice.user.persistence.SocialType;
 import kr.mybrary.userservice.user.persistence.User;
 import lombok.Builder;
 import lombok.Getter;
+import org.apache.commons.lang3.RandomStringUtils;
 
 @Getter
 public class OAuthAttributes { // 소셜 별로 받는 데이터를 분기 처리하는 DTO 클래스
@@ -45,7 +46,7 @@ public class OAuthAttributes { // 소셜 별로 받는 데이터를 분기 처�
                 .loginId(UUID.randomUUID().toString())
                 .password(UUID.randomUUID().toString())
                 .email(oAuth2UserInfo.getEmail())
-                .nickname(oAuth2UserInfo.getNickname())
+                .nickname(oAuth2UserInfo.getNickname() + RandomStringUtils.randomNumeric(5))
                 .profileImageUrl(oAuth2UserInfo.getImageUrl())
                 .role(Role.GUEST)
                 .build();

--- a/user-service/src/main/java/kr/mybrary/userservice/authentication/domain/oauth2/handler/OAuth2LoginFailureHandler.java
+++ b/user-service/src/main/java/kr/mybrary/userservice/authentication/domain/oauth2/handler/OAuth2LoginFailureHandler.java
@@ -10,6 +10,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 import org.springframework.security.web.authentication.AuthenticationFailureHandler;
@@ -22,7 +23,8 @@ public class OAuth2LoginFailureHandler implements AuthenticationFailureHandler {
     static final String ENCODING_UTF_8 = "UTF-8";
     static final String CONTENT_TYPE_JSON = "application/json";
 
-    private static final ObjectMapper objectMapper = new ObjectMapper();
+    @Autowired
+    private ObjectMapper objectMapper;
 
     @Override
     public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response,
@@ -31,10 +33,10 @@ public class OAuth2LoginFailureHandler implements AuthenticationFailureHandler {
         response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
         response.setCharacterEncoding(ENCODING_UTF_8);
         response.setContentType(CONTENT_TYPE_JSON);
-        response.getWriter().write(generateRequestBody(exception));
+        response.getWriter().write(generateResponseBody(exception));
     }
 
-    private String generateRequestBody(AuthenticationException exception)
+    private String generateResponseBody(AuthenticationException exception)
             throws JsonProcessingException {
         Map<String, String> responseMessage = new HashMap<>();
         responseMessage.put("errorCode", getErrorCode(exception));

--- a/user-service/src/main/java/kr/mybrary/userservice/authentication/domain/oauth2/handler/OAuth2LoginFailureHandler.java
+++ b/user-service/src/main/java/kr/mybrary/userservice/authentication/domain/oauth2/handler/OAuth2LoginFailureHandler.java
@@ -1,11 +1,17 @@
 package kr.mybrary.userservice.authentication.domain.oauth2.handler;
 
-import jakarta.servlet.ServletException;
+import static kr.mybrary.userservice.authentication.domain.oauth2.OAuth2Exception.SOCIAL_LOGIN_FAILED;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 import org.springframework.security.web.authentication.AuthenticationFailureHandler;
 import org.springframework.stereotype.Component;
 
@@ -13,12 +19,42 @@ import org.springframework.stereotype.Component;
 @Slf4j
 public class OAuth2LoginFailureHandler implements AuthenticationFailureHandler {
 
+    static final String ENCODING_UTF_8 = "UTF-8";
+    static final String CONTENT_TYPE_JSON = "application/json";
+
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+
     @Override
     public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response,
             AuthenticationException exception) throws IOException {
-        log.info("OAuth2 Login Failure Handler 실행 - OAuth2 로그인 실패");
+        log.info("OAuth2 Login Failure Handler 실행 - OAuth2 로그인 실패 : " + exception.getMessage());
         response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
-        response.getWriter().write("소셜 로그인 실패! 서버 로그를 확인해주세요.");
+        response.setCharacterEncoding(ENCODING_UTF_8);
+        response.setContentType(CONTENT_TYPE_JSON);
+        response.getWriter().write(generateRequestBody(exception));
     }
+
+    private String generateRequestBody(AuthenticationException exception)
+            throws JsonProcessingException {
+        Map<String, String> responseMessage = new HashMap<>();
+        responseMessage.put("errorCode", getErrorCode(exception));
+        responseMessage.put("errorMessage", getErrorMessage(exception));
+        return objectMapper.writeValueAsString(responseMessage);
+    }
+
+    private String getErrorCode(AuthenticationException exception) {
+        if(exception instanceof OAuth2AuthenticationException) {
+            return SOCIAL_LOGIN_FAILED.getErrorCode();
+        }
+        return null;
+    }
+
+    private String getErrorMessage(AuthenticationException exception) {
+        if(exception instanceof OAuth2AuthenticationException) {
+            return String.format(SOCIAL_LOGIN_FAILED.getErrorMessage(), exception.getMessage());
+        }
+        return exception.getMessage();
+    }
+
 
 }

--- a/user-service/src/main/java/kr/mybrary/userservice/authentication/domain/oauth2/handler/OAuth2LoginFailureHandler.java
+++ b/user-service/src/main/java/kr/mybrary/userservice/authentication/domain/oauth2/handler/OAuth2LoginFailureHandler.java
@@ -1,0 +1,24 @@
+package kr.mybrary.userservice.authentication.domain.oauth2.handler;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+public class OAuth2LoginFailureHandler implements AuthenticationFailureHandler {
+
+    @Override
+    public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response,
+            AuthenticationException exception) throws IOException {
+        log.info("OAuth2 Login Failure Handler 실행 - OAuth2 로그인 실패");
+        response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+        response.getWriter().write("소셜 로그인 실패! 서버 로그를 확인해주세요.");
+    }
+
+}

--- a/user-service/src/main/java/kr/mybrary/userservice/authentication/domain/oauth2/handler/OAuth2LoginSuccessHandler.java
+++ b/user-service/src/main/java/kr/mybrary/userservice/authentication/domain/oauth2/handler/OAuth2LoginSuccessHandler.java
@@ -4,11 +4,13 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.Date;
+import kr.mybrary.userservice.authentication.domain.AuthenticationService;
 import kr.mybrary.userservice.authentication.domain.oauth2.CustomOAuth2User;
 import kr.mybrary.userservice.global.jwt.service.JwtService;
 import kr.mybrary.userservice.user.persistence.Role;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
@@ -18,16 +20,19 @@ import org.springframework.stereotype.Component;
 @Slf4j
 public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
 
+    static final String ENCODING_UTF_8 = "UTF-8";
+    static final String CONTENT_TYPE_TEXT_PLAIN = "text/plain";
+
     private final JwtService jwtService;
+    private final AuthenticationService authenticationService;
 
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
             Authentication authentication) throws IOException {
-        log.info("OAth2 Login Success Handler 실행 - OAuth2 로그인 성공");
+        log.info("OAuth2 Login Success Handler 실행 - OAuth2 로그인 성공");
 
         CustomOAuth2User oAuth2User = (CustomOAuth2User) authentication.getPrincipal();
 
-        // User의 Role이 GUEST일 경우, 처음 요청한 회원이므로 회원가입 페이지로 리다이렉트
         if (oAuth2User.getRole() == Role.GUEST) {
             initialLoginSuccess(response, oAuth2User);
             return;
@@ -40,9 +45,13 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
             throws IOException {
         String accessToken = jwtService.createAccessToken(oAuth2User.getLoginId(), new Date());
         response.addHeader(jwtService.getAccessHeader(), "Bearer " + accessToken);
-        response.sendRedirect("oauth2/sign-up"); // 회원 가입 추가 정보(닉네임) 입력 페이지로 리다이렉트
-        // Role을 GUEST -> USER 로 업데이트하는 로직 필요
+        response.setCharacterEncoding(ENCODING_UTF_8);
+        response.setContentType(CONTENT_TYPE_TEXT_PLAIN);
+        response.getWriter().write("회원 가입이 완료되었습니다.");
         jwtService.sendAccessAndRefreshToken(response, accessToken, null);
+        // 추가 정보 입력 필요 시 회원 가입 추가 정보 입력 페이지로 리다이렉트 후 USER 권한 부여
+        authenticationService.authorizeUser(oAuth2User.getLoginId());
+        log.info("OAuth2 Login Success Handler : initialLoginSuccess 실행 - 회원 가입 성공");
     }
 
     // TODO : 소셜 로그인 시에도 무조건 토큰 생성하지 말고 JWT 인증 필터처럼 RefreshToken 유/무에 따라 다르게 처리해보기
@@ -55,7 +64,6 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
         jwtService.sendAccessAndRefreshToken(response, accessToken, refreshToken);
         jwtService.updateRefreshToken(oAuth2User.getLoginId(), refreshToken);
     }
-
 
 
 }

--- a/user-service/src/main/java/kr/mybrary/userservice/authentication/domain/oauth2/handler/OAuth2LoginSuccessHandler.java
+++ b/user-service/src/main/java/kr/mybrary/userservice/authentication/domain/oauth2/handler/OAuth2LoginSuccessHandler.java
@@ -1,0 +1,61 @@
+package kr.mybrary.userservice.authentication.domain.oauth2.handler;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Date;
+import kr.mybrary.userservice.authentication.domain.oauth2.CustomOAuth2User;
+import kr.mybrary.userservice.global.jwt.service.JwtService;
+import kr.mybrary.userservice.user.persistence.Role;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
+
+    private final JwtService jwtService;
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
+            Authentication authentication) throws IOException {
+        log.info("OAth2 Login Success Handler 실행 - OAuth2 로그인 성공");
+
+        CustomOAuth2User oAuth2User = (CustomOAuth2User) authentication.getPrincipal();
+
+        // User의 Role이 GUEST일 경우, 처음 요청한 회원이므로 회원가입 페이지로 리다이렉트
+        if (oAuth2User.getRole() == Role.GUEST) {
+            initialLoginSuccess(response, oAuth2User);
+            return;
+        }
+        loginSuccess(response, oAuth2User);
+
+    }
+
+    private void initialLoginSuccess(HttpServletResponse response, CustomOAuth2User oAuth2User)
+            throws IOException {
+        String accessToken = jwtService.createAccessToken(oAuth2User.getLoginId(), new Date());
+        response.addHeader(jwtService.getAccessHeader(), "Bearer " + accessToken);
+        response.sendRedirect("oauth2/sign-up"); // 회원 가입 추가 정보(닉네임) 입력 페이지로 리다이렉트
+        // Role을 GUEST -> USER 로 업데이트하는 로직 필요
+        jwtService.sendAccessAndRefreshToken(response, accessToken, null);
+    }
+
+    // TODO : 소셜 로그인 시에도 무조건 토큰 생성하지 말고 JWT 인증 필터처럼 RefreshToken 유/무에 따라 다르게 처리해보기
+    private void loginSuccess(HttpServletResponse response, CustomOAuth2User oAuth2User) {
+        String accessToken = jwtService.createAccessToken(oAuth2User.getLoginId(), new Date());
+        String refreshToken = jwtService.createRefreshToken(new Date());
+        response.addHeader(jwtService.getAccessHeader(), "Bearer " + accessToken);
+        response.addHeader(jwtService.getRefreshHeader(), "Bearer " + refreshToken);
+
+        jwtService.sendAccessAndRefreshToken(response, accessToken, refreshToken);
+        jwtService.updateRefreshToken(oAuth2User.getLoginId(), refreshToken);
+    }
+
+
+
+}

--- a/user-service/src/main/java/kr/mybrary/userservice/authentication/domain/oauth2/service/CustomOAuth2UserService.java
+++ b/user-service/src/main/java/kr/mybrary/userservice/authentication/domain/oauth2/service/CustomOAuth2UserService.java
@@ -14,6 +14,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
 
@@ -26,6 +27,7 @@ public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
     private final PasswordEncoder passwordEncoder;
 
     private static final String GOOGLE = "google";
+    private static final String SOCIAL_TYPE_NOT_SUPPORTED = "지원하지 않는 소셜 로그인입니다.";
 
     @Override
     public OAuth2User loadUser(OAuth2UserRequest userRequest) {
@@ -67,7 +69,7 @@ public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
         if (registrationId.equals(GOOGLE)) {
             return SocialType.GOOGLE;
         }
-        throw new IllegalArgumentException("지원하지 않는 소셜 타입입니다.");
+        throw new OAuth2AuthenticationException(SOCIAL_TYPE_NOT_SUPPORTED);
     }
 
     private User getUser(OAuthAttributes attributes, SocialType socialType) {

--- a/user-service/src/main/java/kr/mybrary/userservice/authentication/domain/oauth2/service/CustomOAuth2UserService.java
+++ b/user-service/src/main/java/kr/mybrary/userservice/authentication/domain/oauth2/service/CustomOAuth2UserService.java
@@ -1,0 +1,86 @@
+package kr.mybrary.userservice.authentication.domain.oauth2.service;
+
+import java.util.Collections;
+import java.util.Map;
+import kr.mybrary.userservice.authentication.domain.oauth2.CustomOAuth2User;
+import kr.mybrary.userservice.authentication.domain.oauth2.OAuthAttributes;
+import kr.mybrary.userservice.user.persistence.SocialType;
+import kr.mybrary.userservice.user.persistence.User;
+import kr.mybrary.userservice.user.persistence.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequest, OAuth2User> {
+
+    private final UserRepository userRepository;
+
+    private static final String GOOGLE = "google";
+
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) {
+        log.info("CustomOAuth2UserService.loadUser() 실행 - OAuth2 로그인 요청 진입");
+
+        /* DefaultOAuth2UserService의 loadUser()는 소셜 로그인 API의 사용자 정보 제공 URI로 요청을 보내서
+        사용자 정보를 얻은 후, 이를 통해 DefaultOAuth2User 객체를 생성 후 반환한다.
+        결과적으로, OAuth2User는 OAuth 서비스에서 가져온 유저 정보를 담고 있는 유저 */
+        OAuth2UserService<OAuth2UserRequest, OAuth2User> delegate = new DefaultOAuth2UserService();
+        OAuth2User oAuth2User = delegate.loadUser(userRequest);
+
+        // userRequest에서 registrationId, socialType, userNameAttributeName을 가져온다.
+        String registrationId = userRequest.getClientRegistration().getRegistrationId();
+        SocialType socialType = getSocialType(registrationId);
+        String userNameAttributeName = userRequest.getClientRegistration().getProviderDetails()
+                .getUserInfoEndpoint().getUserNameAttributeName();
+        Map<String, Object> attributes = oAuth2User.getAttributes();
+
+        // socialType에 따라 유저 정보를 통해 OAuthAttributes 객체를 생성한다.
+        OAuthAttributes extractAttributes = OAuthAttributes.of(socialType, userNameAttributeName,
+                attributes);
+
+        // OAuthAttributes 객체와 SocialType를 통해 User 객체를 생성한다.
+        User createdUser = getUser(extractAttributes, socialType);
+
+        // DefaultOAuth2User를 구현한 CustomOAuth2User 객체를 생성하여 반환한다.
+        return new CustomOAuth2User(
+                Collections.singleton(
+                        new SimpleGrantedAuthority(createdUser.getRole().getDescription())),
+                attributes,
+                extractAttributes.getNameAttributeKey(),
+                createdUser.getLoginId(),
+                createdUser.getRole()
+        );
+
+    }
+
+    private SocialType getSocialType(String registrationId) {
+        if (registrationId.equals(GOOGLE)) {
+            return SocialType.GOOGLE;
+        }
+        throw new IllegalArgumentException("지원하지 않는 소셜 타입입니다.");
+    }
+
+    private User getUser(OAuthAttributes attributes, SocialType socialType) {
+        User findUser = userRepository.findBySocialTypeAndSocialId(socialType,
+                attributes.getOAuth2UserInfo().getId()).orElse(null);
+
+        if (findUser == null) {
+            return saveUser(attributes, socialType);
+        }
+        return findUser;
+    }
+
+    private User saveUser(OAuthAttributes attributes, SocialType socialType) {
+        User createdUser = attributes.toEntity(socialType, attributes.getOAuth2UserInfo());
+        return userRepository.save(createdUser);
+    }
+
+}

--- a/user-service/src/main/java/kr/mybrary/userservice/authentication/domain/oauth2/service/CustomOAuth2UserService.java
+++ b/user-service/src/main/java/kr/mybrary/userservice/authentication/domain/oauth2/service/CustomOAuth2UserService.java
@@ -27,6 +27,8 @@ public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
     private final PasswordEncoder passwordEncoder;
 
     private static final String GOOGLE = "google";
+    private static final String KAKAO = "kakao";
+    private static final String NAVER = "naver";
     private static final String SOCIAL_TYPE_NOT_SUPPORTED = "지원하지 않는 소셜 로그인입니다.";
 
     @Override
@@ -68,6 +70,12 @@ public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
     private SocialType getSocialType(String registrationId) {
         if (registrationId.equals(GOOGLE)) {
             return SocialType.GOOGLE;
+        }
+        if (registrationId.equals(KAKAO)) {
+            return SocialType.KAKAO;
+        }
+        if (registrationId.equals(NAVER)) {
+            return SocialType.NAVER;
         }
         throw new OAuth2AuthenticationException(SOCIAL_TYPE_NOT_SUPPORTED);
     }

--- a/user-service/src/main/java/kr/mybrary/userservice/authentication/domain/oauth2/service/CustomOAuth2UserService.java
+++ b/user-service/src/main/java/kr/mybrary/userservice/authentication/domain/oauth2/service/CustomOAuth2UserService.java
@@ -10,6 +10,7 @@ import kr.mybrary.userservice.user.persistence.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
@@ -22,6 +23,7 @@ import org.springframework.stereotype.Service;
 public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequest, OAuth2User> {
 
     private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
 
     private static final String GOOGLE = "google";
 
@@ -80,6 +82,7 @@ public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
 
     private User saveUser(OAuthAttributes attributes, SocialType socialType) {
         User createdUser = attributes.toEntity(socialType, attributes.getOAuth2UserInfo());
+        createdUser.updatePassword(passwordEncoder.encode(createdUser.getPassword()));
         return userRepository.save(createdUser);
     }
 

--- a/user-service/src/main/java/kr/mybrary/userservice/authentication/domain/oauth2/userinfo/GoogleOAuth2UserInfo.java
+++ b/user-service/src/main/java/kr/mybrary/userservice/authentication/domain/oauth2/userinfo/GoogleOAuth2UserInfo.java
@@ -1,0 +1,30 @@
+package kr.mybrary.userservice.authentication.domain.oauth2.userinfo;
+
+import java.util.Map;
+
+public class GoogleOAuth2UserInfo extends OAuth2UserInfo {
+
+    public GoogleOAuth2UserInfo(Map<String, Object> attributes) {
+        super(attributes);
+    }
+
+    @Override
+    public String getId() {
+        return (String) attributes.get("sub");
+    }
+
+    @Override
+    public String getNickname() {
+        return (String) attributes.get("name");
+    }
+
+    @Override
+    public String getImageUrl() {
+        return (String) attributes.get("picture");
+    }
+
+    public String getEmail() {
+        return (String) attributes.get("email");
+    }
+
+}

--- a/user-service/src/main/java/kr/mybrary/userservice/authentication/domain/oauth2/userinfo/GoogleOAuth2UserInfo.java
+++ b/user-service/src/main/java/kr/mybrary/userservice/authentication/domain/oauth2/userinfo/GoogleOAuth2UserInfo.java
@@ -23,6 +23,7 @@ public class GoogleOAuth2UserInfo extends OAuth2UserInfo {
         return (String) attributes.get("picture");
     }
 
+    @Override
     public String getEmail() {
         return (String) attributes.get("email");
     }

--- a/user-service/src/main/java/kr/mybrary/userservice/authentication/domain/oauth2/userinfo/KakaoOAuth2UserInfo.java
+++ b/user-service/src/main/java/kr/mybrary/userservice/authentication/domain/oauth2/userinfo/KakaoOAuth2UserInfo.java
@@ -1,0 +1,52 @@
+package kr.mybrary.userservice.authentication.domain.oauth2.userinfo;
+
+import java.util.Map;
+
+public class KakaoOAuth2UserInfo extends OAuth2UserInfo {
+
+    public KakaoOAuth2UserInfo(Map<String, Object> attributes) {
+        super(attributes);
+    }
+
+    @Override
+    public String getId() {
+        return String.valueOf(attributes.get("id"));
+    }
+
+    @Override
+    public String getNickname() {
+        Map<String, Object> profile = getProfile();
+        if (profile == null) {
+            return null;
+        }
+        return (String) profile.get("nickname");
+    }
+
+    @Override
+    public String getImageUrl() {
+        Map<String, Object> profile = getProfile();
+        if (profile == null) {
+            return null;
+        }
+        return (String) profile.get("profile_image_url");
+    }
+
+    @Override
+    public String getEmail() {
+        Map<String, Object> account = (Map<String, Object>) attributes.get("kakao_account");
+        if (account == null) {
+            return null;
+        }
+        return (String) account.get("email");
+    }
+
+    private Map<String, Object> getProfile() {
+        Map<String, Object> account = (Map<String, Object>) attributes.get("kakao_account");
+        if (account == null) {
+            return null;
+        }
+        Map<String, Object> profile = (Map<String, Object>) account.get("profile");
+        return profile;
+    }
+
+}

--- a/user-service/src/main/java/kr/mybrary/userservice/authentication/domain/oauth2/userinfo/NaverOAuth2UserInfo.java
+++ b/user-service/src/main/java/kr/mybrary/userservice/authentication/domain/oauth2/userinfo/NaverOAuth2UserInfo.java
@@ -1,0 +1,60 @@
+package kr.mybrary.userservice.authentication.domain.oauth2.userinfo;
+
+import java.util.Map;
+
+public class NaverOAuth2UserInfo extends OAuth2UserInfo {
+
+    public NaverOAuth2UserInfo(Map<String, Object> attributes) {
+        super(attributes);
+    }
+
+    @Override
+    public String getId() {
+        Map<String, Object> response = getResponse();
+
+        if (response == null) {
+            return null;
+        }
+        return (String) response.get("id");
+    }
+
+    @Override
+    public String getNickname() {
+        Map<String, Object> response = getResponse();
+
+        if (response == null) {
+            return null;
+        }
+
+        return (String) response.get("nickname");
+    }
+
+    @Override
+    public String getImageUrl() {
+        Map<String, Object> response = getResponse();
+
+        if (response == null) {
+            return null;
+        }
+
+        return (String) response.get("profile_image");
+    }
+
+    @Override
+    public String getEmail() {
+        Map<String, Object> response = getResponse();
+
+        if (response == null) {
+            return null;
+        }
+
+        return (String) response.get("email");
+    }
+
+    private Map<String, Object> getResponse() {
+        Map<String, Object> response = (Map<String, Object>) attributes.get("response");
+        return response;
+    }
+
+
+}

--- a/user-service/src/main/java/kr/mybrary/userservice/authentication/domain/oauth2/userinfo/OAuth2UserInfo.java
+++ b/user-service/src/main/java/kr/mybrary/userservice/authentication/domain/oauth2/userinfo/OAuth2UserInfo.java
@@ -1,0 +1,19 @@
+package kr.mybrary.userservice.authentication.domain.oauth2.userinfo;
+
+import java.util.Map;
+
+public abstract class OAuth2UserInfo {
+
+    protected Map<String, Object> attributes;
+
+    public OAuth2UserInfo(Map<String, Object> attributes) {
+        this.attributes = attributes;
+    }
+
+    public abstract String getId();
+
+    public abstract String getNickname();
+
+    public abstract String getImageUrl();
+
+}

--- a/user-service/src/main/java/kr/mybrary/userservice/authentication/domain/oauth2/userinfo/OAuth2UserInfo.java
+++ b/user-service/src/main/java/kr/mybrary/userservice/authentication/domain/oauth2/userinfo/OAuth2UserInfo.java
@@ -16,4 +16,6 @@ public abstract class OAuth2UserInfo {
 
     public abstract String getImageUrl();
 
+    public abstract String getEmail();
+
 }

--- a/user-service/src/main/java/kr/mybrary/userservice/authentication/presentation/dto/request/SignUpRequest.java
+++ b/user-service/src/main/java/kr/mybrary/userservice/authentication/presentation/dto/request/SignUpRequest.java
@@ -22,7 +22,7 @@ public class SignUpRequest {
 
     @NotNull
     @NotBlank(message = "닉네임은 필수입니다.")
-    @Pattern(regexp = "^[ㄱ-ㅎ가-힣a-z0-9-_]{2,10}$", message = "닉네임은 특수문자를 제외한 2~10자리여야 합니다.")
+    @Pattern(regexp = "^[ㄱ-ㅎ가-힣a-zA-Z0-9-_]{2,20}$", message = "닉네임은 특수문자를 제외한 2~20자리여야 합니다.")
     private String nickname;
 
     @Email(message = "이메일 형식이 올바르지 않습니다.")

--- a/user-service/src/main/java/kr/mybrary/userservice/global/config/WebSecurityConfig.java
+++ b/user-service/src/main/java/kr/mybrary/userservice/global/config/WebSecurityConfig.java
@@ -6,6 +6,9 @@ import kr.mybrary.userservice.authentication.domain.AuthenticationService;
 import kr.mybrary.userservice.authentication.domain.login.filter.CustomJsonUsernamePasswordAuthenticationFilter;
 import kr.mybrary.userservice.authentication.domain.login.handler.LoginFailureHandler;
 import kr.mybrary.userservice.authentication.domain.login.handler.LoginSuccessHandler;
+import kr.mybrary.userservice.authentication.domain.oauth2.handler.OAuth2LoginFailureHandler;
+import kr.mybrary.userservice.authentication.domain.oauth2.handler.OAuth2LoginSuccessHandler;
+import kr.mybrary.userservice.authentication.domain.oauth2.service.CustomOAuth2UserService;
 import kr.mybrary.userservice.global.jwt.filter.JwtAuthenticationProcessingFilter;
 import kr.mybrary.userservice.global.jwt.service.JwtService;
 import kr.mybrary.userservice.user.persistence.repository.UserRepository;
@@ -32,6 +35,9 @@ public class WebSecurityConfig {
     private final UserRepository userRepository;
     private final ObjectMapper objectMapper;
     private final PasswordEncoder passwordEncoder;
+    private final CustomOAuth2UserService customOAuth2UserService;
+    private final OAuth2LoginSuccessHandler oAuth2LoginSuccessHandler;
+    private final OAuth2LoginFailureHandler oAuth2LoginFailureHandler;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -43,6 +49,12 @@ public class WebSecurityConfig {
                 .authorizeRequests(request -> request
                         .requestMatchers("/sign-up").permitAll()
                         .anyRequest().authenticated()
+                )
+                .oauth2Login(oauth2 -> oauth2
+                        .successHandler(oAuth2LoginSuccessHandler)
+                        .failureHandler(oAuth2LoginFailureHandler)
+                        .userInfoEndpoint(userInfo -> userInfo
+                                .userService(customOAuth2UserService))
                 );
 
         http.addFilterAfter(customJsonUsernamePasswordAuthenticationFilter(), LogoutFilter.class);

--- a/user-service/src/main/java/kr/mybrary/userservice/global/jwt/service/JwtService.java
+++ b/user-service/src/main/java/kr/mybrary/userservice/global/jwt/service/JwtService.java
@@ -4,6 +4,7 @@ import com.auth0.jwt.JWT;
 import com.auth0.jwt.algorithms.Algorithm;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import jakarta.transaction.Transactional;
 import java.util.Date;
 import java.util.Optional;
 import kr.mybrary.userservice.user.persistence.repository.UserRepository;
@@ -14,6 +15,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 @Service
+@Transactional
 @RequiredArgsConstructor
 @Getter
 @Slf4j

--- a/user-service/src/main/java/kr/mybrary/userservice/user/persistence/Role.java
+++ b/user-service/src/main/java/kr/mybrary/userservice/user/persistence/Role.java
@@ -1,7 +1,9 @@
 package kr.mybrary.userservice.user.persistence;
 
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
+@Getter
 @RequiredArgsConstructor
 public enum Role {
 

--- a/user-service/src/main/java/kr/mybrary/userservice/user/persistence/User.java
+++ b/user-service/src/main/java/kr/mybrary/userservice/user/persistence/User.java
@@ -45,7 +45,7 @@ public class User extends BaseEntity {
 
     // 주소, 직장, 직장 공개 여부, 성별, 생년월일, 학력, 본인인증 여부 추가 예정
 
-    public void authorizeUser() {
+    public void grantUserRole() {
         this.role = Role.USER;
     }
 

--- a/user-service/src/main/java/kr/mybrary/userservice/user/persistence/User.java
+++ b/user-service/src/main/java/kr/mybrary/userservice/user/persistence/User.java
@@ -53,10 +53,6 @@ public class User extends BaseEntity {
         this.password = password;
     }
 
-    public void updateRole(Role role) {
-        this.role = role;
-    }
-
     public void updateRefreshToken(String refreshToken) {
         this.refreshToken = refreshToken;
     }

--- a/user-service/src/main/resources/application-oauth.yml
+++ b/user-service/src/main/resources/application-oauth.yml
@@ -7,3 +7,34 @@ spring:
             client-id: ${GOOGLE_CLIENT_ID}
             client-secret: ${GOOGLE_CLIENT_SECRET}
             scope: profile, email
+
+          naver:
+            client-id: ${NAVER_CLIENT_ID}
+            client-secret: ${NAVER_CLIENT_SECRET}
+            redirect-uri: http://localhost:8080/login/oauth2/code/naver
+            authorization-grant-type: authorization_code
+            scope: name, email, profile_image
+            client-name: Naver
+
+          kakao:
+            client-id: ${KAKAO_CLIENT_ID}
+            client-secret: ${KAKAO_CLIENT_SECRET}
+            redirect-uri: http://localhost:8080/login/oauth2/code/kakao
+            client-authentication-method: POST
+            authorization-grant-type: authorization_code
+            scope: profile_nickname, profile_image
+            client-name: Kakao
+
+        provider:
+          naver:
+            authorization_uri: https://nid.naver.com/oauth2.0/authorize
+            token_uri: https://nid.naver.com/oauth2.0/token
+            user-info-uri: https://openapi.naver.com/v1/nid/me
+            user_name_attribute: response
+
+          kakao:
+            authorization-uri: https://kauth.kakao.com/oauth/authorize
+            token-uri: https://kauth.kakao.com/oauth/token
+            user-info-uri: https://kapi.kakao.com/v2/user/me
+            user-name-attribute: id
+

--- a/user-service/src/main/resources/application-oauth.yml
+++ b/user-service/src/main/resources/application-oauth.yml
@@ -4,6 +4,6 @@ spring:
       client:
         registration:
           google:
-            client-id: {$GOOGLE_CLIENT_ID}
-            client-secret: {$GOOGLE_CLIENT_SECRET}
+            client-id: ${GOOGLE_CLIENT_ID}
+            client-secret: ${GOOGLE_CLIENT_SECRET}
             scope: profile, email

--- a/user-service/src/main/resources/application-oauth.yml
+++ b/user-service/src/main/resources/application-oauth.yml
@@ -1,0 +1,9 @@
+spring:
+  security:
+    oauth2:
+      client:
+        registration:
+          google:
+            client-id: {$GOOGLE_CLIENT_ID}
+            client-secret: {$GOOGLE_CLIENT_SECRET}
+            scope: profile, email

--- a/user-service/src/main/resources/application.yml
+++ b/user-service/src/main/resources/application.yml
@@ -1,4 +1,7 @@
 spring:
+  profiles:
+    include: oauth
+
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
     url: jdbc:mysql://${MYSQL_HOST}:3306/USER_DB?useSSL=false&allowPublicKeyRetrieval=true&useUnicode=true&serverTimezone=Asia/Seoul

--- a/user-service/src/test/java/kr/mybrary/userservice/UserServiceApplicationTests.java
+++ b/user-service/src/test/java/kr/mybrary/userservice/UserServiceApplicationTests.java
@@ -2,7 +2,9 @@ package kr.mybrary.userservice;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
+@ActiveProfiles("test")
 @SpringBootTest
 class UserServiceApplicationTests {
 

--- a/user-service/src/test/java/kr/mybrary/userservice/authentication/domain/login/LoginTest.java
+++ b/user-service/src/test/java/kr/mybrary/userservice/authentication/domain/login/LoginTest.java
@@ -1,4 +1,4 @@
-package kr.mybrary.userservice.authentication.presentation;
+package kr.mybrary.userservice.authentication.domain.login;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -26,7 +26,7 @@ import org.springframework.test.web.servlet.MvcResult;
 @SpringBootTest
 @AutoConfigureMockMvc
 @ActiveProfiles("test")
-public class AuthenticationTest {
+public class LoginTest {
 
     @Autowired
     MockMvc mockMvc;
@@ -66,13 +66,11 @@ public class AuthenticationTest {
     @Test
     void loginSuccess() throws Exception {
         // given
-
-        // when
         Map<String, String> loginRequest = new HashMap<>();
         loginRequest.put("loginId", LOGIN_ID);
         loginRequest.put("password", PASSWORD);
 
-        // then
+        // when // then
         MvcResult result = mockMvc.perform(post("/login")
                         .contentType("application/json")
                         .content(objectMapper.writeValueAsString(loginRequest)))
@@ -91,13 +89,11 @@ public class AuthenticationTest {
     @Test
     void loginWithWrongPassword() throws Exception {
         // given
-
-        // when
         Map<String, String> loginRequest = new HashMap<>();
         loginRequest.put("loginId", LOGIN_ID);
         loginRequest.put("password", "wrongPassword");
 
-        // then
+        // when // then
         mockMvc.perform(post("/login")
                         .contentType("application/json")
                         .content(objectMapper.writeValueAsString(loginRequest)))
@@ -112,13 +108,11 @@ public class AuthenticationTest {
     @Test
     void loginWithWrongLoginId() throws Exception {
         // given
-
-        // when
         Map<String, String> loginRequest = new HashMap<>();
         loginRequest.put("loginId", "wrongId");
         loginRequest.put("password", PASSWORD);
 
-        // then
+        // when // then
         mockMvc.perform(post("/login")
                         .contentType("application/json")
                         .content(objectMapper.writeValueAsString(loginRequest)))
@@ -132,13 +126,11 @@ public class AuthenticationTest {
     @Test
     void loginWithWrongFormat() throws Exception {
         // given
-
-        // when
         Map<String, String> loginRequest = new HashMap<>();
         loginRequest.put("loginId", LOGIN_ID);
         loginRequest.put("password", PASSWORD);
 
-        // then
+        // when // then
         mockMvc.perform(post("/login")
                         .contentType(MediaType.TEXT_PLAIN)
                         .content(objectMapper.writeValueAsString(loginRequest)))
@@ -148,6 +140,5 @@ public class AuthenticationTest {
                 .andExpect(content().json(
                         "{'errorCode':'U-07','errorMessage':'지원되지 않는 Content-Type 입니다: text/plain. JSON 형식으로 요청해주세요.'}"));
     }
-
 
 }

--- a/user-service/src/test/java/kr/mybrary/userservice/authentication/domain/oauth/OAuth2Test.java
+++ b/user-service/src/test/java/kr/mybrary/userservice/authentication/domain/oauth/OAuth2Test.java
@@ -21,11 +21,13 @@ public class OAuth2Test {
     @Autowired
     MockMvc mockMvc;
 
+    static final String OAUTH2_URL = "/oauth2/authorization";
+
     @DisplayName("Google 로그인 시도 시 Google OAuth 인증 창이 나타난다")
     @Test
     void googleLogin() throws Exception {
         // given
-        String googleOAuth2Url = "/oauth2/authorization/google";
+        String googleOAuth2Url = OAUTH2_URL + "/google";
         String redirectedGoogleOAuth2Url = "https://accounts.google.com/o/oauth2/v2/auth";
 
         // when // then
@@ -39,7 +41,7 @@ public class OAuth2Test {
     @Test
     void kakaoLogin() throws Exception {
         // given
-        String kakaoOAuth2Url = "/oauth2/authorization/kakao";
+        String kakaoOAuth2Url = OAUTH2_URL + "/kakao";
         String redirectedKakaoOAuth2Url = "https://kauth.kakao.com/oauth/authorize";
 
         // when // then
@@ -52,7 +54,7 @@ public class OAuth2Test {
     @Test
     void naverLogin() throws Exception {
         // given
-        String naverOAuth2Url = "/oauth2/authorization/naver";
+        String naverOAuth2Url = OAUTH2_URL + "/naver";
         String redirectedNaverOAuth2Url = "https://nid.naver.com/oauth2.0/authorize";
 
         // when // then

--- a/user-service/src/test/java/kr/mybrary/userservice/authentication/domain/oauth/OAuth2Test.java
+++ b/user-service/src/test/java/kr/mybrary/userservice/authentication/domain/oauth/OAuth2Test.java
@@ -1,0 +1,64 @@
+package kr.mybrary.userservice.authentication.domain.oauth;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+public class OAuth2Test {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @DisplayName("Google 로그인 시도 시 Google OAuth 인증 창이 나타난다")
+    @Test
+    void googleLogin() throws Exception {
+        // given
+        String googleOAuth2Url = "/oauth2/authorization/google";
+        String redirectedGoogleOAuth2Url = "https://accounts.google.com/o/oauth2/v2/auth";
+
+        // when // then
+        mockMvc.perform(post(googleOAuth2Url))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(header().string("Location",containsString(redirectedGoogleOAuth2Url)));
+    }
+
+
+    @DisplayName("Kakao 로그인 시도 시 Kakao OAuth 인증 창이 나타난다")
+    @Test
+    void kakaoLogin() throws Exception {
+        // given
+        String kakaoOAuth2Url = "/oauth2/authorization/kakao";
+        String redirectedKakaoOAuth2Url = "https://kauth.kakao.com/oauth/authorize";
+
+        // when // then
+        mockMvc.perform(post(kakaoOAuth2Url))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(header().string("Location",containsString(redirectedKakaoOAuth2Url)));
+    }
+
+    @DisplayName("Naver 로그인 시도 시 Naver OAuth 인증 창이 나타난다")
+    @Test
+    void naverLogin() throws Exception {
+        // given
+        String naverOAuth2Url = "/oauth2/authorization/naver";
+        String redirectedNaverOAuth2Url = "https://nid.naver.com/oauth2.0/authorize";
+
+        // when // then
+        mockMvc.perform(post(naverOAuth2Url))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(header().string("Location",containsString(redirectedNaverOAuth2Url)));
+    }
+
+}


### PR DESCRIPTION
## 🧑‍💻 작업 사항

### 구글 소셜 로그인
1. http://localhost:8080/oauth2/authorization/google 으로 요청을 보내면 구글 로그인 페이지로 리다이렉트 된다
![image](https://github.com/SWM-IDLE/mybrary/assets/78717113/befdf568-087f-4499-b041-0ab847bf7a12)

2. 최초 로그인 시 구글 소셜 로그인 회원으로 회원 가입 된다
  - 소셜 아이디, 닉네임, 이메일, 프로필 사진 url을 받아와서 저장 (닉네임은 랜덤 5자리 숫자를 덧붙여서 저장)
  - 아이디와 비밀번호는 UUID로 생성 (비밀번호는 암호화하여 저장)
<img width="1512" alt="image" src="https://github.com/SWM-IDLE/mybrary/assets/78717113/eca09fb3-cbf4-45f3-88d8-e89928148482">

3. 다시 해당 계정으로 로그인 하게 되면 기존에 등록된 회원 정보를 바탕으로 로그인 성공
![image](https://github.com/SWM-IDLE/mybrary/assets/78717113/91ab52a5-a873-43ef-a546-c766bf77d82a)

### 카카오 소셜 로그인
1. http://localhost:8080/oauth2/authorization/kakao 으로 요청을 보내면 카카오 로그인 페이지로 리다이렉트 된다
![image](https://github.com/SWM-IDLE/mybrary/assets/78717113/c7919332-5c9f-4da8-8ff9-c646c26bdd68)

2. 최초 로그인 시 카카오 소셜 로그인 회원으로 회원 가입 된다
  - 소셜 아이디, 닉네임, 프로필 사진 url을 받아와서 저장 (닉네임은 랜덤 5자리 숫자를 덧붙여서 저장)
  - 이메일은 선택 사항이므로 받아오지 못한다면 null로 저장
  - 아이디와 비밀번호는 UUID로 생성 (비밀번호는 암호화하여 저장)
<img width="1512" alt="image" src="https://github.com/SWM-IDLE/mybrary/assets/78717113/08f19e07-a923-4e04-ab43-172dc20d964d">

3. 다시 해당 계정으로 로그인 하게 되면 기존에 등록된 회원 정보를 바탕으로 로그인 성공
![image](https://github.com/SWM-IDLE/mybrary/assets/78717113/0ea84ba5-b2f8-4edf-bb07-beded8e6f2a0)


### 네이버 소셜 로그인
1. http://localhost:8080/oauth2/authorization/naver 으로 요청을 보내면 네이버 로그인 페이지로 리다이렉트 된다
![image](https://github.com/SWM-IDLE/mybrary/assets/78717113/59882759-ae80-4700-ac90-ce419f6669c0)

2. 최초 로그인 시 네이버 소셜 로그인 회원으로 회원 가입 된다
  - 소셜 아이디, 닉네임, 이메일, 프로필 사진 url을 받아와서 저장 (닉네임은 랜덤 5자리 숫자를 덧붙여서 저장)
  - 아이디와 비밀번호는 UUID로 생성 (비밀번호는 암호화하여 저장)
<img width="1512" alt="image" src="https://github.com/SWM-IDLE/mybrary/assets/78717113/68aac6c3-8506-417f-8c5b-fa9d9edf2b65">

3. 다시 해당 계정으로 로그인 하게 되면 기존에 등록된 회원 정보를 바탕으로 로그인 성공
![image](https://github.com/SWM-IDLE/mybrary/assets/78717113/ba96df27-6bd2-4117-ba02-501853abae3f)


<br><br>

## 🔗 링크

<br><br>

## 🐰 시급한 정도

🐢 천천히 : 급하지 않습니다.

<br><br>

## 📖 참고 사항

### 카카오 OAuth 관련
카카오 OAuth 정책 상 이메일을 필수로 받아오는 것이 불가해 선택 항목으로 지정해두었는데 동의 화면에서 이메일 선택 정보 제공 동의가 나타나지 않고 있습니다.
<img width="978" alt="image" src="https://github.com/SWM-IDLE/mybrary/assets/78717113/e2c06169-c1ee-41e6-adf2-f6f2286546c4">

관련 이슈에 대한 레퍼런스 입니다.
https://devtalk.kakao.com/t/topic/113061

해당 계정의 사용자가 이메일을 등록해두지 않으면 동의 화면에서 이메일 선택 정보 제공 동의가 표시되지 않는다고 합니다.
음,, 저는 제 카카오 계정에 이메일을 등록해두었는데 왜 동의 화면에서 안나타나는지 모르겠네요ㅜㅜ
확인이 조금 더 필요할 것 같습니다.

### 프로필 이미지 관련
현재 google, kakao, naver 소셜 로그인 모두 oauth 기능을 통해 프로필 이미지 url을 받아오고 있는데 google, kakao에서 제공되는 이미지의 해상도가 상당히 낮습니다.

google
<img width="1512" alt="image" src="https://github.com/SWM-IDLE/mybrary/assets/78717113/0e99d8be-bcab-463b-80fe-a3d6bddc7e53">

kakao
<img width="1512" alt="image" src="https://github.com/SWM-IDLE/mybrary/assets/78717113/3c0b9db5-66c3-4466-8984-a9cc94fe44a3">

naver
<img width="1512" alt="image" src="https://github.com/SWM-IDLE/mybrary/assets/78717113/f74dd1d0-2ee4-4697-bc7d-70e68547637d">

회원 가입 시 해상도가 낮은 이미지를 받아오기 보다 그냥 기본 이미지를 적용하는 것이 어떨까 싶네요. 관련해서 의견 남겨주시면 감사하겠습니다 :)

