### PR TITLE
[IDLE-105] feat: 사용자 프로필 조회 API 개발

### DIFF
--- a/user-service/build.gradle
+++ b/user-service/build.gradle
@@ -47,6 +47,8 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
+	testCompileOnly 'org.projectlombok:lombok'
+	testAnnotationProcessor 'org.projectlombok:lombok'
 	//spring rest docs
 	testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
 	//restdocs-api-spec 의존성 추가

--- a/user-service/src/main/java/kr/mybrary/userservice/global/exception/ApplicationException.java
+++ b/user-service/src/main/java/kr/mybrary/userservice/global/exception/ApplicationException.java
@@ -5,10 +5,12 @@ import lombok.Getter;
 @Getter
 public class ApplicationException extends RuntimeException {
 
+    private int status;
     private String errorCode;
     private String errorMessage;
 
-    public ApplicationException(String errorCode, String errorMessage) {
+    public ApplicationException(int status, String errorCode, String errorMessage) {
+        this.status = status;
         this.errorCode = errorCode;
         this.errorMessage = errorMessage;
     }

--- a/user-service/src/main/java/kr/mybrary/userservice/global/exception/GlobalExceptionHandler.java
+++ b/user-service/src/main/java/kr/mybrary/userservice/global/exception/GlobalExceptionHandler.java
@@ -10,7 +10,7 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(ApplicationException.class)
     public ResponseEntity<ErrorResponse> applicationException(ApplicationException e) {
-        return ResponseEntity.badRequest()
+        return ResponseEntity.status(e.getStatus())
                 .body(ErrorResponse.of(e.getErrorCode(), e.getErrorMessage()));
     }
 

--- a/user-service/src/main/java/kr/mybrary/userservice/user/domain/UserService.java
+++ b/user-service/src/main/java/kr/mybrary/userservice/user/domain/UserService.java
@@ -7,7 +7,7 @@ import kr.mybrary.userservice.user.domain.dto.request.ProfileUpdateServiceReques
 import kr.mybrary.userservice.user.domain.dto.request.SignUpServiceRequest;
 import kr.mybrary.userservice.user.domain.dto.response.FollowerServiceResponse;
 import kr.mybrary.userservice.user.domain.dto.response.FollowingServiceResponse;
-import kr.mybrary.userservice.user.domain.dto.response.ProfileImageServiceResponse;
+import kr.mybrary.userservice.user.domain.dto.response.ProfileImageUrlServiceResponse;
 import kr.mybrary.userservice.user.domain.dto.response.ProfileServiceResponse;
 import kr.mybrary.userservice.user.domain.dto.response.SignUpServiceResponse;
 
@@ -19,11 +19,11 @@ public interface UserService {
 
     ProfileServiceResponse updateProfile(ProfileUpdateServiceRequest serviceRequest);
 
-    ProfileImageServiceResponse getProfileImage(String loginId);
+    ProfileImageUrlServiceResponse getProfileImageUrl(String loginId);
 
-    ProfileImageServiceResponse updateProfileImage(ProfileImageUpdateServiceRequest serviceRequest);
+    ProfileImageUrlServiceResponse updateProfileImage(ProfileImageUpdateServiceRequest serviceRequest);
 
-    ProfileImageServiceResponse deleteProfileImage(String loginId);
+    ProfileImageUrlServiceResponse deleteProfileImage(String loginId);
 
     FollowerServiceResponse getFollowers(String loginId);
 

--- a/user-service/src/main/java/kr/mybrary/userservice/user/domain/UserServiceImpl.java
+++ b/user-service/src/main/java/kr/mybrary/userservice/user/domain/UserServiceImpl.java
@@ -14,6 +14,7 @@ import kr.mybrary.userservice.user.domain.dto.response.SignUpServiceResponse;
 import kr.mybrary.userservice.user.domain.exception.DuplicateEmailException;
 import kr.mybrary.userservice.user.domain.exception.DuplicateLoginIdException;
 import kr.mybrary.userservice.user.domain.exception.DuplicateNicknameException;
+import kr.mybrary.userservice.user.domain.exception.UserNotFoundException;
 import kr.mybrary.userservice.user.persistence.Role;
 import kr.mybrary.userservice.user.persistence.User;
 import kr.mybrary.userservice.user.persistence.repository.UserRepository;
@@ -40,7 +41,8 @@ public class UserServiceImpl implements UserService {
         User user = UserMapper.INSTANCE.toEntity(serviceRequest);
         user.updatePassword(passwordEncoder.encode(user.getPassword()));
         user.updateRole(Role.USER);
-        SignUpServiceResponse serviceResponse = UserMapper.INSTANCE.toSignUpServiceResponse(userRepository.save(user));
+        SignUpServiceResponse serviceResponse = UserMapper.INSTANCE.toSignUpServiceResponse(
+                userRepository.save(user));
 
         return serviceResponse;
     }
@@ -65,7 +67,11 @@ public class UserServiceImpl implements UserService {
 
     @Override
     public ProfileServiceResponse getProfile(String loginId) {
-        return null;
+        User user = userRepository.findByLoginId(loginId)
+                .orElseThrow(UserNotFoundException::new);
+        ProfileServiceResponse serviceResponse = UserMapper.INSTANCE.toProfileServiceResponse(user);
+
+        return serviceResponse;
     }
 
     @Override

--- a/user-service/src/main/java/kr/mybrary/userservice/user/domain/UserServiceImpl.java
+++ b/user-service/src/main/java/kr/mybrary/userservice/user/domain/UserServiceImpl.java
@@ -8,12 +8,13 @@ import kr.mybrary.userservice.user.domain.dto.request.ProfileUpdateServiceReques
 import kr.mybrary.userservice.user.domain.dto.request.SignUpServiceRequest;
 import kr.mybrary.userservice.user.domain.dto.response.FollowerServiceResponse;
 import kr.mybrary.userservice.user.domain.dto.response.FollowingServiceResponse;
-import kr.mybrary.userservice.user.domain.dto.response.ProfileImageServiceResponse;
+import kr.mybrary.userservice.user.domain.dto.response.ProfileImageUrlServiceResponse;
 import kr.mybrary.userservice.user.domain.dto.response.ProfileServiceResponse;
 import kr.mybrary.userservice.user.domain.dto.response.SignUpServiceResponse;
 import kr.mybrary.userservice.user.domain.exception.DuplicateEmailException;
 import kr.mybrary.userservice.user.domain.exception.DuplicateLoginIdException;
 import kr.mybrary.userservice.user.domain.exception.DuplicateNicknameException;
+import kr.mybrary.userservice.user.domain.exception.ProfileImageUrlNotFoundException;
 import kr.mybrary.userservice.user.domain.exception.UserNotFoundException;
 import kr.mybrary.userservice.user.persistence.Role;
 import kr.mybrary.userservice.user.persistence.User;
@@ -80,18 +81,33 @@ public class UserServiceImpl implements UserService {
     }
 
     @Override
-    public ProfileImageServiceResponse getProfileImage(String loginId) {
-        return null;
+    public ProfileImageUrlServiceResponse getProfileImageUrl(String loginId) {
+        User user = userRepository.findByLoginId(loginId)
+                .orElseThrow(UserNotFoundException::new);
+
+        checkProfileImageUrlExistence(user);
+
+        ProfileImageUrlServiceResponse serviceResponse = ProfileImageUrlServiceResponse.builder()
+                .profileImageUrl(user.getProfileImageUrl())
+                .build();
+
+        return serviceResponse;
+    }
+
+    private void checkProfileImageUrlExistence(User user) {
+        if (user.getProfileImageUrl() == null) {
+            throw new ProfileImageUrlNotFoundException();
+        }
     }
 
     @Override
-    public ProfileImageServiceResponse updateProfileImage(
+    public ProfileImageUrlServiceResponse updateProfileImage(
             ProfileImageUpdateServiceRequest serviceRequest) {
         return null;
     }
 
     @Override
-    public ProfileImageServiceResponse deleteProfileImage(String loginId) {
+    public ProfileImageUrlServiceResponse deleteProfileImage(String loginId) {
         return null;
     }
 

--- a/user-service/src/main/java/kr/mybrary/userservice/user/domain/UserServiceImpl.java
+++ b/user-service/src/main/java/kr/mybrary/userservice/user/domain/UserServiceImpl.java
@@ -67,6 +67,7 @@ public class UserServiceImpl implements UserService {
     }
 
     @Override
+    @Transactional(readOnly = true)
     public ProfileServiceResponse getProfile(String loginId) {
         User user = userRepository.findByLoginId(loginId)
                 .orElseThrow(UserNotFoundException::new);
@@ -81,6 +82,7 @@ public class UserServiceImpl implements UserService {
     }
 
     @Override
+    @Transactional(readOnly = true)
     public ProfileImageUrlServiceResponse getProfileImageUrl(String loginId) {
         User user = userRepository.findByLoginId(loginId)
                 .orElseThrow(UserNotFoundException::new);
@@ -112,11 +114,13 @@ public class UserServiceImpl implements UserService {
     }
 
     @Override
+    @Transactional(readOnly = true)
     public FollowerServiceResponse getFollowers(String loginId) {
         return null;
     }
 
     @Override
+    @Transactional(readOnly = true)
     public FollowingServiceResponse getFollowings(String loginId) {
         return null;
     }

--- a/user-service/src/main/java/kr/mybrary/userservice/user/domain/dto/UserMapper.java
+++ b/user-service/src/main/java/kr/mybrary/userservice/user/domain/dto/UserMapper.java
@@ -1,6 +1,7 @@
 package kr.mybrary.userservice.user.domain.dto;
 
 import kr.mybrary.userservice.user.domain.dto.request.SignUpServiceRequest;
+import kr.mybrary.userservice.user.domain.dto.response.ProfileServiceResponse;
 import kr.mybrary.userservice.user.domain.dto.response.SignUpServiceResponse;
 import kr.mybrary.userservice.user.persistence.User;
 import org.mapstruct.Mapper;
@@ -15,4 +16,6 @@ public interface UserMapper {
     User toEntity(SignUpServiceRequest serviceRequest);
 
     SignUpServiceResponse toSignUpServiceResponse(User user);
+
+    ProfileServiceResponse toProfileServiceResponse(User user);
 }

--- a/user-service/src/main/java/kr/mybrary/userservice/user/domain/dto/response/ProfileImageUrlServiceResponse.java
+++ b/user-service/src/main/java/kr/mybrary/userservice/user/domain/dto/response/ProfileImageUrlServiceResponse.java
@@ -5,7 +5,7 @@ import lombok.Getter;
 
 @Getter
 @Builder
-public class ProfileImageServiceResponse {
+public class ProfileImageUrlServiceResponse {
 
     private String profileImageUrl;
 

--- a/user-service/src/main/java/kr/mybrary/userservice/user/domain/exception/DuplicateEmailException.java
+++ b/user-service/src/main/java/kr/mybrary/userservice/user/domain/exception/DuplicateEmailException.java
@@ -4,11 +4,12 @@ import kr.mybrary.userservice.global.exception.ApplicationException;
 
 public class DuplicateEmailException extends ApplicationException {
 
+    private final static int STATUS = 400;
     private final static String ERROR_CODE = "U-04";
     private final static String ERROR_MESSAGE = "이미 존재하는 이메일입니다.";
 
     public DuplicateEmailException() {
-        super(ERROR_CODE, ERROR_MESSAGE);
+        super(STATUS, ERROR_CODE, ERROR_MESSAGE);
     }
 
 }

--- a/user-service/src/main/java/kr/mybrary/userservice/user/domain/exception/DuplicateLoginIdException.java
+++ b/user-service/src/main/java/kr/mybrary/userservice/user/domain/exception/DuplicateLoginIdException.java
@@ -4,11 +4,12 @@ import kr.mybrary.userservice.global.exception.ApplicationException;
 
 public class DuplicateLoginIdException extends ApplicationException {
 
+    private final static int STATUS = 400;
     private final static String ERROR_CODE = "U-02";
     private final static String ERROR_MESSAGE = "이미 존재하는 로그인 아이디입니다.";
 
     public DuplicateLoginIdException() {
-        super(ERROR_CODE, ERROR_MESSAGE);
+        super(STATUS, ERROR_CODE, ERROR_MESSAGE);
     }
 
 

--- a/user-service/src/main/java/kr/mybrary/userservice/user/domain/exception/DuplicateNicknameException.java
+++ b/user-service/src/main/java/kr/mybrary/userservice/user/domain/exception/DuplicateNicknameException.java
@@ -4,11 +4,12 @@ import kr.mybrary.userservice.global.exception.ApplicationException;
 
 public class DuplicateNicknameException extends ApplicationException {
 
+    private final static int STATUS = 400;
     private final static String ERROR_CODE = "U-03";
     private final static String ERROR_MESSAGE = "이미 존재하는 닉네임입니다.";
 
     public DuplicateNicknameException() {
-        super(ERROR_CODE, ERROR_MESSAGE);
+        super(STATUS, ERROR_CODE, ERROR_MESSAGE);
     }
 
 }

--- a/user-service/src/main/java/kr/mybrary/userservice/user/domain/exception/DuplicateUserInfoException.java
+++ b/user-service/src/main/java/kr/mybrary/userservice/user/domain/exception/DuplicateUserInfoException.java
@@ -4,10 +4,11 @@ import kr.mybrary.userservice.global.exception.ApplicationException;
 
 public class DuplicateUserInfoException extends ApplicationException {
 
+    private final static int STATUS = 400;
     private final static String ERROR_CODE = "U-01";
     private final static String ERROR_MESSAGE = "이미 존재하는 회원입니다.";
 
     public DuplicateUserInfoException() {
-        super(ERROR_CODE, ERROR_MESSAGE);
+        super(STATUS, ERROR_CODE, ERROR_MESSAGE);
     }
 }

--- a/user-service/src/main/java/kr/mybrary/userservice/user/domain/exception/ProfileImageUrlNotFoundException.java
+++ b/user-service/src/main/java/kr/mybrary/userservice/user/domain/exception/ProfileImageUrlNotFoundException.java
@@ -1,0 +1,14 @@
+package kr.mybrary.userservice.user.domain.exception;
+
+import kr.mybrary.userservice.global.exception.ApplicationException;
+
+public class ProfileImageUrlNotFoundException extends ApplicationException {
+
+    private final static String ERROR_CODE = "P-01";
+    private final static String ERROR_MESSAGE = "프로필 이미지 URL이 존재하지 않습니다.";
+
+    public ProfileImageUrlNotFoundException() {
+        super(ERROR_CODE, ERROR_MESSAGE);
+    }
+
+}

--- a/user-service/src/main/java/kr/mybrary/userservice/user/domain/exception/ProfileImageUrlNotFoundException.java
+++ b/user-service/src/main/java/kr/mybrary/userservice/user/domain/exception/ProfileImageUrlNotFoundException.java
@@ -4,11 +4,12 @@ import kr.mybrary.userservice.global.exception.ApplicationException;
 
 public class ProfileImageUrlNotFoundException extends ApplicationException {
 
+    private final static int STATUS = 404;
     private final static String ERROR_CODE = "P-01";
     private final static String ERROR_MESSAGE = "프로필 이미지 URL이 존재하지 않습니다.";
 
     public ProfileImageUrlNotFoundException() {
-        super(ERROR_CODE, ERROR_MESSAGE);
+        super(STATUS, ERROR_CODE, ERROR_MESSAGE);
     }
 
 }

--- a/user-service/src/main/java/kr/mybrary/userservice/user/domain/exception/UserNotFoundException.java
+++ b/user-service/src/main/java/kr/mybrary/userservice/user/domain/exception/UserNotFoundException.java
@@ -1,0 +1,14 @@
+package kr.mybrary.userservice.user.domain.exception;
+
+import kr.mybrary.userservice.global.exception.ApplicationException;
+
+public class UserNotFoundException extends ApplicationException {
+
+    private final static String ERROR_CODE = "U-05";
+    private final static String ERROR_MESSAGE = "존재하지 않는 사용자입니다.";
+
+    public UserNotFoundException() {
+        super(ERROR_CODE, ERROR_MESSAGE);
+    }
+
+}

--- a/user-service/src/main/java/kr/mybrary/userservice/user/domain/exception/UserNotFoundException.java
+++ b/user-service/src/main/java/kr/mybrary/userservice/user/domain/exception/UserNotFoundException.java
@@ -4,11 +4,12 @@ import kr.mybrary.userservice.global.exception.ApplicationException;
 
 public class UserNotFoundException extends ApplicationException {
 
+    private final static int STATUS = 404;
     private final static String ERROR_CODE = "U-05";
     private final static String ERROR_MESSAGE = "존재하지 않는 사용자입니다.";
 
     public UserNotFoundException() {
-        super(ERROR_CODE, ERROR_MESSAGE);
+        super(STATUS, ERROR_CODE, ERROR_MESSAGE);
     }
 
 }

--- a/user-service/src/main/java/kr/mybrary/userservice/user/presentation/UserController.java
+++ b/user-service/src/main/java/kr/mybrary/userservice/user/presentation/UserController.java
@@ -10,7 +10,7 @@ import kr.mybrary.userservice.user.domain.dto.request.ProfileUpdateServiceReques
 import kr.mybrary.userservice.user.domain.dto.request.SignUpServiceRequest;
 import kr.mybrary.userservice.user.domain.dto.response.FollowerServiceResponse;
 import kr.mybrary.userservice.user.domain.dto.response.FollowingServiceResponse;
-import kr.mybrary.userservice.user.domain.dto.response.ProfileImageServiceResponse;
+import kr.mybrary.userservice.user.domain.dto.response.ProfileImageUrlServiceResponse;
 import kr.mybrary.userservice.user.domain.dto.response.ProfileServiceResponse;
 import kr.mybrary.userservice.user.domain.dto.response.SignUpServiceResponse;
 import kr.mybrary.userservice.user.presentation.dto.request.FollowRequest;
@@ -81,9 +81,9 @@ public class UserController {
     }
 
     @GetMapping("/profile/image")
-    public ResponseEntity<SuccessResponse> getProfileImage(
+    public ResponseEntity<SuccessResponse> getProfileImageUrl(
             @RequestHeader("USER-ID") String loginId) {
-        ProfileImageServiceResponse serviceResponse = userService.getProfileImage(loginId);
+        ProfileImageUrlServiceResponse serviceResponse = userService.getProfileImageUrl(loginId);
 
         return ResponseEntity.ok().body(
                 SuccessResponse.of(HttpStatus.OK.toString(), "로그인 된 사용자의 프로필 이미지 URL입니다.",
@@ -96,7 +96,7 @@ public class UserController {
             @RequestHeader("USER-ID") String loginId, @RequestParam("profileImage") MultipartFile profileImage) {
         ProfileImageUpdateServiceRequest serviceRequest = ProfileImageUpdateServiceRequest.of(
                 profileImage, loginId);
-        ProfileImageServiceResponse serviceResponse = userService.updateProfileImage(
+        ProfileImageUrlServiceResponse serviceResponse = userService.updateProfileImage(
                 serviceRequest);
 
         return ResponseEntity.ok().body(
@@ -108,7 +108,7 @@ public class UserController {
     @DeleteMapping("/profile/image")
     public ResponseEntity<SuccessResponse> deleteProfileImage(
             @RequestHeader("USER-ID") String loginId) {
-        ProfileImageServiceResponse serviceResponse = userService.deleteProfileImage(loginId);
+        ProfileImageUrlServiceResponse serviceResponse = userService.deleteProfileImage(loginId);
 
         return ResponseEntity.ok().body(
                 SuccessResponse.of(HttpStatus.OK.toString(), "로그인 된 사용자의 프로필 이미지를 삭제했습니다.",

--- a/user-service/src/test/java/kr/mybrary/userservice/user/UserFixture.java
+++ b/user-service/src/test/java/kr/mybrary/userservice/user/UserFixture.java
@@ -6,10 +6,12 @@ import kr.mybrary.userservice.user.persistence.Follow;
 import kr.mybrary.userservice.user.persistence.Role;
 import kr.mybrary.userservice.user.persistence.SocialType;
 import kr.mybrary.userservice.user.persistence.User;
+import lombok.AllArgsConstructor;
 
+@AllArgsConstructor
 public enum UserFixture {
 
-    USER(1L, "loginId", "nickname", "encodedPassword", Role.USER, "socialId", SocialType.GOOGLE,
+    COMMON_USER(1L, "loginId", "nickname", "encodedPassword", Role.USER, "socialId", SocialType.GOOGLE,
             "refreshToken", "email@mail.com", "introduction", "profileImageUrl",
             Collections.emptyList(), Collections.emptyList()),
     USER_WITHOUT_PROFILE_IMAGE_URL(1L, "loginId", "nickname", "encodedPassword", Role.USER,
@@ -31,25 +33,6 @@ public enum UserFixture {
     private final String profileImageUrl;
     private final List<Follow> followers;
     private final List<Follow> followings;
-
-    UserFixture(Long id, String loginId, String nickname, String password, Role role,
-            String socialId, SocialType socialType, String refreshToken, String email,
-            String introduction, String profileImageUrl, List<Follow> followers,
-            List<Follow> followings) {
-        this.id = id;
-        this.loginId = loginId;
-        this.nickname = nickname;
-        this.password = password;
-        this.role = role;
-        this.socialId = socialId;
-        this.socialType = socialType;
-        this.refreshToken = refreshToken;
-        this.email = email;
-        this.introduction = introduction;
-        this.profileImageUrl = profileImageUrl;
-        this.followers = followers;
-        this.followings = followings;
-    }
 
     public User getUser() {
         return User.builder()

--- a/user-service/src/test/java/kr/mybrary/userservice/user/UserFixture.java
+++ b/user-service/src/test/java/kr/mybrary/userservice/user/UserFixture.java
@@ -1,0 +1,72 @@
+package kr.mybrary.userservice.user;
+
+import java.util.Collections;
+import java.util.List;
+import kr.mybrary.userservice.user.persistence.Follow;
+import kr.mybrary.userservice.user.persistence.Role;
+import kr.mybrary.userservice.user.persistence.SocialType;
+import kr.mybrary.userservice.user.persistence.User;
+
+public enum UserFixture {
+
+    USER(1L, "loginId", "nickname", "encodedPassword", Role.USER, "socialId", SocialType.GOOGLE,
+            "refreshToken", "email@mail.com", "introduction", "profileImageUrl",
+            Collections.emptyList(), Collections.emptyList()),
+    USER_WITHOUT_PROFILE_IMAGE_URL(1L, "loginId", "nickname", "encodedPassword", Role.USER,
+            "socialId",
+            SocialType.GOOGLE, "refreshToken", "email@mail.com", "introduction", null,
+            Collections.emptyList(),
+            Collections.emptyList());
+
+    private final Long id;
+    private final String loginId;
+    private final String nickname;
+    private final String password;
+    private final Role role;
+    private final String socialId;
+    private final SocialType socialType;
+    private final String refreshToken;
+    private final String email;
+    private final String introduction;
+    private final String profileImageUrl;
+    private final List<Follow> followers;
+    private final List<Follow> followings;
+
+    UserFixture(Long id, String loginId, String nickname, String password, Role role,
+            String socialId, SocialType socialType, String refreshToken, String email,
+            String introduction, String profileImageUrl, List<Follow> followers,
+            List<Follow> followings) {
+        this.id = id;
+        this.loginId = loginId;
+        this.nickname = nickname;
+        this.password = password;
+        this.role = role;
+        this.socialId = socialId;
+        this.socialType = socialType;
+        this.refreshToken = refreshToken;
+        this.email = email;
+        this.introduction = introduction;
+        this.profileImageUrl = profileImageUrl;
+        this.followers = followers;
+        this.followings = followings;
+    }
+
+    public User getUser() {
+        return User.builder()
+                .id(id)
+                .loginId(loginId)
+                .nickname(nickname)
+                .password(password)
+                .role(role)
+                .socialId(socialId)
+                .socialType(socialType)
+                .refreshToken(refreshToken)
+                .email(email)
+                .introduction(introduction)
+                .profileImageUrl(profileImageUrl)
+                .followers(followers)
+                .followings(followings)
+                .build();
+    }
+
+}

--- a/user-service/src/test/java/kr/mybrary/userservice/user/UserTestData.java
+++ b/user-service/src/test/java/kr/mybrary/userservice/user/UserTestData.java
@@ -1,8 +1,30 @@
 package kr.mybrary.userservice.user;
 
+import java.util.Collections;
+import kr.mybrary.userservice.user.persistence.Role;
+import kr.mybrary.userservice.user.persistence.SocialType;
 import kr.mybrary.userservice.user.persistence.User;
 
 public class UserTestData {
+
+    public static User createUser() {
+
+            return User.builder()
+                    .id(1L)
+                    .loginId("loginId")
+                    .nickname("nickname")
+                    .password("password")
+                    .role(Role.USER)
+                    .socialId("socialId")
+                    .socialType(SocialType.GOOGLE)
+                    .refreshToken("refreshToken")
+                    .email("email@mail.com")
+                    .introduction("introduction")
+                    .profileImageUrl("profileImageUrl")
+                    .followers(Collections.emptyList())
+                    .followings(Collections.emptyList())
+                    .build();
+    }
 
     public static User createUserWithProfile() {
 

--- a/user-service/src/test/java/kr/mybrary/userservice/user/UserTestData.java
+++ b/user-service/src/test/java/kr/mybrary/userservice/user/UserTestData.java
@@ -5,14 +5,6 @@ import kr.mybrary.userservice.user.persistence.User;
 
 public class UserTestData {
 
-    public static User createUser() {
-        return UserFixture.USER.getUser();
-    }
-
-    public static User createUserWithOutProfileImageUrl() {
-        return UserFixture.USER_WITHOUT_PROFILE_IMAGE_URL.getUser();
-    }
-
     public static SignUpServiceRequest createSignUpServiceRequest() {
         return SignUpServiceRequest.builder()
                 .loginId("loginId")

--- a/user-service/src/test/java/kr/mybrary/userservice/user/UserTestData.java
+++ b/user-service/src/test/java/kr/mybrary/userservice/user/UserTestData.java
@@ -1,0 +1,19 @@
+package kr.mybrary.userservice.user;
+
+import kr.mybrary.userservice.user.persistence.User;
+
+public class UserTestData {
+
+    public static User createUserWithProfile() {
+
+        return User.builder()
+                .id(1L)
+                .loginId("loginId")
+                .nickname("nickname")
+                .email("email@mail.com")
+                .introduction("introduction")
+                .profileImageUrl("profileImageUrl")
+                .build();
+    }
+
+}

--- a/user-service/src/test/java/kr/mybrary/userservice/user/UserTestData.java
+++ b/user-service/src/test/java/kr/mybrary/userservice/user/UserTestData.java
@@ -16,4 +16,14 @@ public class UserTestData {
                 .build();
     }
 
+    public static User createUserWithOutProfileImageUrl() {
+
+        return User.builder()
+                .id(1L)
+                .loginId("loginId")
+                .nickname("nickname")
+                .email("email@mail.com")
+                .introduction("introduction")
+                .build();
+    }
 }

--- a/user-service/src/test/java/kr/mybrary/userservice/user/UserTestData.java
+++ b/user-service/src/test/java/kr/mybrary/userservice/user/UserTestData.java
@@ -1,51 +1,24 @@
 package kr.mybrary.userservice.user;
 
-import java.util.Collections;
-import kr.mybrary.userservice.user.persistence.Role;
-import kr.mybrary.userservice.user.persistence.SocialType;
+import kr.mybrary.userservice.user.domain.dto.request.SignUpServiceRequest;
 import kr.mybrary.userservice.user.persistence.User;
 
 public class UserTestData {
 
     public static User createUser() {
-
-            return User.builder()
-                    .id(1L)
-                    .loginId("loginId")
-                    .nickname("nickname")
-                    .password("password")
-                    .role(Role.USER)
-                    .socialId("socialId")
-                    .socialType(SocialType.GOOGLE)
-                    .refreshToken("refreshToken")
-                    .email("email@mail.com")
-                    .introduction("introduction")
-                    .profileImageUrl("profileImageUrl")
-                    .followers(Collections.emptyList())
-                    .followings(Collections.emptyList())
-                    .build();
-    }
-
-    public static User createUserWithProfile() {
-
-        return User.builder()
-                .id(1L)
-                .loginId("loginId")
-                .nickname("nickname")
-                .email("email@mail.com")
-                .introduction("introduction")
-                .profileImageUrl("profileImageUrl")
-                .build();
+        return UserFixture.USER.getUser();
     }
 
     public static User createUserWithOutProfileImageUrl() {
+        return UserFixture.USER_WITHOUT_PROFILE_IMAGE_URL.getUser();
+    }
 
-        return User.builder()
-                .id(1L)
+    public static SignUpServiceRequest createSignUpServiceRequest() {
+        return SignUpServiceRequest.builder()
                 .loginId("loginId")
+                .password("password123!")
                 .nickname("nickname")
                 .email("email@mail.com")
-                .introduction("introduction")
                 .build();
     }
 }

--- a/user-service/src/test/java/kr/mybrary/userservice/user/domain/UserServiceImplTest.java
+++ b/user-service/src/test/java/kr/mybrary/userservice/user/domain/UserServiceImplTest.java
@@ -7,6 +7,7 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 
 import java.util.Optional;
+import kr.mybrary.userservice.user.UserFixture;
 import kr.mybrary.userservice.user.UserTestData;
 import kr.mybrary.userservice.user.domain.dto.request.SignUpServiceRequest;
 import kr.mybrary.userservice.user.domain.dto.response.ProfileImageUrlServiceResponse;
@@ -47,11 +48,13 @@ class UserServiceImplTest {
         // Given
         SignUpServiceRequest serviceRequest = UserTestData.createSignUpServiceRequest();
 
-        given(userRepository.findByLoginId(serviceRequest.getLoginId())).willReturn(Optional.empty());
-        given(userRepository.findByNickname(serviceRequest.getNickname())).willReturn(Optional.empty());
+        given(userRepository.findByLoginId(serviceRequest.getLoginId())).willReturn(
+                Optional.empty());
+        given(userRepository.findByNickname(serviceRequest.getNickname())).willReturn(
+                Optional.empty());
         given(userRepository.findByEmail(serviceRequest.getEmail())).willReturn(Optional.empty());
         given(passwordEncoder.encode(serviceRequest.getPassword())).willReturn("encodedPassword");
-        given(userRepository.save(any(User.class))).willReturn(UserTestData.createUser());
+        given(userRepository.save(any(User.class))).willReturn(UserFixture.COMMON_USER.getUser());
 
         // When
         SignUpServiceResponse savedUser = userService.signUp(serviceRequest);
@@ -76,12 +79,8 @@ class UserServiceImplTest {
         // Given
         SignUpServiceRequest serviceRequest = UserTestData.createSignUpServiceRequest();
 
-        User user = User.builder()
-                .loginId("loginId")
-                .build();
-
         given(userRepository.findByLoginId(serviceRequest.getLoginId())).willReturn(
-                Optional.of(user));
+                Optional.of(UserFixture.COMMON_USER.getUser()));
 
         // When
         assertThatThrownBy(() -> userService.signUp(serviceRequest))
@@ -99,12 +98,8 @@ class UserServiceImplTest {
         // Given
         SignUpServiceRequest serviceRequest = UserTestData.createSignUpServiceRequest();
 
-        User user = User.builder()
-                .nickname("nickname")
-                .build();
-
         given(userRepository.findByNickname(serviceRequest.getNickname())).willReturn(
-                Optional.of(user));
+                Optional.of(UserFixture.COMMON_USER.getUser()));
 
         // When
         assertThatThrownBy(() -> userService.signUp(serviceRequest))
@@ -122,12 +117,8 @@ class UserServiceImplTest {
         // Given
         SignUpServiceRequest serviceRequest = UserTestData.createSignUpServiceRequest();
 
-        User user = User.builder()
-                .email("email@mail.com")
-                .build();
-
         given(userRepository.findByEmail(serviceRequest.getEmail())).willReturn(
-                Optional.of(user));
+                Optional.of(UserFixture.COMMON_USER.getUser()));
 
         // When
         assertThatThrownBy(() -> userService.signUp(serviceRequest))
@@ -144,17 +135,21 @@ class UserServiceImplTest {
     void getUserProfile() {
         // Given
         given(userRepository.findByLoginId(LOGIN_ID)).willReturn(
-                Optional.of(UserTestData.createUser()));
+                Optional.of(UserFixture.COMMON_USER.getUser()));
 
         // When
         ProfileServiceResponse userProfile = userService.getProfile(LOGIN_ID);
 
         // Then
         Assertions.assertAll(
-                () -> assertThat(userProfile.getNickname()).isEqualTo("nickname"),
-                () -> assertThat(userProfile.getEmail()).isEqualTo("email@mail.com"),
-                () -> assertThat(userProfile.getIntroduction()).isEqualTo("introduction"),
-                () -> assertThat(userProfile.getProfileImageUrl()).isEqualTo("profileImageUrl")
+                () -> assertThat(userProfile.getNickname()).isEqualTo(
+                        UserFixture.COMMON_USER.getUser().getNickname()),
+                () -> assertThat(userProfile.getEmail()).isEqualTo(
+                        UserFixture.COMMON_USER.getUser().getEmail()),
+                () -> assertThat(userProfile.getIntroduction()).isEqualTo(
+                        UserFixture.COMMON_USER.getUser().getIntroduction()),
+                () -> assertThat(userProfile.getProfileImageUrl()).isEqualTo(
+                        UserFixture.COMMON_USER.getUser().getProfileImageUrl())
         );
 
         verify(userRepository).findByLoginId(LOGIN_ID);
@@ -181,13 +176,14 @@ class UserServiceImplTest {
     void getProfileImageUrl() {
         // Given
         given(userRepository.findByLoginId(LOGIN_ID)).willReturn(
-                Optional.of(UserTestData.createUser()));
+                Optional.of(UserFixture.COMMON_USER.getUser()));
 
         // When
         ProfileImageUrlServiceResponse profileImage = userService.getProfileImageUrl(LOGIN_ID);
 
         // Then
-        assertThat(profileImage.getProfileImageUrl()).isEqualTo("profileImageUrl");
+        assertThat(profileImage.getProfileImageUrl()).isEqualTo(
+                UserFixture.COMMON_USER.getUser().getProfileImageUrl());
 
         verify(userRepository).findByLoginId(LOGIN_ID);
     }
@@ -213,7 +209,7 @@ class UserServiceImplTest {
     void getProfileImageUrlWithNoProfileImageUrl() {
         // Given
         given(userRepository.findByLoginId(LOGIN_ID)).willReturn(
-                Optional.of(UserTestData.createUserWithOutProfileImageUrl()));
+                Optional.of(UserFixture.USER_WITHOUT_PROFILE_IMAGE_URL.getUser()));
 
         // When
         assertThatThrownBy(() -> userService.getProfileImageUrl(LOGIN_ID))

--- a/user-service/src/test/java/kr/mybrary/userservice/user/domain/UserServiceImplTest.java
+++ b/user-service/src/test/java/kr/mybrary/userservice/user/domain/UserServiceImplTest.java
@@ -45,26 +45,13 @@ class UserServiceImplTest {
     @DisplayName("회원가입 요청이 들어오면 암호화된 비밀번호와 함께 회원 권한으로 사용자 정보를 저장한다")
     void signUp() {
         // Given
-        SignUpServiceRequest serviceRequest = SignUpServiceRequest.builder()
-                .loginId("loginId")
-                .password("password123!")
-                .nickname("nickname")
-                .email("email@mail.com")
-                .build();
+        SignUpServiceRequest serviceRequest = UserTestData.createSignUpServiceRequest();
 
         given(userRepository.findByLoginId(serviceRequest.getLoginId())).willReturn(Optional.empty());
         given(userRepository.findByNickname(serviceRequest.getNickname())).willReturn(Optional.empty());
         given(userRepository.findByEmail(serviceRequest.getEmail())).willReturn(Optional.empty());
         given(passwordEncoder.encode(serviceRequest.getPassword())).willReturn("encodedPassword");
-        given(userRepository.save(any(User.class))).willReturn(
-                User.builder()
-                        .loginId(serviceRequest.getLoginId())
-                        .password("encodedPassword")
-                        .nickname(serviceRequest.getNickname())
-                        .email(serviceRequest.getEmail())
-                        .role(Role.USER)
-                        .build()
-        );
+        given(userRepository.save(any(User.class))).willReturn(UserTestData.createUser());
 
         // When
         SignUpServiceResponse savedUser = userService.signUp(serviceRequest);
@@ -87,12 +74,7 @@ class UserServiceImplTest {
     @DisplayName("아이디가 중복되면 예외를 던진다")
     void signUpWithDuplicateLoginId() {
         // Given
-        SignUpServiceRequest serviceRequest = SignUpServiceRequest.builder()
-                .loginId("loginId")
-                .password("password123!")
-                .nickname("nickname")
-                .email("email@mail.com")
-                .build();
+        SignUpServiceRequest serviceRequest = UserTestData.createSignUpServiceRequest();
 
         User user = User.builder()
                 .loginId("loginId")
@@ -115,12 +97,7 @@ class UserServiceImplTest {
     @DisplayName("닉네임이 중복되면 예외를 던진다")
     void signUpWithDuplicateNickname() {
         // Given
-        SignUpServiceRequest serviceRequest = SignUpServiceRequest.builder()
-                .loginId("loginId")
-                .password("password123!")
-                .nickname("nickname")
-                .email("email@mail.com")
-                .build();
+        SignUpServiceRequest serviceRequest = UserTestData.createSignUpServiceRequest();
 
         User user = User.builder()
                 .nickname("nickname")
@@ -143,12 +120,7 @@ class UserServiceImplTest {
     @DisplayName("이메일이 중복되면 예외를 던진다")
     void signUpWithDuplicateEmail() {
         // Given
-        SignUpServiceRequest serviceRequest = SignUpServiceRequest.builder()
-                .loginId("loginId")
-                .password("password123!")
-                .nickname("nickname")
-                .email("email@mail.com")
-                .build();
+        SignUpServiceRequest serviceRequest = UserTestData.createSignUpServiceRequest();
 
         User user = User.builder()
                 .email("email@mail.com")
@@ -172,7 +144,7 @@ class UserServiceImplTest {
     void getUserProfile() {
         // Given
         given(userRepository.findByLoginId(LOGIN_ID)).willReturn(
-                Optional.of(UserTestData.createUserWithProfile()));
+                Optional.of(UserTestData.createUser()));
 
         // When
         ProfileServiceResponse userProfile = userService.getProfile(LOGIN_ID);
@@ -209,7 +181,7 @@ class UserServiceImplTest {
     void getProfileImageUrl() {
         // Given
         given(userRepository.findByLoginId(LOGIN_ID)).willReturn(
-                Optional.of(UserTestData.createUserWithProfile()));
+                Optional.of(UserTestData.createUser()));
 
         // When
         ProfileImageUrlServiceResponse profileImage = userService.getProfileImageUrl(LOGIN_ID);

--- a/user-service/src/test/java/kr/mybrary/userservice/user/domain/dto/UserMapperTest.java
+++ b/user-service/src/test/java/kr/mybrary/userservice/user/domain/dto/UserMapperTest.java
@@ -1,0 +1,73 @@
+package kr.mybrary.userservice.user.domain.dto;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import kr.mybrary.userservice.user.UserTestData;
+import kr.mybrary.userservice.user.domain.dto.request.SignUpServiceRequest;
+import kr.mybrary.userservice.user.domain.dto.response.ProfileServiceResponse;
+import kr.mybrary.userservice.user.domain.dto.response.SignUpServiceResponse;
+import kr.mybrary.userservice.user.persistence.User;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class UserMapperTest {
+
+    @Test
+    @DisplayName("회원가입 요청 DTO를 User 엔티티로 변환한다.")
+    void signUpServiceRequestToEntity() {
+        // given
+        SignUpServiceRequest serviceRequest = SignUpServiceRequest.builder()
+            .loginId("test")
+            .password("test")
+            .email("eamil@mail.com")
+            .nickname("nickname")
+            .build();
+
+        // when
+        User user = UserMapper.INSTANCE.toEntity(serviceRequest);
+
+        // then
+        assertAll(
+            () -> assertEquals(serviceRequest.getLoginId(), user.getLoginId()),
+            () -> assertEquals(serviceRequest.getPassword(), user.getPassword()),
+            () -> assertEquals(serviceRequest.getEmail(), user.getEmail()),
+            () -> assertEquals(serviceRequest.getNickname(), user.getNickname())
+        );
+    }
+
+    @Test
+    @DisplayName("User 엔티티를 회원가입 응답 DTO로 변환한다.")
+    void toSignUpServiceResponse() {
+        // given
+        User user = UserTestData.createUser();
+
+        // when
+        SignUpServiceResponse serviceResponse = UserMapper.INSTANCE.toSignUpServiceResponse(user);
+
+        // then
+        assertAll(
+            () -> assertEquals(user.getLoginId(), serviceResponse.getLoginId()),
+            () -> assertEquals(user.getEmail(), serviceResponse.getEmail()),
+            () -> assertEquals(user.getNickname(), serviceResponse.getNickname()),
+            () -> assertEquals(user.getRole(), serviceResponse.getRole())
+        );
+    }
+
+    @Test
+    @DisplayName("User 엔티티를 프로필 응답 DTO로 변환한다.")
+    void toProfileServiceResponse() {
+        // given
+        User user = UserTestData.createUser();
+
+        // when
+        ProfileServiceResponse serviceResponse = UserMapper.INSTANCE.toProfileServiceResponse(user);
+
+        // then
+        assertAll(
+            () -> assertEquals(user.getNickname(), serviceResponse.getNickname()),
+            () -> assertEquals(user.getProfileImageUrl(), serviceResponse.getProfileImageUrl()),
+            () -> assertEquals(user.getEmail(), serviceResponse.getEmail()),
+            () -> assertEquals(user.getIntroduction(), serviceResponse.getIntroduction())
+        );
+    }
+}

--- a/user-service/src/test/java/kr/mybrary/userservice/user/domain/dto/UserMapperTest.java
+++ b/user-service/src/test/java/kr/mybrary/userservice/user/domain/dto/UserMapperTest.java
@@ -2,7 +2,7 @@ package kr.mybrary.userservice.user.domain.dto;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-import kr.mybrary.userservice.user.UserTestData;
+import kr.mybrary.userservice.user.UserFixture;
 import kr.mybrary.userservice.user.domain.dto.request.SignUpServiceRequest;
 import kr.mybrary.userservice.user.domain.dto.response.ProfileServiceResponse;
 import kr.mybrary.userservice.user.domain.dto.response.SignUpServiceResponse;
@@ -39,7 +39,7 @@ class UserMapperTest {
     @DisplayName("User 엔티티를 회원가입 응답 DTO로 변환한다.")
     void toSignUpServiceResponse() {
         // given
-        User user = UserTestData.createUser();
+        User user = UserFixture.COMMON_USER.getUser();
 
         // when
         SignUpServiceResponse serviceResponse = UserMapper.INSTANCE.toSignUpServiceResponse(user);
@@ -57,7 +57,7 @@ class UserMapperTest {
     @DisplayName("User 엔티티를 프로필 응답 DTO로 변환한다.")
     void toProfileServiceResponse() {
         // given
-        User user = UserTestData.createUser();
+        User user = UserFixture.COMMON_USER.getUser();
 
         // when
         ProfileServiceResponse serviceResponse = UserMapper.INSTANCE.toProfileServiceResponse(user);

--- a/user-service/src/test/java/kr/mybrary/userservice/user/persistence/repository/UserRepositoryTest.java
+++ b/user-service/src/test/java/kr/mybrary/userservice/user/persistence/repository/UserRepositoryTest.java
@@ -1,0 +1,110 @@
+package kr.mybrary.userservice.user.persistence.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.Optional;
+import kr.mybrary.userservice.user.UserTestData;
+import kr.mybrary.userservice.user.persistence.User;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.ActiveProfiles;
+
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@ActiveProfiles("test")
+@DataJpaTest
+class UserRepositoryTest {
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Test
+    @DisplayName("로그인 아이디로 사용자를 가져온다.")
+    void findByLoginId() {
+        // given
+        User savedUser = userRepository.save(UserTestData.createUser());
+
+        // when
+        Optional<User> foundUser = userRepository.findByLoginId(savedUser.getLoginId());
+
+        // then
+        assertAll(
+            () -> assertThat(foundUser).isPresent(),
+            () -> assertThat(foundUser.get().getId()).isEqualTo(savedUser.getId()),
+            () -> assertThat(foundUser.get().getLoginId()).isEqualTo(savedUser.getLoginId())
+        );
+
+    }
+
+    @Test
+    @DisplayName("이메일로 사용자를 가져온다.")
+    void findByEmail() {
+        // given
+        User savedUser = userRepository.save(UserTestData.createUser());
+
+        // when
+        Optional<User> foundUser = userRepository.findByEmail(savedUser.getEmail());
+
+        // then
+        assertAll(
+            () -> assertThat(foundUser).isPresent(),
+            () -> assertThat(foundUser.get().getId()).isEqualTo(savedUser.getId()),
+            () -> assertThat(foundUser.get().getEmail()).isEqualTo(savedUser.getEmail())
+        );
+    }
+
+    @Test
+    @DisplayName("닉네임으로 사용자를 가져온다.")
+    void findByNickname() {
+        // given
+        User savedUser = userRepository.save(UserTestData.createUser());
+
+        // when
+        Optional<User> foundUser = userRepository.findByNickname(savedUser.getNickname());
+
+        // then
+        assertAll(
+            () -> assertThat(foundUser).isPresent(),
+            () -> assertThat(foundUser.get().getId()).isEqualTo(savedUser.getId()),
+            () -> assertThat(foundUser.get().getNickname()).isEqualTo(savedUser.getNickname())
+        );
+    }
+
+    @Test
+    @DisplayName("리프레쉬 토큰으로 사용자를 가져온다.")
+    void findByRefreshToken() {
+        // given
+        User savedUser = userRepository.save(UserTestData.createUser());
+
+        // when
+        Optional<User> foundUser = userRepository.findByRefreshToken(savedUser.getRefreshToken());
+
+        // then
+        assertAll(
+            () -> assertThat(foundUser).isPresent(),
+            () -> assertThat(foundUser.get().getId()).isEqualTo(savedUser.getId()),
+            () -> assertThat(foundUser.get().getRefreshToken()).isEqualTo(savedUser.getRefreshToken())
+        );
+    }
+
+    @Test
+    @DisplayName("소셜 타입과 소셜 식별자로 사용자를 가져온다.")
+    void findBySocialTypeAndSocialId() {
+        // given
+        User savedUser = userRepository.save(UserTestData.createUser());
+
+        // when
+        Optional<User> foundUser = userRepository.findBySocialTypeAndSocialId(savedUser.getSocialType(), savedUser.getSocialId());
+
+        // then
+        assertAll(
+            () -> assertThat(foundUser).isPresent(),
+            () -> assertThat(foundUser.get().getId()).isEqualTo(savedUser.getId()),
+            () -> assertThat(foundUser.get().getSocialType()).isEqualTo(savedUser.getSocialType()),
+            () -> assertThat(foundUser.get().getSocialId()).isEqualTo(savedUser.getSocialId())
+        );
+    }
+}

--- a/user-service/src/test/java/kr/mybrary/userservice/user/persistence/repository/UserRepositoryTest.java
+++ b/user-service/src/test/java/kr/mybrary/userservice/user/persistence/repository/UserRepositoryTest.java
@@ -4,7 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.Optional;
-import kr.mybrary.userservice.user.UserTestData;
+import kr.mybrary.userservice.user.UserFixture;
 import kr.mybrary.userservice.user.persistence.User;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -25,7 +25,7 @@ class UserRepositoryTest {
     @DisplayName("로그인 아이디로 사용자를 가져온다.")
     void findByLoginId() {
         // given
-        User savedUser = userRepository.save(UserTestData.createUser());
+        User savedUser = userRepository.save(UserFixture.COMMON_USER.getUser());
 
         // when
         Optional<User> foundUser = userRepository.findByLoginId(savedUser.getLoginId());
@@ -43,7 +43,7 @@ class UserRepositoryTest {
     @DisplayName("이메일로 사용자를 가져온다.")
     void findByEmail() {
         // given
-        User savedUser = userRepository.save(UserTestData.createUser());
+        User savedUser = userRepository.save(UserFixture.COMMON_USER.getUser());
 
         // when
         Optional<User> foundUser = userRepository.findByEmail(savedUser.getEmail());
@@ -60,7 +60,7 @@ class UserRepositoryTest {
     @DisplayName("닉네임으로 사용자를 가져온다.")
     void findByNickname() {
         // given
-        User savedUser = userRepository.save(UserTestData.createUser());
+        User savedUser = userRepository.save(UserFixture.COMMON_USER.getUser());
 
         // when
         Optional<User> foundUser = userRepository.findByNickname(savedUser.getNickname());
@@ -77,7 +77,7 @@ class UserRepositoryTest {
     @DisplayName("리프레쉬 토큰으로 사용자를 가져온다.")
     void findByRefreshToken() {
         // given
-        User savedUser = userRepository.save(UserTestData.createUser());
+        User savedUser = userRepository.save(UserFixture.COMMON_USER.getUser());
 
         // when
         Optional<User> foundUser = userRepository.findByRefreshToken(savedUser.getRefreshToken());
@@ -94,7 +94,7 @@ class UserRepositoryTest {
     @DisplayName("소셜 타입과 소셜 식별자로 사용자를 가져온다.")
     void findBySocialTypeAndSocialId() {
         // given
-        User savedUser = userRepository.save(UserTestData.createUser());
+        User savedUser = userRepository.save(UserFixture.COMMON_USER.getUser());
 
         // when
         Optional<User> foundUser = userRepository.findBySocialTypeAndSocialId(savedUser.getSocialType(), savedUser.getSocialId());

--- a/user-service/src/test/java/kr/mybrary/userservice/user/presentation/UserControllerTest.java
+++ b/user-service/src/test/java/kr/mybrary/userservice/user/presentation/UserControllerTest.java
@@ -19,7 +19,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.epages.restdocs.apispec.ResourceSnippetParameters;
 import com.epages.restdocs.apispec.Schema;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import java.io.FileInputStream;
 import java.util.ArrayList;
 import java.util.List;
 import kr.mybrary.userservice.user.domain.UserService;
@@ -31,7 +30,7 @@ import kr.mybrary.userservice.user.domain.dto.request.SignUpServiceRequest;
 import kr.mybrary.userservice.user.domain.dto.response.FollowResponse;
 import kr.mybrary.userservice.user.domain.dto.response.FollowerServiceResponse;
 import kr.mybrary.userservice.user.domain.dto.response.FollowingServiceResponse;
-import kr.mybrary.userservice.user.domain.dto.response.ProfileImageServiceResponse;
+import kr.mybrary.userservice.user.domain.dto.response.ProfileImageUrlServiceResponse;
 import kr.mybrary.userservice.user.domain.dto.response.ProfileServiceResponse;
 import kr.mybrary.userservice.user.domain.dto.response.SignUpServiceResponse;
 import kr.mybrary.userservice.user.persistence.Role;
@@ -310,11 +309,12 @@ class UserControllerTest {
     @Test
     void getProfileImageUrl() throws Exception {
         // given
-        ProfileImageServiceResponse profileImageServiceResponse = ProfileImageServiceResponse.builder()
+        ProfileImageUrlServiceResponse profileImageUrlServiceResponse = ProfileImageUrlServiceResponse.builder()
                 .profileImageUrl("profileImageUrl_1")
                 .build();
 
-        given(userService.getProfileImage(anyString())).willReturn(profileImageServiceResponse);
+        given(userService.getProfileImageUrl(anyString())).willReturn(
+                profileImageUrlServiceResponse);
 
         // when
         ResultActions actions = mockMvc.perform(
@@ -328,9 +328,9 @@ class UserControllerTest {
                 .andExpect(jsonPath("$.status").value(HttpStatus.OK.toString()))
                 .andExpect(jsonPath("$.message").value("로그인 된 사용자의 프로필 이미지 URL입니다."))
                 .andExpect(jsonPath("$.data.profileImageUrl").value(
-                        profileImageServiceResponse.getProfileImageUrl()));
+                        profileImageUrlServiceResponse.getProfileImageUrl()));
 
-        verify(userService).getProfileImage(anyString());
+        verify(userService).getProfileImageUrl(anyString());
 
         // docs
         actions.andDo(document("get-user-profile-image",
@@ -366,12 +366,12 @@ class UserControllerTest {
         MockMultipartFile profileImage = new MockMultipartFile("profileImage", "user1.png", "image/jpg",
                 "profileImage".getBytes());
 
-        ProfileImageServiceResponse profileImageServiceResponse = ProfileImageServiceResponse.builder()
+        ProfileImageUrlServiceResponse profileImageUrlServiceResponse = ProfileImageUrlServiceResponse.builder()
                 .profileImageUrl("profileImageUrl")
                 .build();
 
         given(userService.updateProfileImage(any(ProfileImageUpdateServiceRequest.class))).willReturn(
-                profileImageServiceResponse);
+                profileImageUrlServiceResponse);
 
         // when
         ResultActions actions = mockMvc.perform(
@@ -390,7 +390,7 @@ class UserControllerTest {
                 .andExpect(jsonPath("$.status").value(HttpStatus.OK.toString()))
                 .andExpect(jsonPath("$.message").value("로그인 된 사용자의 프로필 이미지를 등록했습니다."))
                 .andExpect(jsonPath("$.data.profileImageUrl").value(
-                        profileImageServiceResponse.getProfileImageUrl()));
+                        profileImageUrlServiceResponse.getProfileImageUrl()));
 
         verify(userService).updateProfileImage(any(ProfileImageUpdateServiceRequest.class));
 
@@ -427,11 +427,12 @@ class UserControllerTest {
     @Test
     void deleteProfileImage() throws Exception {
         // given
-        ProfileImageServiceResponse profileImageServiceResponse = ProfileImageServiceResponse.builder()
+        ProfileImageUrlServiceResponse profileImageUrlServiceResponse = ProfileImageUrlServiceResponse.builder()
                 .profileImageUrl("profileImageUrl_1")
                 .build();
 
-        given(userService.deleteProfileImage(anyString())).willReturn(profileImageServiceResponse);
+        given(userService.deleteProfileImage(anyString())).willReturn(
+                profileImageUrlServiceResponse);
 
         // when
         ResultActions actions = mockMvc.perform(
@@ -445,7 +446,7 @@ class UserControllerTest {
                 .andExpect(jsonPath("$.status").value(HttpStatus.OK.toString()))
                 .andExpect(jsonPath("$.message").value("로그인 된 사용자의 프로필 이미지를 삭제했습니다."))
                 .andExpect(jsonPath("$.data.profileImageUrl").value(
-                        profileImageServiceResponse.getProfileImageUrl()));
+                        profileImageUrlServiceResponse.getProfileImageUrl()));
 
         verify(userService).deleteProfileImage(anyString());
 


### PR DESCRIPTION
## 🧑‍💻 작업 사항
### 사용자 프로필 조회 기능 구현
- 로그인 아이디를 통해 프로필/ 프로필 사진 조회 가능
- 로그인 아이디로 사용자를 찾을 수 없다면 UserNotFoundException 반환
- 사용자에게 프로필 이미지 URL이 없다면 ProfileImageUrlNotFoundException 반환
  - 기본 이미지 URL조차 없는 경우 문제가 있다고 판단하여, 예외 처리되도록 구현했습니다

### 테스트 데이터 생성 로직 분리
- Enum을 통해 UserFixture 생성
- UserTestData 클래스에 테스트 데이터 생성 함수 추가

### 레포지토리, Mapper 테스트 코드 추가
- UserRepositoryTest
- UserMapperTest

<br><br>

## 🔗 링크


<br><br>

## 🐰 시급한 정도
🏃‍♂️ 보통 : 최대한 빠르게 리뷰 부탁드립니다.
(곧바로 프로필 수정/삭제 기능 개발하려구 합니다 ^-^,,)

<br><br>

## 📖 참고 사항
[Test Data 만들기 (Builder vs Object Mother)](https://velog.io/@gwichanlee/Test-Data-%EB%A7%8C%EB%93%A4%EA%B8%B0-Builder-vs-Object-Mother)

