### PR TITLE
[IDLE-111] feat: 마이북 전체 조회/상세 조회 API 개발

### DIFF
--- a/backend/book-service/src/main/java/kr/mybrary/bookservice/book/domain/dto/request/BookCreateServiceRequest.java
+++ b/backend/book-service/src/main/java/kr/mybrary/bookservice/book/domain/dto/request/BookCreateServiceRequest.java
@@ -4,10 +4,8 @@ import java.time.LocalDateTime;
 import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.Setter;
 
 @Getter
-@Setter
 @Builder
 public class BookCreateServiceRequest {
     private String title;

--- a/backend/book-service/src/main/java/kr/mybrary/bookservice/book/presentation/dto/request/BookCreateRequest.java
+++ b/backend/book-service/src/main/java/kr/mybrary/bookservice/book/presentation/dto/request/BookCreateRequest.java
@@ -5,10 +5,8 @@ import java.util.List;
 import kr.mybrary.bookservice.book.domain.dto.request.BookCreateServiceRequest;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.Setter;
 
 @Getter
-@Setter
 @Builder
 public class BookCreateRequest {
 

--- a/backend/book-service/src/main/java/kr/mybrary/bookservice/booksearch/domain/dto/BookSearchResultDto.java
+++ b/backend/book-service/src/main/java/kr/mybrary/bookservice/booksearch/domain/dto/BookSearchResultDto.java
@@ -4,10 +4,8 @@ import java.time.OffsetDateTime;
 import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.Setter;
 
 @Getter
-@Setter
 @Builder
 public class BookSearchResultDto {
 

--- a/backend/book-service/src/main/java/kr/mybrary/bookservice/mybook/domain/MyBookService.java
+++ b/backend/book-service/src/main/java/kr/mybrary/bookservice/mybook/domain/MyBookService.java
@@ -59,7 +59,7 @@ public class MyBookService {
         MyBook myBook = myBookRepository.findByIdAndDeletedIsFalse(request.getMybookId())
                 .orElseThrow(MyBookNotFoundException::new);
 
-        if (!myBook.isShareable() && !request.getUserId().equals(request.getLoginId())) {
+        if (!myBook.isShowable() && !request.getUserId().equals(request.getLoginId())) {
             throw new MyBookAccessDeniedException();
         }
 

--- a/backend/book-service/src/main/java/kr/mybrary/bookservice/mybook/domain/MyBookService.java
+++ b/backend/book-service/src/main/java/kr/mybrary/bookservice/mybook/domain/MyBookService.java
@@ -29,15 +29,9 @@ public class MyBookService {
     public MyBook create(MyBookCreateServiceRequest request) {
 
         Book book = bookService.getRegisteredBook(request.toBookCreateRequest());
-
         checkBookAlreadyRegisteredAsMyBook(request.getUserId(), book);
 
-        MyBook myBook = MyBook.builder()
-                .book(book)
-                .userId(request.getUserId())
-                .deleted(false)
-                .build();
-
+        MyBook myBook = MyBook.of(book, request.getUserId());
         return myBookRepository.save(myBook);
     }
 
@@ -46,7 +40,6 @@ public class MyBookService {
             throw new MyBookAlreadyExistsException();
         }
     }
-
 
     @Transactional(readOnly = true)
     public List<MyBookElementResponse> findAllMyBooks(MyBookFindAllServiceRequest request) {

--- a/backend/book-service/src/main/java/kr/mybrary/bookservice/mybook/domain/dto/MyBookDtoMapper.java
+++ b/backend/book-service/src/main/java/kr/mybrary/bookservice/mybook/domain/dto/MyBookDtoMapper.java
@@ -1,9 +1,14 @@
 package kr.mybrary.bookservice.mybook.domain.dto;
 
+import java.util.List;
+import kr.mybrary.bookservice.book.persistence.author.BookAuthor;
+import kr.mybrary.bookservice.book.persistence.translator.BookTranslator;
 import kr.mybrary.bookservice.mybook.persistence.MyBook;
+import kr.mybrary.bookservice.mybook.presentation.dto.response.MyBookDetailResponse;
 import kr.mybrary.bookservice.mybook.presentation.dto.response.MyBookElementResponse;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
+import org.mapstruct.Named;
 import org.mapstruct.ReportingPolicy;
 import org.mapstruct.factory.Mappers;
 
@@ -14,4 +19,23 @@ public interface MyBookDtoMapper {
 
     @Mapping(target = "book.stars", constant = "0.0")
     MyBookElementResponse entityToMyBookElementResponse(MyBook myBook);
+
+    @Mapping(target = "book.stars", constant = "0.0")
+    @Mapping(target = "book.authors", source = "book.bookAuthors", qualifiedByName = "getAuthors")
+    @Mapping(target = "book.translators", source = "book.bookTranslators", qualifiedByName = "getTranslators")
+    MyBookDetailResponse entityToMyBookDetailResponse(MyBook myBook);
+
+    @Named("getAuthors")
+    static List<String> getAuthors(List<BookAuthor> bookAuthors) {
+        return bookAuthors.stream()
+                .map(bookAuthor -> bookAuthor.getAuthor().getName())
+                .toList();
+    }
+
+    @Named("getTranslators")
+    static List<String> getTranslators(List<BookTranslator> bookTranslators) {
+        return bookTranslators.stream()
+                .map(bookTranslator -> bookTranslator.getTranslator().getName())
+                .toList();
+    }
 }

--- a/backend/book-service/src/main/java/kr/mybrary/bookservice/mybook/domain/dto/MyBookDtoMapper.java
+++ b/backend/book-service/src/main/java/kr/mybrary/bookservice/mybook/domain/dto/MyBookDtoMapper.java
@@ -1,0 +1,17 @@
+package kr.mybrary.bookservice.mybook.domain.dto;
+
+import kr.mybrary.bookservice.mybook.persistence.MyBook;
+import kr.mybrary.bookservice.mybook.presentation.dto.response.MyBookElementResponse;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.ReportingPolicy;
+import org.mapstruct.factory.Mappers;
+
+@Mapper(componentModel = "spring", unmappedTargetPolicy = ReportingPolicy.IGNORE)
+public interface MyBookDtoMapper {
+
+    MyBookDtoMapper INSTANCE = Mappers.getMapper(MyBookDtoMapper.class);
+
+    @Mapping(target = "book.stars", constant = "0.0")
+    MyBookElementResponse entityToMyBookElementResponse(MyBook myBook);
+}

--- a/backend/book-service/src/main/java/kr/mybrary/bookservice/mybook/domain/dto/request/MyBookCreateServiceRequest.java
+++ b/backend/book-service/src/main/java/kr/mybrary/bookservice/mybook/domain/dto/request/MyBookCreateServiceRequest.java
@@ -5,10 +5,8 @@ import java.util.List;
 import kr.mybrary.bookservice.book.domain.dto.request.BookCreateServiceRequest;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.Setter;
 
 @Getter
-@Setter
 @Builder
 public class MyBookCreateServiceRequest {
 

--- a/backend/book-service/src/main/java/kr/mybrary/bookservice/mybook/domain/dto/request/MyBookDetailServiceRequest.java
+++ b/backend/book-service/src/main/java/kr/mybrary/bookservice/mybook/domain/dto/request/MyBookDetailServiceRequest.java
@@ -1,0 +1,22 @@
+package kr.mybrary.bookservice.mybook.domain.dto.request;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+public class MyBookDetailServiceRequest {
+    private String loginId;
+    private String userId;
+    private Long mybookId;
+
+    public static MyBookDetailServiceRequest of(String loginId, String userId, Long mybookId) {
+        return MyBookDetailServiceRequest.builder()
+                .loginId(loginId)
+                .userId(userId)
+                .mybookId(mybookId)
+                .build();
+    }
+}

--- a/backend/book-service/src/main/java/kr/mybrary/bookservice/mybook/domain/dto/request/MyBookDetailServiceRequest.java
+++ b/backend/book-service/src/main/java/kr/mybrary/bookservice/mybook/domain/dto/request/MyBookDetailServiceRequest.java
@@ -2,10 +2,8 @@ package kr.mybrary.bookservice.mybook.domain.dto.request;
 
 import lombok.Builder;
 import lombok.Getter;
-import lombok.Setter;
 
 @Getter
-@Setter
 @Builder
 public class MyBookDetailServiceRequest {
     private String loginId;

--- a/backend/book-service/src/main/java/kr/mybrary/bookservice/mybook/domain/dto/request/MyBookFindAllServiceRequest.java
+++ b/backend/book-service/src/main/java/kr/mybrary/bookservice/mybook/domain/dto/request/MyBookFindAllServiceRequest.java
@@ -2,10 +2,8 @@ package kr.mybrary.bookservice.mybook.domain.dto.request;
 
 import lombok.Builder;
 import lombok.Getter;
-import lombok.Setter;
 
 @Getter
-@Setter
 @Builder
 public class MyBookFindAllServiceRequest {
 

--- a/backend/book-service/src/main/java/kr/mybrary/bookservice/mybook/domain/dto/request/MyBookFindAllServiceRequest.java
+++ b/backend/book-service/src/main/java/kr/mybrary/bookservice/mybook/domain/dto/request/MyBookFindAllServiceRequest.java
@@ -1,0 +1,21 @@
+package kr.mybrary.bookservice.mybook.domain.dto.request;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+public class MyBookFindAllServiceRequest {
+
+    private String loginId;
+    private String userId;
+
+    public static MyBookFindAllServiceRequest of(String loginId, String userId) {
+        return MyBookFindAllServiceRequest.builder()
+                .loginId(loginId)
+                .userId(userId)
+                .build();
+    }
+}

--- a/backend/book-service/src/main/java/kr/mybrary/bookservice/mybook/domain/exception/MyBookAccessDeniedException.java
+++ b/backend/book-service/src/main/java/kr/mybrary/bookservice/mybook/domain/exception/MyBookAccessDeniedException.java
@@ -1,0 +1,14 @@
+package kr.mybrary.bookservice.mybook.domain.exception;
+
+import kr.mybrary.bookservice.global.exception.ApplicationException;
+
+public class MyBookAccessDeniedException extends ApplicationException {
+
+    private final static int STATUS = 403;
+    private final static String ERROR_CODE = "B-04";
+    private final static String ERROR_MESSAGE = "마이북에 대해 접근할 수 없습니다.";
+
+    public MyBookAccessDeniedException() {
+        super(STATUS, ERROR_CODE, ERROR_MESSAGE);
+    }
+}

--- a/backend/book-service/src/main/java/kr/mybrary/bookservice/mybook/domain/exception/MyBookNotFoundException.java
+++ b/backend/book-service/src/main/java/kr/mybrary/bookservice/mybook/domain/exception/MyBookNotFoundException.java
@@ -1,0 +1,14 @@
+package kr.mybrary.bookservice.mybook.domain.exception;
+
+import kr.mybrary.bookservice.global.exception.ApplicationException;
+
+public class MyBookNotFoundException extends ApplicationException {
+
+    private final static int STATUS = 404;
+    private final static String ERROR_CODE = "B-03";
+    private final static String ERROR_MESSAGE = "마이북으로 등록된 도서가 아닙니다.";
+
+    public MyBookNotFoundException() {
+        super(STATUS, ERROR_CODE, ERROR_MESSAGE);
+    }
+}

--- a/backend/book-service/src/main/java/kr/mybrary/bookservice/mybook/persistence/MyBook.java
+++ b/backend/book-service/src/main/java/kr/mybrary/bookservice/mybook/persistence/MyBook.java
@@ -36,14 +36,14 @@ public class MyBook extends BaseEntity {
     @JoinColumn(name = "book_id")
     private Book book;
 
-    private boolean isPublic;
-
     @Enumerated(EnumType.STRING)
     private ReadStatus readStatus;
 
     private LocalDateTime startDateOfPossession;
-    private boolean isExchangeable;
-    private boolean isShareable;
 
-    private boolean isDeleted;
+    private boolean showable;
+    private boolean exchangeable;
+    private boolean shareable;
+
+    private boolean deleted;
 }

--- a/backend/book-service/src/main/java/kr/mybrary/bookservice/mybook/persistence/MyBook.java
+++ b/backend/book-service/src/main/java/kr/mybrary/bookservice/mybook/persistence/MyBook.java
@@ -46,4 +46,17 @@ public class MyBook extends BaseEntity {
     private boolean shareable;
 
     private boolean deleted;
+
+    public static MyBook of(Book book, String userId) {
+        return MyBook.builder()
+                .userId(userId)
+                .book(book)
+                .startDateOfPossession(null)
+                .readStatus(ReadStatus.TO_READ)
+                .showable(true)
+                .exchangeable(false)
+                .shareable(false)
+                .deleted(false)
+                .build();
+    }
 }

--- a/backend/book-service/src/main/java/kr/mybrary/bookservice/mybook/persistence/repository/MyBookRepository.java
+++ b/backend/book-service/src/main/java/kr/mybrary/bookservice/mybook/persistence/repository/MyBookRepository.java
@@ -1,5 +1,6 @@
 package kr.mybrary.bookservice.mybook.persistence.repository;
 
+import java.util.List;
 import kr.mybrary.bookservice.book.persistence.Book;
 import kr.mybrary.bookservice.mybook.persistence.MyBook;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -7,4 +8,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface MyBookRepository extends JpaRepository<MyBook, Long> {
 
     boolean existsByUserIdAndBook(String userId, Book book);
+
+    List<MyBook> findAllByUserId(String userId);
 }

--- a/backend/book-service/src/main/java/kr/mybrary/bookservice/mybook/persistence/repository/MyBookRepository.java
+++ b/backend/book-service/src/main/java/kr/mybrary/bookservice/mybook/persistence/repository/MyBookRepository.java
@@ -1,6 +1,7 @@
 package kr.mybrary.bookservice.mybook.persistence.repository;
 
 import java.util.List;
+import java.util.Optional;
 import kr.mybrary.bookservice.book.persistence.Book;
 import kr.mybrary.bookservice.mybook.persistence.MyBook;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -10,4 +11,6 @@ public interface MyBookRepository extends JpaRepository<MyBook, Long> {
     boolean existsByUserIdAndBook(String userId, Book book);
 
     List<MyBook> findAllByUserId(String userId);
+
+    Optional<MyBook> findByIdAndDeletedIsFalse(Long bookId);
 }

--- a/backend/book-service/src/main/java/kr/mybrary/bookservice/mybook/presentation/MyBookController.java
+++ b/backend/book-service/src/main/java/kr/mybrary/bookservice/mybook/presentation/MyBookController.java
@@ -27,10 +27,9 @@ public class MyBookController {
     private final MyBookService myBookService;
 
     @PostMapping("/mybooks")
-    public ResponseEntity createMyBook(@RequestBody MyBookCreateRequest request) {
+    public ResponseEntity createMyBook(@RequestHeader("USER-ID") String loginId, @RequestBody MyBookCreateRequest request) {
 
-        String userId = "test1"; // TODO: 임시 회원 ID
-        myBookService.create(request.toServiceRequest(userId));
+        myBookService.create(request.toServiceRequest(loginId));
 
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(SuccessResponse.of(HttpStatus.CREATED.toString(), "내 서재에 도서를 등록했습니다.", null));

--- a/backend/book-service/src/main/java/kr/mybrary/bookservice/mybook/presentation/MyBookController.java
+++ b/backend/book-service/src/main/java/kr/mybrary/bookservice/mybook/presentation/MyBookController.java
@@ -3,6 +3,7 @@ package kr.mybrary.bookservice.mybook.presentation;
 import java.util.List;
 import kr.mybrary.bookservice.global.dto.response.SuccessResponse;
 import kr.mybrary.bookservice.mybook.domain.MyBookService;
+import kr.mybrary.bookservice.mybook.domain.dto.request.MyBookDetailServiceRequest;
 import kr.mybrary.bookservice.mybook.domain.dto.request.MyBookFindAllServiceRequest;
 import kr.mybrary.bookservice.mybook.presentation.dto.request.MyBookCreateRequest;
 import kr.mybrary.bookservice.mybook.presentation.dto.response.MyBookElementResponse;
@@ -44,13 +45,15 @@ public class MyBookController {
         return ResponseEntity.ok(SuccessResponse.of(HttpStatus.OK.toString(), "서재의 도서 목록입니다.", myBooks));
     }
 
-    @GetMapping("/mybooks/{id}")
-    public ResponseEntity findMyBookDetail(@PathVariable Long id) {
+    @GetMapping("/users/{userId}/mybooks/{mybookId}")
+    public ResponseEntity findMyBookDetail(@RequestHeader("USER-ID") String loginId,
+            @PathVariable("userId") String userId,
+            @PathVariable("mybookId") Long mybookId) {
 
-        String userId = "test1"; // TODO: 임시 회원 ID
+        MyBookDetailServiceRequest request = MyBookDetailServiceRequest.of(userId, loginId, mybookId);
 
         return ResponseEntity.ok(
-                SuccessResponse.of(HttpStatus.OK.toString(), "마이북 상세보기입니다.", myBookService.findMyBookDetail(userId, id)));
+                SuccessResponse.of(HttpStatus.OK.toString(), "마이북 상세보기입니다.", myBookService.findMyBookDetail(request)));
     }
 
     @DeleteMapping("/mybooks/{id}")

--- a/backend/book-service/src/main/java/kr/mybrary/bookservice/mybook/presentation/MyBookController.java
+++ b/backend/book-service/src/main/java/kr/mybrary/bookservice/mybook/presentation/MyBookController.java
@@ -1,8 +1,11 @@
 package kr.mybrary.bookservice.mybook.presentation;
 
+import java.util.List;
 import kr.mybrary.bookservice.global.dto.response.SuccessResponse;
 import kr.mybrary.bookservice.mybook.domain.MyBookService;
+import kr.mybrary.bookservice.mybook.domain.dto.request.MyBookFindAllServiceRequest;
 import kr.mybrary.bookservice.mybook.presentation.dto.request.MyBookCreateRequest;
+import kr.mybrary.bookservice.mybook.presentation.dto.response.MyBookElementResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -11,17 +14,18 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/api/v1/mybooks")
+@RequestMapping("/api/v1")
 @RequiredArgsConstructor
 public class MyBookController {
 
     private final MyBookService myBookService;
 
-    @PostMapping
+    @PostMapping("/mybooks")
     public ResponseEntity createMyBook(@RequestBody MyBookCreateRequest request) {
 
         String userId = "test1"; // TODO: 임시 회원 ID
@@ -31,16 +35,16 @@ public class MyBookController {
                 .body(SuccessResponse.of(HttpStatus.CREATED.toString(), "내 서재에 도서를 등록했습니다.", null));
     }
 
-    @GetMapping
-    public ResponseEntity findAllMyBooks() {
+    @GetMapping("/users/{userId}/mybooks")
+    public ResponseEntity findAllMyBooks(@RequestHeader("USER-ID") String loginId, @PathVariable("userId") String userId) {
 
-        String userId = "test1"; // TODO: 임시 회원 ID
+        List<MyBookElementResponse> myBooks = myBookService.findAllMyBooks(
+                MyBookFindAllServiceRequest.of(userId, loginId));
 
-        return ResponseEntity.ok(
-                SuccessResponse.of(HttpStatus.OK.toString(), "내 서재의 도서 목록입니다.", myBookService.findAllMyBooks(userId)));
+        return ResponseEntity.ok(SuccessResponse.of(HttpStatus.OK.toString(), "서재의 도서 목록입니다.", myBooks));
     }
 
-    @GetMapping("/{id}")
+    @GetMapping("/mybooks/{id}")
     public ResponseEntity findMyBookDetail(@PathVariable Long id) {
 
         String userId = "test1"; // TODO: 임시 회원 ID
@@ -49,7 +53,7 @@ public class MyBookController {
                 SuccessResponse.of(HttpStatus.OK.toString(), "마이북 상세보기입니다.", myBookService.findMyBookDetail(userId, id)));
     }
 
-    @DeleteMapping("/{id}")
+    @DeleteMapping("/mybooks/{id}")
     public ResponseEntity deleteMyBook(@PathVariable Long id) {
 
         String userId = "test1"; // TODO: 임시 회원 ID

--- a/backend/book-service/src/main/java/kr/mybrary/bookservice/mybook/presentation/dto/request/MyBookCreateRequest.java
+++ b/backend/book-service/src/main/java/kr/mybrary/bookservice/mybook/presentation/dto/request/MyBookCreateRequest.java
@@ -5,10 +5,8 @@ import java.util.List;
 import kr.mybrary.bookservice.mybook.domain.dto.request.MyBookCreateServiceRequest;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.Setter;
 
 @Getter
-@Setter
 @Builder
 public class MyBookCreateRequest {
     private String title;

--- a/backend/book-service/src/main/java/kr/mybrary/bookservice/mybook/presentation/dto/response/MyBookDetailResponse.java
+++ b/backend/book-service/src/main/java/kr/mybrary/bookservice/mybook/presentation/dto/response/MyBookDetailResponse.java
@@ -12,9 +12,9 @@ import lombok.Setter;
 @Builder
 public class MyBookDetailResponse {
     private Long id;
-    private boolean isPublic;
-    private boolean isExchangeable;
-    private boolean isShareable;
+    private boolean showable;
+    private boolean exchangeable;
+    private boolean shareable;
     private ReadStatus readStatus;
     private LocalDateTime startDateOfPossession;
 

--- a/backend/book-service/src/main/java/kr/mybrary/bookservice/mybook/presentation/dto/response/MyBookDetailResponse.java
+++ b/backend/book-service/src/main/java/kr/mybrary/bookservice/mybook/presentation/dto/response/MyBookDetailResponse.java
@@ -31,6 +31,6 @@ public class MyBookDetailResponse {
         private List<String> translators;
         private String publisher;
         private String thumbnailUrl;
-        private Integer stars;
+        private Double stars;
     }
 }

--- a/backend/book-service/src/main/java/kr/mybrary/bookservice/mybook/presentation/dto/response/MyBookDetailResponse.java
+++ b/backend/book-service/src/main/java/kr/mybrary/bookservice/mybook/presentation/dto/response/MyBookDetailResponse.java
@@ -5,10 +5,8 @@ import java.util.List;
 import kr.mybrary.bookservice.mybook.persistence.ReadStatus;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.Setter;
 
 @Getter
-@Setter
 @Builder
 public class MyBookDetailResponse {
     private Long id;
@@ -21,7 +19,6 @@ public class MyBookDetailResponse {
     private BookDetailResponse book;
 
     @Getter
-    @Setter
     @Builder
     public static class BookDetailResponse {
         private Long id;

--- a/backend/book-service/src/main/java/kr/mybrary/bookservice/mybook/presentation/dto/response/MyBookElementResponse.java
+++ b/backend/book-service/src/main/java/kr/mybrary/bookservice/mybook/presentation/dto/response/MyBookElementResponse.java
@@ -4,10 +4,8 @@ import java.time.LocalDateTime;
 import kr.mybrary.bookservice.mybook.persistence.ReadStatus;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.Setter;
 
 @Getter
-@Setter
 @Builder
 public class MyBookElementResponse {
 
@@ -21,7 +19,6 @@ public class MyBookElementResponse {
     private BookElementResponse book;
 
     @Getter
-    @Setter
     @Builder
     public static class BookElementResponse {
         private Long id;

--- a/backend/book-service/src/main/java/kr/mybrary/bookservice/mybook/presentation/dto/response/MyBookElementResponse.java
+++ b/backend/book-service/src/main/java/kr/mybrary/bookservice/mybook/presentation/dto/response/MyBookElementResponse.java
@@ -3,20 +3,18 @@ package kr.mybrary.bookservice.mybook.presentation.dto.response;
 import java.time.LocalDateTime;
 import kr.mybrary.bookservice.mybook.persistence.ReadStatus;
 import lombok.Builder;
-import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
 
 @Getter
 @Setter
 @Builder
-@EqualsAndHashCode
 public class MyBookElementResponse {
 
     private Long id;
-    private boolean isPublic;
-    private boolean isExchangeable;
-    private boolean isShareable;
+    private boolean showable;
+    private boolean exchangeable;
+    private boolean shareable;
     private ReadStatus readStatus;
     private LocalDateTime startDateOfPossession;
 
@@ -30,6 +28,6 @@ public class MyBookElementResponse {
         private String title;
         private String description;
         private String thumbnailUrl;
-        private Integer stars;
+        private Double stars;
     }
 }

--- a/backend/book-service/src/test/java/kr/mybrary/bookservice/book/BookTestData.java
+++ b/backend/book-service/src/test/java/kr/mybrary/bookservice/book/BookTestData.java
@@ -4,6 +4,10 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 import kr.mybrary.bookservice.book.persistence.Book;
+import kr.mybrary.bookservice.book.persistence.author.Author;
+import kr.mybrary.bookservice.book.persistence.author.BookAuthor;
+import kr.mybrary.bookservice.book.persistence.translator.BookTranslator;
+import kr.mybrary.bookservice.book.persistence.translator.Translator;
 
 public class BookTestData {
 
@@ -19,10 +23,42 @@ public class BookTestData {
                 .thumbnailUrl("test_thumbnailUrl")
                 .detailsUrl("test_detailsUrl")
                 .holderCount(1)
-                .bookTranslators(List.of())
-                .bookAuthors(List.of())
+                .bookAuthors(createBookAuthors())
+                .bookTranslators(createBookTranslators())
                 .interestCount(1)
                 .readCount(1)
                 .build();
+    }
+
+    private static List<BookAuthor> createBookAuthors() {
+        BookAuthor testAuthor_1 = BookAuthor.builder()
+                .author(Author.builder()
+                        .name("test_author_1")
+                        .build())
+                .build();
+
+        BookAuthor testAuthor_2 = BookAuthor.builder()
+                .author(Author.builder()
+                        .name("test_author_2")
+                        .build())
+                .build();
+
+        return List.of(testAuthor_1, testAuthor_2);
+    }
+
+    private static List<BookTranslator> createBookTranslators() {
+        BookTranslator testTranslator_1 = BookTranslator.builder()
+                .translator(Translator.builder()
+                        .name("test_translator_1")
+                        .build())
+                .build();
+
+        BookTranslator testTranslator_2 = BookTranslator.builder()
+                .translator(Translator.builder()
+                        .name("test_translator_2")
+                        .build())
+                .build();
+
+        return List.of(testTranslator_1, testTranslator_2);
     }
 }

--- a/backend/book-service/src/test/java/kr/mybrary/bookservice/book/BookTestData.java
+++ b/backend/book-service/src/test/java/kr/mybrary/bookservice/book/BookTestData.java
@@ -1,0 +1,28 @@
+package kr.mybrary.bookservice.book;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+import kr.mybrary.bookservice.book.persistence.Book;
+
+public class BookTestData {
+
+    public static Book createBook() {
+        return Book.builder()
+                .title("test_title")
+                .isbn10(UUID.randomUUID().toString().substring(0, 10))
+                .isbn13(UUID.randomUUID().toString().substring(0, 13))
+                .description("test_description")
+                .publisher("test_publisher")
+                .publishDate(LocalDateTime.now())
+                .price(10000)
+                .thumbnailUrl("test_thumbnailUrl")
+                .detailsUrl("test_detailsUrl")
+                .holderCount(1)
+                .bookTranslators(List.of())
+                .bookAuthors(List.of())
+                .interestCount(1)
+                .readCount(1)
+                .build();
+    }
+}

--- a/backend/book-service/src/test/java/kr/mybrary/bookservice/mybook/MybookTestData.java
+++ b/backend/book-service/src/test/java/kr/mybrary/bookservice/mybook/MybookTestData.java
@@ -2,6 +2,11 @@ package kr.mybrary.bookservice.mybook;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import kr.mybrary.bookservice.book.BookTestData;
+import kr.mybrary.bookservice.book.persistence.Book;
+import kr.mybrary.bookservice.mybook.domain.dto.request.MyBookCreateServiceRequest;
+import kr.mybrary.bookservice.mybook.domain.dto.request.MyBookFindAllServiceRequest;
+import kr.mybrary.bookservice.mybook.persistence.MyBook;
 import kr.mybrary.bookservice.mybook.persistence.ReadStatus;
 import kr.mybrary.bookservice.mybook.presentation.dto.request.MyBookCreateRequest;
 import kr.mybrary.bookservice.mybook.presentation.dto.response.MyBookDetailResponse;
@@ -10,6 +15,61 @@ import kr.mybrary.bookservice.mybook.presentation.dto.response.MyBookElementResp
 import kr.mybrary.bookservice.mybook.presentation.dto.response.MyBookElementResponse.BookElementResponse;
 
 public class MybookTestData {
+
+    public static MyBook createMyBook() {
+
+        return MyBook.builder()
+                .shareable(false)
+                .startDateOfPossession(LocalDateTime.now())
+                .exchangeable(false)
+                .showable(true)
+                .readStatus(ReadStatus.TO_READ)
+                .book(BookTestData.createBook())
+                .deleted(false)
+                .userId("test_userId")
+                .build();
+    }
+    public static MyBook createDeletedMyBook() {
+
+        return MyBook.builder()
+                .shareable(false)
+                .startDateOfPossession(LocalDateTime.now())
+                .exchangeable(false)
+                .showable(true)
+                .readStatus(ReadStatus.TO_READ)
+                .book(BookTestData.createBook())
+                .deleted(true)
+                .userId("test_userId")
+                .build();
+    }
+
+    public static MyBook createMyBook(Book book) {
+
+        return MyBook.builder()
+                .shareable(false)
+                .startDateOfPossession(LocalDateTime.now())
+                .exchangeable(false)
+                .showable(true)
+                .readStatus(ReadStatus.TO_READ)
+                .book(book)
+                .deleted(false)
+                .userId("test_userId")
+                .build();
+    }
+
+    public static MyBook createMyBookNotShowable() {
+
+        return MyBook.builder()
+                .shareable(false)
+                .startDateOfPossession(LocalDateTime.now())
+                .exchangeable(false)
+                .showable(false)
+                .readStatus(ReadStatus.TO_READ)
+                .book(BookTestData.createBook())
+                .deleted(false)
+                .userId("test_userId")
+                .build();
+    }
 
     public static MyBookCreateRequest createMyBookCreateRequest() {
         return MyBookCreateRequest.builder()
@@ -30,16 +90,16 @@ public class MybookTestData {
     public static MyBookElementResponse createMyBookElementResponse() {
         return MyBookElementResponse.builder()
                 .id(1L)
-                .isShareable(true)
+                .shareable(true)
                 .startDateOfPossession(LocalDateTime.now())
-                .isExchangeable(true)
-                .isPublic(true).readStatus(ReadStatus.TO_READ)
+                .exchangeable(true)
+                .showable(true).readStatus(ReadStatus.TO_READ)
                 .book(BookElementResponse.builder()
                         .id(1L)
                         .title("토비의 스프링 3.1")
                         .description("스프링의 기본기를 다지기 위한 책")
                         .thumbnailUrl("https://bookthumb-phinf.pstatic.net/cover/137/995/13799585.jpg?type=m1&udate=20191226")
-                        .stars(5)
+                        .stars(5.0)
                         .build())
                 .build();
     }
@@ -60,9 +120,32 @@ public class MybookTestData {
                         .translators(List.of("토비"))
                         .publisher("토비의 출판사")
                         .thumbnailUrl("https://bookthumb-phinf.pstatic.net/cover/137/995/13799585.jpg?type=m1&udate=20191226")
-                        .stars(5)
+                        .stars(5.0)
                         .build()
                 )
+                .build();
+    }
+
+    public static MyBookCreateServiceRequest createMyBookCreateServiceRequest() {
+        return MyBookCreateServiceRequest.builder()
+                .userId("test1")
+                .title("title")
+                .description("description")
+                .isbn10("isbn10")
+                .isbn13("isbn13")
+                .publisher("publisher")
+                .publicationDate(LocalDateTime.now())
+                .price(10000)
+                .thumbnailUrl("thumbnailUrl")
+                .authors(List.of("author1", "author2"))
+                .translators(List.of("translator1", "translator2"))
+                .build();
+    }
+
+    public static MyBookFindAllServiceRequest createMyBookFindAllServiceRequest(String userId, String loginId) {
+        return MyBookFindAllServiceRequest.builder()
+                .userId(userId)
+                .loginId(loginId)
                 .build();
     }
 }

--- a/backend/book-service/src/test/java/kr/mybrary/bookservice/mybook/MybookTestData.java
+++ b/backend/book-service/src/test/java/kr/mybrary/bookservice/mybook/MybookTestData.java
@@ -43,6 +43,20 @@ public class MybookTestData {
                 .build();
     }
 
+    public static MyBook createDeletedMyBook(Book book) {
+
+        return MyBook.builder()
+                .shareable(false)
+                .startDateOfPossession(LocalDateTime.now())
+                .exchangeable(false)
+                .showable(true)
+                .readStatus(ReadStatus.TO_READ)
+                .book(book)
+                .deleted(true)
+                .userId("test_userId")
+                .build();
+    }
+
     public static MyBook createMyBook(Book book) {
 
         return MyBook.builder()
@@ -107,9 +121,9 @@ public class MybookTestData {
     public static MyBookDetailResponse createMyBookDetailResponse() {
         return MyBookDetailResponse.builder()
                 .id(1L)
-                .isShareable(true)
-                .isExchangeable(true)
-                .isPublic(true)
+                .shareable(true)
+                .exchangeable(true)
+                .showable(true)
                 .startDateOfPossession(LocalDateTime.now())
                 .readStatus(ReadStatus.TO_READ)
                 .book(BookDetailResponse.builder()

--- a/backend/book-service/src/test/java/kr/mybrary/bookservice/mybook/domain/dto/MyBookDtoMapperTest.java
+++ b/backend/book-service/src/test/java/kr/mybrary/bookservice/mybook/domain/dto/MyBookDtoMapperTest.java
@@ -5,20 +5,24 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import kr.mybrary.bookservice.mybook.MybookTestData;
 import kr.mybrary.bookservice.mybook.persistence.MyBook;
+import kr.mybrary.bookservice.mybook.presentation.dto.response.MyBookDetailResponse;
 import kr.mybrary.bookservice.mybook.presentation.dto.response.MyBookElementResponse;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 class MyBookDtoMapperTest {
 
-    @DisplayName("MyBook 엔티티를 MyBookCreateRequest 매핑한다.")
+    @DisplayName("MyBook 엔티티를 MyBookElementResponse로 매핑한다.")
     @Test
     void entityToMyBookElementResponse() {
 
+        // given
         MyBook myBook = MybookTestData.createMyBook();
 
+        // when
         MyBookElementResponse myBookElementResponse = MyBookDtoMapper.INSTANCE.entityToMyBookElementResponse(myBook);
 
+        // then
         assertAll(
                 () -> assertThat(myBookElementResponse.getId()).isEqualTo(myBook.getId()),
                 () -> assertThat(myBookElementResponse.getStartDateOfPossession()).isEqualTo(myBook.getStartDateOfPossession()),
@@ -31,6 +35,39 @@ class MyBookDtoMapperTest {
                 () -> assertThat(myBookElementResponse.getBook().getDescription()).isEqualTo(myBook.getBook().getDescription()),
                 () -> assertThat(myBookElementResponse.getBook().getThumbnailUrl()).isEqualTo(myBook.getBook().getThumbnailUrl()),
                 () -> assertThat(myBookElementResponse.getBook().getStars()).isEqualTo(0.0)
+        );
+    }
+
+    @DisplayName("MyBook 엔티티를 MyBookDeatail로 매핑한다.")
+    @Test
+    void entityToMyBookDetailResponse() {
+
+        // given
+        MyBook myBook = MybookTestData.createMyBook();
+
+        // when
+        MyBookDetailResponse myBookDetailResponse = MyBookDtoMapper.INSTANCE.entityToMyBookDetailResponse(
+                myBook);
+
+        // then
+        assertAll(
+                () -> assertThat(myBookDetailResponse.getId()).isEqualTo(myBook.getId()),
+                () -> assertThat(myBookDetailResponse.getStartDateOfPossession()).isEqualTo(myBook.getStartDateOfPossession()),
+                () -> assertThat(myBookDetailResponse.getReadStatus()).isEqualTo(myBook.getReadStatus()),
+                () -> assertThat(myBookDetailResponse.isExchangeable()).isEqualTo(myBook.isExchangeable()),
+                () -> assertThat(myBookDetailResponse.isShareable()).isEqualTo(myBook.isShareable()),
+                () -> assertThat(myBookDetailResponse.isShowable()).isEqualTo(myBook.isShowable()),
+                () -> assertThat(myBookDetailResponse.getBook().getId()).isEqualTo(myBook.getBook().getId()),
+                () -> assertThat(myBookDetailResponse.getBook().getTitle()).isEqualTo(myBook.getBook().getTitle()),
+                () -> assertThat(myBookDetailResponse.getBook().getDescription()).isEqualTo(myBook.getBook().getDescription()),
+                () -> assertThat(myBookDetailResponse.getBook().getThumbnailUrl()).isEqualTo(myBook.getBook().getThumbnailUrl()),
+                () -> assertThat(myBookDetailResponse.getBook().getStars()).isEqualTo(0.0),
+                () -> assertThat(myBookDetailResponse.getBook().getAuthors()).isEqualTo(myBook.getBook().getBookAuthors().stream()
+                        .map(bookAuthor -> bookAuthor.getAuthor().getName())
+                        .toList()),
+                () -> assertThat(myBookDetailResponse.getBook().getTranslators()).isEqualTo(myBook.getBook().getBookTranslators().stream()
+                        .map(bookTranslator -> bookTranslator.getTranslator().getName())
+                        .toList())
         );
     }
 }

--- a/backend/book-service/src/test/java/kr/mybrary/bookservice/mybook/domain/dto/MyBookDtoMapperTest.java
+++ b/backend/book-service/src/test/java/kr/mybrary/bookservice/mybook/domain/dto/MyBookDtoMapperTest.java
@@ -1,0 +1,36 @@
+package kr.mybrary.bookservice.mybook.domain.dto;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import kr.mybrary.bookservice.mybook.MybookTestData;
+import kr.mybrary.bookservice.mybook.persistence.MyBook;
+import kr.mybrary.bookservice.mybook.presentation.dto.response.MyBookElementResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class MyBookDtoMapperTest {
+
+    @DisplayName("MyBook 엔티티를 MyBookCreateRequest 매핑한다.")
+    @Test
+    void entityToMyBookElementResponse() {
+
+        MyBook myBook = MybookTestData.createMyBook();
+
+        MyBookElementResponse myBookElementResponse = MyBookDtoMapper.INSTANCE.entityToMyBookElementResponse(myBook);
+
+        assertAll(
+                () -> assertThat(myBookElementResponse.getId()).isEqualTo(myBook.getId()),
+                () -> assertThat(myBookElementResponse.getStartDateOfPossession()).isEqualTo(myBook.getStartDateOfPossession()),
+                () -> assertThat(myBookElementResponse.getReadStatus()).isEqualTo(myBook.getReadStatus()),
+                () -> assertThat(myBookElementResponse.isExchangeable()).isEqualTo(myBook.isExchangeable()),
+                () -> assertThat(myBookElementResponse.isShareable()).isEqualTo(myBook.isShareable()),
+                () -> assertThat(myBookElementResponse.isShowable()).isEqualTo(myBook.isShowable()),
+                () -> assertThat(myBookElementResponse.getBook().getId()).isEqualTo(myBook.getBook().getId()),
+                () -> assertThat(myBookElementResponse.getBook().getTitle()).isEqualTo(myBook.getBook().getTitle()),
+                () -> assertThat(myBookElementResponse.getBook().getDescription()).isEqualTo(myBook.getBook().getDescription()),
+                () -> assertThat(myBookElementResponse.getBook().getThumbnailUrl()).isEqualTo(myBook.getBook().getThumbnailUrl()),
+                () -> assertThat(myBookElementResponse.getBook().getStars()).isEqualTo(0.0)
+        );
+    }
+}

--- a/backend/book-service/src/test/java/kr/mybrary/bookservice/mybook/persistence/MyBookRepositoryTest.java
+++ b/backend/book-service/src/test/java/kr/mybrary/bookservice/mybook/persistence/MyBookRepositoryTest.java
@@ -41,6 +41,7 @@ class MyBookRepositoryTest {
                 () -> assertThat(savedMyBook.getUserId()).isEqualTo(myBook.getUserId()),
                 () -> assertThat(savedMyBook.getBook().getIsbn10()).isEqualTo(myBook.getBook().getIsbn10()),
                 () -> assertThat(savedMyBook.getBook().getIsbn13()).isEqualTo(myBook.getBook().getIsbn13()),
+                () -> assertThat(savedMyBook.getReadStatus()).isEqualTo(ReadStatus.TO_READ),
                 () -> assertThat(savedMyBook.isShowable()).isEqualTo(true),
                 () -> assertThat(savedMyBook.isDeleted()).isEqualTo(false),
                 () -> assertThat(savedMyBook.isExchangeable()).isEqualTo(false),

--- a/backend/book-service/src/test/java/kr/mybrary/bookservice/mybook/persistence/MyBookRepositoryTest.java
+++ b/backend/book-service/src/test/java/kr/mybrary/bookservice/mybook/persistence/MyBookRepositoryTest.java
@@ -1,11 +1,13 @@
 package kr.mybrary.bookservice.mybook.persistence;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
-import java.time.LocalDateTime;
+import java.util.List;
+import kr.mybrary.bookservice.book.BookTestData;
 import kr.mybrary.bookservice.book.persistence.Book;
 import kr.mybrary.bookservice.book.persistence.repository.BookRepository;
+import kr.mybrary.bookservice.mybook.MybookTestData;
 import kr.mybrary.bookservice.mybook.persistence.repository.MyBookRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -25,10 +27,10 @@ class MyBookRepositoryTest {
 
     @DisplayName("마이북을 저장한다.")
     @Test
-    void saveAuthor() {
+    void saveMybook() {
         // given
-        Book savedBook = bookRepository.save(createBook());
-        MyBook myBook = createMyBook(savedBook);
+        Book savedBook = bookRepository.save(BookTestData.createBook());
+        MyBook myBook = MybookTestData.createMyBook(savedBook);
 
         // when
         MyBook savedMyBook = myBookRepository.save(myBook);
@@ -36,9 +38,9 @@ class MyBookRepositoryTest {
         // then
         assertAll(
                 () -> assertThat(savedMyBook.getUserId()).isEqualTo(myBook.getUserId()),
-                () -> assertThat(savedMyBook.getBook().getIsbn10()).isEqualTo("isbn10"),
-                () -> assertThat(savedMyBook.getBook().getIsbn13()).isEqualTo("isbn13"),
-                () -> assertThat(savedMyBook.isPublic()).isEqualTo(false),
+                () -> assertThat(savedMyBook.getBook().getIsbn10()).isEqualTo(myBook.getBook().getIsbn10()),
+                () -> assertThat(savedMyBook.getBook().getIsbn13()).isEqualTo(myBook.getBook().getIsbn13()),
+                () -> assertThat(savedMyBook.isShowable()).isEqualTo(true),
                 () -> assertThat(savedMyBook.isDeleted()).isEqualTo(false),
                 () -> assertThat(savedMyBook.isExchangeable()).isEqualTo(false),
                 () -> assertThat(savedMyBook.isShareable()).isEqualTo(false)
@@ -49,38 +51,34 @@ class MyBookRepositoryTest {
     @Test
     void existsByUserIdAndBook() {
         // given
-        Book savedBook = bookRepository.save(createBook());
-        MyBook myBook = createMyBook(savedBook);
+        Book savedBook = bookRepository.save(BookTestData.createBook());
+        MyBook myBook = MybookTestData.createMyBook(savedBook);
 
         MyBook savedMyBook = myBookRepository.save(myBook);
 
         // when, then
-        assertThat(myBookRepository.existsByUserIdAndBook(savedMyBook.getUserId(), savedMyBook.getBook())).isTrue();
+        assertThat(myBookRepository.existsByUserIdAndBook(savedMyBook.getUserId(),
+                savedMyBook.getBook())).isTrue();
     }
 
-    private MyBook createMyBook(Book book) {
-        return MyBook.builder()
-                .userId("user_id")
-                .book(book)
-                .isDeleted(false)
-                .isExchangeable(false)
-                .isShareable(false)
-                .isPublic(false)
-                .readStatus(ReadStatus.READING)
-                .startDateOfPossession(LocalDateTime.now())
-                .build();
-    }
+    @DisplayName("마이북을 모두 조회한다.")
+    @Test
+    void findAllMyBooks() {
 
-    private Book createBook() {
-        return Book.builder()
-                .isbn10("isbn10")
-                .isbn13("isbn13")
-                .title("title")
-                .description("description")
-                .publisher("publisher")
-                .publishDate(LocalDateTime.now())
-                .price(10000)
-                .thumbnailUrl("thumbnailUrl")
-                .build();
+        // given
+        Book savedBook_1 = bookRepository.save(BookTestData.createBook());
+        Book savedBook_2 = bookRepository.save(BookTestData.createBook());
+
+        MyBook myBook_1 = MybookTestData.createMyBook(savedBook_1);
+        MyBook myBook_2 = MybookTestData.createMyBook(savedBook_2);
+
+        myBookRepository.save(myBook_1);
+        myBookRepository.save(myBook_2);
+
+        // when
+        List<MyBook> myBooks = myBookRepository.findAllByUserId("test_userId");
+
+        // then
+        assertThat(myBooks.size()).isEqualTo(2);
     }
 }

--- a/backend/book-service/src/test/java/kr/mybrary/bookservice/mybook/persistence/MyBookRepositoryTest.java
+++ b/backend/book-service/src/test/java/kr/mybrary/bookservice/mybook/persistence/MyBookRepositoryTest.java
@@ -1,6 +1,7 @@
 package kr.mybrary.bookservice.mybook.persistence;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 import java.util.List;
@@ -80,5 +81,28 @@ class MyBookRepositoryTest {
 
         // then
         assertThat(myBooks.size()).isEqualTo(2);
+    }
+
+    @DisplayName("마이북 ID로 마이북을 조회한다. (삭제된 책은 보여주지 않는다.)")
+    @Test
+    void findMyBookById() {
+
+        // given
+        Book savedBook_1 = bookRepository.save(BookTestData.createBook());
+        Book savedBook_2 = bookRepository.save(BookTestData.createBook());
+
+        MyBook myBook_1 = MybookTestData.createMyBook(savedBook_1);
+        MyBook myBook_2 = MybookTestData.createDeletedMyBook(savedBook_2);
+
+        MyBook savedMyBook = myBookRepository.save(myBook_1);
+        MyBook savedDeletedMyBook = myBookRepository.save(myBook_2);
+
+        // when
+        assertAll(
+                () -> assertThat(myBookRepository.findByIdAndDeletedIsFalse(savedMyBook.getId())
+                        .isPresent()).isTrue(),
+                () -> assertThatThrownBy(() -> myBookRepository.findByIdAndDeletedIsFalse(savedDeletedMyBook.getId())
+                                .orElseThrow(IllegalArgumentException::new))
+        );
     }
 }

--- a/backend/book-service/src/test/java/kr/mybrary/bookservice/mybook/presentation/MyBookControllerTest.java
+++ b/backend/book-service/src/test/java/kr/mybrary/bookservice/mybook/presentation/MyBookControllerTest.java
@@ -72,6 +72,7 @@ class MyBookControllerTest {
 
         // when
         ResultActions actions = mockMvc.perform(post("/api/v1/mybooks")
+                .header("USER-ID", LOGIN_ID)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(requestJson));
 
@@ -92,6 +93,9 @@ class MyBookControllerTest {
                                         .tag("mybook")
                                         .summary("마이북으로 등록한다.")
                                         .requestSchema(Schema.schema("create-mybook request body"))
+                                        .requestHeaders(
+                                                headerWithName("USER-ID").description("사용자 ID")
+                                        )
                                         .requestFields(
                                                 fieldWithPath("title").type(STRING).description("도서 제목"),
                                                 fieldWithPath("description").type(STRING).description("도서 설명"),

--- a/backend/book-service/src/test/java/kr/mybrary/bookservice/mybook/presentation/MyBookControllerTest.java
+++ b/backend/book-service/src/test/java/kr/mybrary/bookservice/mybook/presentation/MyBookControllerTest.java
@@ -55,6 +55,9 @@ class MyBookControllerTest {
     @MockBean
     private MyBookService myBookService;
 
+    private static final String LOGIN_ID = "test-login-id";
+    private static final String USER_ID = "user-login-id";
+
     @DisplayName("내 서재에 책을 추가한다.")
     @Test
     void createMyBook() throws Exception {
@@ -108,7 +111,7 @@ class MyBookControllerTest {
                                         ).build())));
     }
 
-    @DisplayName("내 서재의 도서를 모두 조회한다.")
+    @DisplayName("서재의 도서를 모두 조회한다.")
     @Test
     void findAllMybooks() throws Exception {
         // given
@@ -118,13 +121,14 @@ class MyBookControllerTest {
         given(myBookService.findAllMyBooks(any())).willReturn(List.of(expectedResponse_1, expectedResponse_2));
 
         // when
-        ResultActions actions = mockMvc.perform(get("/api/v1/mybooks"));
+        ResultActions actions = mockMvc.perform(get("/api/v1/users/{userId}/mybooks", USER_ID)
+                .header("USER-ID", LOGIN_ID));
 
         // then
         actions
                 .andExpect(status().is2xxSuccessful())
                 .andExpect(jsonPath("$.status").value("200 OK"))
-                .andExpect(jsonPath("$.message").value("내 서재의 도서 목록입니다."))
+                .andExpect(jsonPath("$.message").value("서재의 도서 목록입니다."))
                 .andExpect(jsonPath("$.data").isNotEmpty());
 
         // document
@@ -147,7 +151,7 @@ class MyBookControllerTest {
                                         fieldWithPath("data[].book.description").type(STRING).description("도서 설명"),
                                         fieldWithPath("data[].book.thumbnailUrl").type(STRING).description("도서 썸네일 URL"),
                                         fieldWithPath("data[].book.stars").type(NUMBER).description("도서 별점"),
-                                        fieldWithPath("data[].public").type(BOOLEAN).description("공개 여부"),
+                                        fieldWithPath("data[].showable").type(BOOLEAN).description("공개 여부"),
                                         fieldWithPath("data[].exchangeable").type(BOOLEAN).description("교환 여부"),
                                         fieldWithPath("data[].shareable").type(BOOLEAN).description("나눔 여부")
                                 ).build())));

--- a/backend/book-service/src/test/java/kr/mybrary/bookservice/mybook/presentation/MyBookControllerTest.java
+++ b/backend/book-service/src/test/java/kr/mybrary/bookservice/mybook/presentation/MyBookControllerTest.java
@@ -1,6 +1,7 @@
 package kr.mybrary.bookservice.mybook.presentation;
 
 import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.document;
+import static com.epages.restdocs.apispec.ResourceDocumentation.headerWithName;
 import static com.epages.restdocs.apispec.ResourceDocumentation.parameterWithName;
 import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
 import static org.mockito.ArgumentMatchers.any;
@@ -57,6 +58,7 @@ class MyBookControllerTest {
 
     private static final String LOGIN_ID = "test-login-id";
     private static final String USER_ID = "user-login-id";
+    private static final Long MYBOOK_ID = 1L;
 
     @DisplayName("내 서재에 책을 추가한다.")
     @Test
@@ -139,6 +141,12 @@ class MyBookControllerTest {
                         ResourceSnippetParameters.builder()
                                 .tag("mybook")
                                 .summary("내 서재의 도서를 모두 조회한다.")
+                                .pathParameters(
+                                        parameterWithName("userId").type(SimpleType.STRING).description("사용자 ID")
+                                )
+                                .requestHeaders(
+                                        headerWithName("USER-ID").description("사용자 ID")
+                                )
                                 .responseSchema(Schema.schema("find-all-mybooks response body"))
                                 .responseFields(
                                         fieldWithPath("status").type(STRING).description("응답 상태"),
@@ -163,13 +171,13 @@ class MyBookControllerTest {
     void findMyBookDetail() throws Exception {
 
         // given
-        Long id = 1L;
         MyBookDetailResponse expectedResponse = MybookTestData.createMyBookDetailResponse();
 
-        given(myBookService.findMyBookDetail(any(), any())).willReturn(expectedResponse);
+        given(myBookService.findMyBookDetail(any())).willReturn(expectedResponse);
 
         // when
-        ResultActions actions = mockMvc.perform(get("/api/v1/mybooks/{id}", id));
+        ResultActions actions = mockMvc.perform(get("/api/v1/users/{userId}/mybooks/{mybookId}", LOGIN_ID, MYBOOK_ID)
+                .header("USER-ID", LOGIN_ID));
 
         // then
         actions
@@ -187,15 +195,19 @@ class MyBookControllerTest {
                                 ResourceSnippetParameters.builder()
                                         .tag("mybook")
                                         .summary("내 마이북의 상세보기를 조회한다.")
+                                        .requestHeaders(
+                                                headerWithName("USER-ID").description("사용자 ID")
+                                        )
                                         .pathParameters(
-                                                parameterWithName("id").type(SimpleType.INTEGER).description("마이북 ID")
+                                                parameterWithName("userId").type(SimpleType.STRING).description("사용자 ID"),
+                                                parameterWithName("mybookId").type(SimpleType.NUMBER).description("마이북 ID")
                                         )
                                         .responseSchema(Schema.schema("find-mybook-detail response body"))
                                         .responseFields(
                                                 fieldWithPath("status").type(STRING).description("응답 상태"),
                                                 fieldWithPath("message").type(STRING).description("응답 메시지"),
                                                 fieldWithPath("data.id").type(NUMBER).description("마이북 ID"),
-                                                fieldWithPath("data.public").type(BOOLEAN).description("공개 여부"),
+                                                fieldWithPath("data.showable").type(BOOLEAN).description("공개 여부"),
                                                 fieldWithPath("data.exchangeable").type(BOOLEAN).description("교환 여부"),
                                                 fieldWithPath("data.shareable").type(BOOLEAN).description("나눔 여부"),
                                                 fieldWithPath("data.readStatus").type(STRING).description("독서 진행 상태"),


### PR DESCRIPTION
## 🧑‍💻 작업 사항

### Mybook 엔티티 필드명 수정
- isPublic, isSharable, isExchangable 에서 is 접두사 제거 (showable, sharable, exchangeable)
- boolean에 대한 Getter 이슈와 Mapstruct 매핑 이슈로 인해 boolean 변수 네이밍에서 is 를 제거하기로 협의

### API 개발
- 마이북 전체조회 : GET "/api/v1/users/{userId}/mybooks"
- 마이북 상세조회 : GET "/api/v1/users/{userId}/mybooks/{mybookId}"
- 각 예외 상황 처리 및 단위 테스트 작성
- 로그인한 사용자 아이디는 Http Request Header를 통해 전달받도록 구현 ("USER-ID")

### 테스트 코드 작성
- 테스트 코드에 필요한 테스트 데이터 추가
- 각 계층 단위 테스트 작성
    - Domain 계층, 여러 예외 상황에 대해서도 테스트 코드 작성
    - Persistence 계층, 작성한 쿼리 메서드가 의도한 쿼리를 생성하고 동작하는지 테스트 코드 작성
- mapStruct 매핑에 대한 테스트 코드 작성

### 예외 코드 추가
<img width="661" alt="image" src="https://github.com/SWM-IDLE/mybrary/assets/71378475/f54fab48-e685-4586-b718-e7de4983ea0f">

<br><br>

## 🔗 링크

<!-- 관련된 대화가 이루어진 슬랙 링크 혹은 피그마 링크를 첨부. -->
<!-- - [프레이머](https://framer.com/projects/2--gSDcZoNKqU6dqCUQUYQe-53rEr?node=tQMWSSKqy)  -->

<br><br>

## 🐰 시급한 정도

🐢 천천히 : 급하지 않습니다.

<br><br>

## 📖 참고 사항

<!-- 공유할 내용, 레퍼런스, 추가로 발생할 것으로 예상되는 이슈, 스크린샷 등을 넣어 주세요.  -->
<!-- 변경사항이 큰 경우 집중해야 할 부분, 또는 불안해서 봐주었으면 하는 부분 등 -->
