### PR TITLE
[IDLE-113] feat: 마이북 속성 설정  및 수정 API 개발

### DIFF
--- a/backend/book-service/src/main/java/kr/mybrary/bookservice/mybook/domain/MyBookService.java
+++ b/backend/book-service/src/main/java/kr/mybrary/bookservice/mybook/domain/MyBookService.java
@@ -8,6 +8,7 @@ import kr.mybrary.bookservice.mybook.domain.dto.request.MyBookCreateServiceReque
 import kr.mybrary.bookservice.mybook.domain.dto.request.MyBookDeleteServiceRequest;
 import kr.mybrary.bookservice.mybook.domain.dto.request.MyBookDetailServiceRequest;
 import kr.mybrary.bookservice.mybook.domain.dto.request.MyBookFindAllServiceRequest;
+import kr.mybrary.bookservice.mybook.domain.dto.request.MybookUpdateServiceRequest;
 import kr.mybrary.bookservice.mybook.domain.exception.MyBookAccessDeniedException;
 import kr.mybrary.bookservice.mybook.domain.exception.MyBookAlreadyExistsException;
 import kr.mybrary.bookservice.mybook.domain.exception.MyBookNotFoundException;
@@ -15,6 +16,7 @@ import kr.mybrary.bookservice.mybook.persistence.MyBook;
 import kr.mybrary.bookservice.mybook.persistence.repository.MyBookRepository;
 import kr.mybrary.bookservice.mybook.presentation.dto.response.MyBookDetailResponse;
 import kr.mybrary.bookservice.mybook.presentation.dto.response.MyBookElementResponse;
+import kr.mybrary.bookservice.mybook.presentation.dto.response.MyBookUpdateResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -77,5 +79,20 @@ public class MyBookService {
         }
 
         myBook.deleteMyBook();
+    }
+
+    public MyBookUpdateResponse updateMyBookProperties(MybookUpdateServiceRequest request) {
+
+        MyBook myBook = myBookRepository.findByIdAndDeletedIsFalse(request.getMyBookId())
+                .orElseThrow(MyBookNotFoundException::new);
+
+        if (!myBook.getUserId().equals(request.getUserId())) {
+            throw new MyBookAccessDeniedException();
+        }
+
+        myBook.updateProperties(request.getReadStatus(), request.getStartDateOfPossession(),
+                request.isShowable(), request.isExchangeable(), request.isShareable());
+
+        return MyBookDtoMapper.INSTANCE.entityToMyBookUpdateResponse(myBook);
     }
 }

--- a/backend/book-service/src/main/java/kr/mybrary/bookservice/mybook/domain/dto/MyBookDtoMapper.java
+++ b/backend/book-service/src/main/java/kr/mybrary/bookservice/mybook/domain/dto/MyBookDtoMapper.java
@@ -6,6 +6,7 @@ import kr.mybrary.bookservice.book.persistence.translator.BookTranslator;
 import kr.mybrary.bookservice.mybook.persistence.MyBook;
 import kr.mybrary.bookservice.mybook.presentation.dto.response.MyBookDetailResponse;
 import kr.mybrary.bookservice.mybook.presentation.dto.response.MyBookElementResponse;
+import kr.mybrary.bookservice.mybook.presentation.dto.response.MyBookUpdateResponse;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.Named;
@@ -24,6 +25,8 @@ public interface MyBookDtoMapper {
     @Mapping(target = "book.authors", source = "book.bookAuthors", qualifiedByName = "getAuthors")
     @Mapping(target = "book.translators", source = "book.bookTranslators", qualifiedByName = "getTranslators")
     MyBookDetailResponse entityToMyBookDetailResponse(MyBook myBook);
+
+    MyBookUpdateResponse entityToMyBookUpdateResponse(MyBook myBook);
 
     @Named("getAuthors")
     static List<String> getAuthors(List<BookAuthor> bookAuthors) {

--- a/backend/book-service/src/main/java/kr/mybrary/bookservice/mybook/domain/dto/request/MybookUpdateServiceRequest.java
+++ b/backend/book-service/src/main/java/kr/mybrary/bookservice/mybook/domain/dto/request/MybookUpdateServiceRequest.java
@@ -1,0 +1,20 @@
+package kr.mybrary.bookservice.mybook.domain.dto.request;
+
+import java.time.LocalDateTime;
+import kr.mybrary.bookservice.mybook.persistence.ReadStatus;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class MybookUpdateServiceRequest {
+
+    private String userId;
+    private Long myBookId;
+
+    private boolean showable;
+    private boolean exchangeable;
+    private boolean shareable;
+    private ReadStatus readStatus;
+    private LocalDateTime startDateOfPossession;
+}

--- a/backend/book-service/src/main/java/kr/mybrary/bookservice/mybook/persistence/MyBook.java
+++ b/backend/book-service/src/main/java/kr/mybrary/bookservice/mybook/persistence/MyBook.java
@@ -63,4 +63,13 @@ public class MyBook extends BaseEntity {
     public void deleteMyBook() {
         this.deleted = true;
     }
+
+    public void updateProperties(ReadStatus readStatus, LocalDateTime startDateOfPossession,
+            boolean showable, boolean exchangeable, boolean shareable) {
+        this.readStatus = readStatus;
+        this.startDateOfPossession = startDateOfPossession;
+        this.showable = showable;
+        this.exchangeable = exchangeable;
+        this.shareable = shareable;
+    }
 }

--- a/backend/book-service/src/main/java/kr/mybrary/bookservice/mybook/presentation/MyBookController.java
+++ b/backend/book-service/src/main/java/kr/mybrary/bookservice/mybook/presentation/MyBookController.java
@@ -6,7 +6,9 @@ import kr.mybrary.bookservice.mybook.domain.MyBookService;
 import kr.mybrary.bookservice.mybook.domain.dto.request.MyBookDeleteServiceRequest;
 import kr.mybrary.bookservice.mybook.domain.dto.request.MyBookDetailServiceRequest;
 import kr.mybrary.bookservice.mybook.domain.dto.request.MyBookFindAllServiceRequest;
+import kr.mybrary.bookservice.mybook.domain.dto.request.MybookUpdateServiceRequest;
 import kr.mybrary.bookservice.mybook.presentation.dto.request.MyBookCreateRequest;
+import kr.mybrary.bookservice.mybook.presentation.dto.request.MyBookUpdateRequest;
 import kr.mybrary.bookservice.mybook.presentation.dto.response.MyBookElementResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -15,6 +17,7 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -28,7 +31,8 @@ public class MyBookController {
     private final MyBookService myBookService;
 
     @PostMapping("/mybooks")
-    public ResponseEntity createMyBook(@RequestHeader("USER-ID") String loginId, @RequestBody MyBookCreateRequest request) {
+    public ResponseEntity createMyBook(@RequestHeader("USER-ID") String loginId,
+            @RequestBody MyBookCreateRequest request) {
 
         myBookService.create(request.toServiceRequest(loginId));
 
@@ -37,12 +41,14 @@ public class MyBookController {
     }
 
     @GetMapping("/users/{userId}/mybooks")
-    public ResponseEntity findAllMyBooks(@RequestHeader("USER-ID") String loginId, @PathVariable("userId") String userId) {
+    public ResponseEntity findAllMyBooks(@RequestHeader("USER-ID") String loginId,
+            @PathVariable("userId") String userId) {
 
         List<MyBookElementResponse> myBooks = myBookService.findAllMyBooks(
                 MyBookFindAllServiceRequest.of(userId, loginId));
 
-        return ResponseEntity.ok(SuccessResponse.of(HttpStatus.OK.toString(), "서재의 도서 목록입니다.", myBooks));
+        return ResponseEntity.ok(
+                SuccessResponse.of(HttpStatus.OK.toString(), "서재의 도서 목록입니다.", myBooks));
     }
 
     @GetMapping("/mybooks/{mybookId}")
@@ -52,7 +58,8 @@ public class MyBookController {
         MyBookDetailServiceRequest request = MyBookDetailServiceRequest.of(loginId, mybookId);
 
         return ResponseEntity.ok(
-                SuccessResponse.of(HttpStatus.OK.toString(), "마이북 상세보기입니다.", myBookService.findMyBookDetail(request)));
+                SuccessResponse.of(HttpStatus.OK.toString(), "마이북 상세보기입니다.",
+                        myBookService.findMyBookDetail(request)));
     }
 
     @DeleteMapping("/mybooks/{mybookId}")
@@ -65,5 +72,16 @@ public class MyBookController {
 
         return ResponseEntity.ok(
                 SuccessResponse.of(HttpStatus.OK.toString(), "내 서재의 도서를 삭제했습니다.", null));
+    }
+
+    @PutMapping("/mybooks/{mybookId}")
+    public ResponseEntity updateMyBookProperties(@RequestHeader("USER-ID") String loginId,
+            @PathVariable Long mybookId, @RequestBody MyBookUpdateRequest request) {
+
+        MybookUpdateServiceRequest serviceRequest = request.toServiceRequest(loginId, mybookId);
+
+        return ResponseEntity.ok(
+                SuccessResponse.of(HttpStatus.OK.toString(), "내 서재의 마이북 속성을 수정했습니다.",
+                        myBookService.updateMyBookProperties(serviceRequest)));
     }
 }

--- a/backend/book-service/src/main/java/kr/mybrary/bookservice/mybook/presentation/dto/request/MyBookUpdateRequest.java
+++ b/backend/book-service/src/main/java/kr/mybrary/bookservice/mybook/presentation/dto/request/MyBookUpdateRequest.java
@@ -1,0 +1,30 @@
+package kr.mybrary.bookservice.mybook.presentation.dto.request;
+
+import java.time.LocalDateTime;
+import kr.mybrary.bookservice.mybook.domain.dto.request.MybookUpdateServiceRequest;
+import kr.mybrary.bookservice.mybook.persistence.ReadStatus;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class MyBookUpdateRequest {
+
+    private boolean showable;
+    private boolean exchangeable;
+    private boolean shareable;
+    private ReadStatus readStatus;
+    private LocalDateTime startDateOfPossession;
+
+    public MybookUpdateServiceRequest toServiceRequest(String userId, Long myBookId) {
+        return MybookUpdateServiceRequest.builder()
+                .userId(userId)
+                .myBookId(myBookId)
+                .showable(showable)
+                .exchangeable(exchangeable)
+                .shareable(shareable)
+                .readStatus(readStatus)
+                .startDateOfPossession(startDateOfPossession)
+                .build();
+    }
+}

--- a/backend/book-service/src/main/java/kr/mybrary/bookservice/mybook/presentation/dto/response/MyBookUpdateResponse.java
+++ b/backend/book-service/src/main/java/kr/mybrary/bookservice/mybook/presentation/dto/response/MyBookUpdateResponse.java
@@ -1,0 +1,19 @@
+package kr.mybrary.bookservice.mybook.presentation.dto.response;
+
+import java.time.LocalDateTime;
+import kr.mybrary.bookservice.mybook.persistence.ReadStatus;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class MyBookUpdateResponse {
+
+    private ReadStatus readStatus;
+
+    private LocalDateTime startDateOfPossession;
+
+    private boolean showable;
+    private boolean exchangeable;
+    private boolean shareable;
+}

--- a/backend/book-service/src/test/java/kr/mybrary/bookservice/book/presentation/BookControllerTest.java
+++ b/backend/book-service/src/test/java/kr/mybrary/bookservice/book/presentation/BookControllerTest.java
@@ -81,7 +81,7 @@ class BookControllerTest {
                         ResourceSnippetParameters.builder()
                                 .tag("book")
                                 .summary("도서를 등록한다.")
-                                .requestSchema(Schema.schema("book-create request body"))
+                                .requestSchema(Schema.schema("book_create_request_body"))
                                 .requestFields(
                                         fieldWithPath("title").type(STRING).description("도서 제목"),
                                         fieldWithPath("description").type(STRING).description("도서 설명"),
@@ -95,7 +95,7 @@ class BookControllerTest {
                                         fieldWithPath("publicationDate").type(STRING).description("출판일"),
                                         fieldWithPath("thumbnailUrl").type(STRING).description("도서 썸네일 URL")
                                 )
-                                .responseSchema(Schema.schema("book-create response body"))
+                                .responseSchema(Schema.schema("book_create_response_body"))
                                 .responseFields(
                                         fieldWithPath("status").type(STRING).description("응답 상태"),
                                         fieldWithPath("message").type(STRING).description("응답 메시지"),

--- a/backend/book-service/src/test/java/kr/mybrary/bookservice/booksearch/presentation/BookSearchControllerTest.java
+++ b/backend/book-service/src/test/java/kr/mybrary/bookservice/booksearch/presentation/BookSearchControllerTest.java
@@ -85,7 +85,7 @@ class BookSearchControllerTest {
                                         .queryParameters(
                                                 parameterWithName("isbn").type(SimpleType.STRING).description("ISBN")
                                         )
-                                        .responseSchema(Schema.schema("book-search-with-isbn response body"))
+                                        .responseSchema(Schema.schema("book_search_with_isbn_response_body"))
                                         .responseFields(
                                                 fieldWithPath("status").type(STRING).description("응답 상태"),
                                                 fieldWithPath("message").type(STRING).description("응답 메시지"),
@@ -156,7 +156,7 @@ class BookSearchControllerTest {
                                                 parameterWithName("sort").type(SimpleType.STRING).optional().defaultValue("accuracy").description("정렬 방식"),
                                                 parameterWithName("page").type(SimpleType.NUMBER).optional().defaultValue(1).description("페이지 번호")
                                         )
-                                        .responseSchema(Schema.schema("book-search-with-keyword response body"))
+                                        .responseSchema(Schema.schema("book_search_with_keyword_response_body"))
                                         .responseFields(
                                                 fieldWithPath("status").type(STRING).description("응답 상태"),
                                                 fieldWithPath("message").type(STRING).description("응답 메시지"),

--- a/backend/book-service/src/test/java/kr/mybrary/bookservice/mybook/MybookDtoTestData.java
+++ b/backend/book-service/src/test/java/kr/mybrary/bookservice/mybook/MybookDtoTestData.java
@@ -4,12 +4,15 @@ import java.time.LocalDateTime;
 import java.util.List;
 import kr.mybrary.bookservice.mybook.domain.dto.request.MyBookCreateServiceRequest;
 import kr.mybrary.bookservice.mybook.domain.dto.request.MyBookFindAllServiceRequest;
+import kr.mybrary.bookservice.mybook.domain.dto.request.MybookUpdateServiceRequest;
 import kr.mybrary.bookservice.mybook.persistence.ReadStatus;
 import kr.mybrary.bookservice.mybook.presentation.dto.request.MyBookCreateRequest;
+import kr.mybrary.bookservice.mybook.presentation.dto.request.MyBookUpdateRequest;
 import kr.mybrary.bookservice.mybook.presentation.dto.response.MyBookDetailResponse;
 import kr.mybrary.bookservice.mybook.presentation.dto.response.MyBookDetailResponse.BookDetailResponse;
 import kr.mybrary.bookservice.mybook.presentation.dto.response.MyBookElementResponse;
 import kr.mybrary.bookservice.mybook.presentation.dto.response.MyBookElementResponse.BookElementResponse;
+import kr.mybrary.bookservice.mybook.presentation.dto.response.MyBookUpdateResponse;
 
 public class MybookDtoTestData {
 
@@ -88,6 +91,38 @@ public class MybookDtoTestData {
         return MyBookFindAllServiceRequest.builder()
                 .userId(userId)
                 .loginId(loginId)
+                .build();
+    }
+
+    public static MyBookUpdateRequest createMyBookUpdateRequest() {
+        return MyBookUpdateRequest.builder()
+                .showable(true)
+                .exchangeable(false)
+                .shareable(true)
+                .readStatus(ReadStatus.READING)
+                .startDateOfPossession(LocalDateTime.now())
+                .build();
+    }
+
+    public static MyBookUpdateResponse createMyBookUpdateResponse() {
+        return MyBookUpdateResponse.builder()
+                .showable(true)
+                .exchangeable(false)
+                .shareable(true)
+                .readStatus(ReadStatus.READING)
+                .startDateOfPossession(LocalDateTime.now())
+                .build();
+    }
+
+    public static MybookUpdateServiceRequest createMyBookUpdateServiceRequest(String loginId, Long myBookId) {
+        return MybookUpdateServiceRequest.builder()
+                .userId(loginId)
+                .myBookId(myBookId)
+                .showable(true)
+                .exchangeable(false)
+                .shareable(true)
+                .readStatus(ReadStatus.READING)
+                .startDateOfPossession(LocalDateTime.now())
                 .build();
     }
 }

--- a/backend/book-service/src/test/java/kr/mybrary/bookservice/mybook/domain/dto/MyBookDtoMapperTest.java
+++ b/backend/book-service/src/test/java/kr/mybrary/bookservice/mybook/domain/dto/MyBookDtoMapperTest.java
@@ -7,6 +7,7 @@ import kr.mybrary.bookservice.mybook.MyBookFixture;
 import kr.mybrary.bookservice.mybook.persistence.MyBook;
 import kr.mybrary.bookservice.mybook.presentation.dto.response.MyBookDetailResponse;
 import kr.mybrary.bookservice.mybook.presentation.dto.response.MyBookElementResponse;
+import kr.mybrary.bookservice.mybook.presentation.dto.response.MyBookUpdateResponse;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -68,6 +69,26 @@ class MyBookDtoMapperTest {
                 () -> assertThat(myBookDetailResponse.getBook().getTranslators()).isEqualTo(myBook.getBook().getBookTranslators().stream()
                         .map(bookTranslator -> bookTranslator.getTranslator().getName())
                         .toList())
+        );
+    }
+
+    @DisplayName("MyBook 엔티티를 MyBookUpdateResponse로 매핑한다.")
+    @Test
+    void entityToMyBookUpdateResponse() {
+
+        // given
+        MyBook myBook = MyBookFixture.COMMON_LOGIN_USER_MYBOOK.getMyBook();
+
+        // when
+        MyBookUpdateResponse myBookUpdateResponse = MyBookDtoMapper.INSTANCE.entityToMyBookUpdateResponse(
+                myBook);
+
+        // then
+        assertAll(
+                () -> assertThat(myBookUpdateResponse.getReadStatus()).isEqualTo(myBook.getReadStatus()),
+                () -> assertThat(myBookUpdateResponse.isExchangeable()).isEqualTo(myBook.isExchangeable()),
+                () -> assertThat(myBookUpdateResponse.isShareable()).isEqualTo(myBook.isShareable()),
+                () -> assertThat(myBookUpdateResponse.isShowable()).isEqualTo(myBook.isShowable())
         );
     }
 }

--- a/backend/book-service/src/test/java/kr/mybrary/bookservice/mybook/presentation/MyBookControllerTest.java
+++ b/backend/book-service/src/test/java/kr/mybrary/bookservice/mybook/presentation/MyBookControllerTest.java
@@ -94,7 +94,7 @@ class MyBookControllerTest {
                                 ResourceSnippetParameters.builder()
                                         .tag("mybook")
                                         .summary("마이북으로 등록한다.")
-                                        .requestSchema(Schema.schema("create-mybook request body"))
+                                        .requestSchema(Schema.schema("create_mybook_request_body"))
                                         .requestHeaders(
                                                 headerWithName("USER-ID").description("사용자 ID")
                                         )
@@ -111,7 +111,7 @@ class MyBookControllerTest {
                                                 fieldWithPath("publicationDate").type(STRING).description("출판일"),
                                                 fieldWithPath("thumbnailUrl").type(STRING).description("썸네일 URL")
                                         )
-                                        .responseSchema(Schema.schema("create-mybook response body"))
+                                        .responseSchema(Schema.schema("create_mybook_response_body"))
                                         .responseFields(
                                                 fieldWithPath("status").type(STRING).description("응답 상태"),
                                                 fieldWithPath("message").type(STRING).description("응답 메시지"),
@@ -153,7 +153,7 @@ class MyBookControllerTest {
                                 .requestHeaders(
                                         headerWithName("USER-ID").description("사용자 ID")
                                 )
-                                .responseSchema(Schema.schema("find-all-mybooks response body"))
+                                .responseSchema(Schema.schema("find_all_mybooks_response_body"))
                                 .responseFields(
                                         fieldWithPath("status").type(STRING).description("응답 상태"),
                                         fieldWithPath("message").type(STRING).description("응답 메시지"),
@@ -207,7 +207,7 @@ class MyBookControllerTest {
                                         .pathParameters(
                                                 parameterWithName("mybookId").type(SimpleType.NUMBER).description("마이북 ID")
                                         )
-                                        .responseSchema(Schema.schema("find-mybook-detail response body"))
+                                        .responseSchema(Schema.schema("find_mybook_detail_response_body"))
                                         .responseFields(
                                                 fieldWithPath("status").type(STRING).description("응답 상태"),
                                                 fieldWithPath("message").type(STRING).description("응답 메시지"),
@@ -261,7 +261,7 @@ class MyBookControllerTest {
                                         .pathParameters(
                                                 parameterWithName("id").type(SimpleType.INTEGER).description("마이북 ID")
                                         )
-                                        .responseSchema(Schema.schema("delete-mybook response body"))
+                                        .responseSchema(Schema.schema("delete_mybook_response_body"))
                                         .responseFields(
                                                 fieldWithPath("status").type(STRING).description("응답 상태"),
                                                 fieldWithPath("message").type(STRING).description("응답 메시지"),
@@ -303,7 +303,7 @@ class MyBookControllerTest {
                                 ResourceSnippetParameters.builder()
                                         .tag("mybook")
                                         .summary("마이북 속성을 수정한다.")
-                                        .requestSchema(Schema.schema("update-mybook-properties request body"))
+                                        .requestSchema(Schema.schema("update_mybook_properties_request_body"))
                                         .requestHeaders(
                                                 headerWithName("USER-ID").description("사용자 ID")
                                         )
@@ -317,7 +317,7 @@ class MyBookControllerTest {
                                                 fieldWithPath("readStatus").type(STRING).description("독서 진행 상태"),
                                                 fieldWithPath("startDateOfPossession").type(STRING).description("보유 시작일")
                                         )
-                                        .responseSchema(Schema.schema("update-mybook-properties response body"))
+                                        .responseSchema(Schema.schema("update_mybook_properties_response_body"))
                                         .responseFields(
                                                 fieldWithPath("status").type(STRING).description("응답 상태"),
                                                 fieldWithPath("message").type(STRING).description("응답 메시지"),

--- a/backend/book-service/src/test/java/kr/mybrary/bookservice/mybook/presentation/MyBookControllerTest.java
+++ b/backend/book-service/src/test/java/kr/mybrary/bookservice/mybook/presentation/MyBookControllerTest.java
@@ -9,6 +9,7 @@ import static org.mockito.BDDMockito.given;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.put;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
@@ -29,8 +30,10 @@ import java.util.List;
 import kr.mybrary.bookservice.mybook.MybookDtoTestData;
 import kr.mybrary.bookservice.mybook.domain.MyBookService;
 import kr.mybrary.bookservice.mybook.presentation.dto.request.MyBookCreateRequest;
+import kr.mybrary.bookservice.mybook.presentation.dto.request.MyBookUpdateRequest;
 import kr.mybrary.bookservice.mybook.presentation.dto.response.MyBookDetailResponse;
 import kr.mybrary.bookservice.mybook.presentation.dto.response.MyBookElementResponse;
+import kr.mybrary.bookservice.mybook.presentation.dto.response.MyBookUpdateResponse;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -266,4 +269,63 @@ class MyBookControllerTest {
                                         ).build())));
     }
 
+    @DisplayName("내 서재의 마이북 속성을 수정한다.")
+    @Test
+    void updateMyBookProperties() throws Exception {
+
+        // given
+        MyBookUpdateRequest request = MybookDtoTestData.createMyBookUpdateRequest();
+        String requestJson = objectMapper.writeValueAsString(request);
+
+        MyBookUpdateResponse expectedResponse = MybookDtoTestData.createMyBookUpdateResponse();
+
+        given(myBookService.updateMyBookProperties(any())).willReturn(expectedResponse);
+
+        // when
+        ResultActions actions = mockMvc.perform(put("/api/v1/mybooks/{mybookId}", MYBOOK_ID)
+                .header("USER-ID", LOGIN_ID)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestJson));
+
+        // then
+        actions
+                .andExpect(status().is2xxSuccessful())
+                .andExpect(jsonPath("$.status").value("200 OK"))
+                .andExpect(jsonPath("$.message").value("내 서재의 마이북 속성을 수정했습니다."))
+                .andExpect(jsonPath("$.data").isNotEmpty());
+
+        // document
+        actions
+                .andDo(document("update-mybook-properties",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        resource(
+                                ResourceSnippetParameters.builder()
+                                        .tag("mybook")
+                                        .summary("마이북 속성을 수정한다.")
+                                        .requestSchema(Schema.schema("update-mybook-properties request body"))
+                                        .requestHeaders(
+                                                headerWithName("USER-ID").description("사용자 ID")
+                                        )
+                                        .pathParameters(
+                                                parameterWithName("mybookId").type(SimpleType.INTEGER).description("마이북 ID")
+                                        )
+                                        .requestFields(
+                                                fieldWithPath("showable").type(BOOLEAN).description("공개 여부"),
+                                                fieldWithPath("exchangeable").type(BOOLEAN).description("교환 여부"),
+                                                fieldWithPath("shareable").type(BOOLEAN).description("나눔 여부"),
+                                                fieldWithPath("readStatus").type(STRING).description("독서 진행 상태"),
+                                                fieldWithPath("startDateOfPossession").type(STRING).description("보유 시작일")
+                                        )
+                                        .responseSchema(Schema.schema("update-mybook-properties response body"))
+                                        .responseFields(
+                                                fieldWithPath("status").type(STRING).description("응답 상태"),
+                                                fieldWithPath("message").type(STRING).description("응답 메시지"),
+                                                fieldWithPath("data.showable").type(BOOLEAN).description("공개 여부"),
+                                                fieldWithPath("data.exchangeable").type(BOOLEAN).description("교환 여부"),
+                                                fieldWithPath("data.shareable").type(BOOLEAN).description("나눔 여부"),
+                                                fieldWithPath("data.readStatus").type(STRING).description("독서 진행 상태"),
+                                                fieldWithPath("data.startDateOfPossession").type(STRING).description("보유 시작일")
+                                        ).build())));
+    }
 }


### PR DESCRIPTION
## 🧑‍💻 작업 사항

### API 개발
- PUT "/api/v1/mybooks/{mybookId}" : 마이북 속성 수정 API 개발
- 수정 가능한 필드값 (의미태그는 추후에 개발 예정)
<img width="303" alt="image" src="https://github.com/SWM-IDLE/mybrary/assets/71378475/37160411-2e56-4ff8-ab0a-386e6dc61b86">

```
private boolean showable;
private boolean exchangeable;
private boolean shareable;
private ReadStatus readStatus;
private LocalDateTime startDateOfPossession;
```

- 응답값  : 수정가능한 필드값과 동일 (수정된 필드값에 대해서 응답)
    - 업데이트 이후 마이북 상세보기 조회시, 조회 API를 호출하지 않고 해당 응답값을 바탕으로 상세보기 페이지를 디스플레이를 하도록 위함.
    - 혹은 로그에 활용하기 위함
- 테스트 코드 작성

<br/>

### Presentation Layer Test Code 수정
- Swagger UI에 생성한 rest docs를 표시하기 위해 requestSchema와 responseSchema 형식 수정
- 하이픈과 띄어쓰기 제거 -> 언더바로 통일


<br><br>

## 🔗 링크

<!-- 관련된 대화가 이루어진 슬랙 링크 혹은 피그마 링크를 첨부. -->
<!-- - [프레이머](https://framer.com/projects/2--gSDcZoNKqU6dqCUQUYQe-53rEr?node=tQMWSSKqy)  -->

<br><br>

## 🐰 시급한 정도

<!-- 🏃‍♂️ 보통 : 최대한 빠르게 리뷰 부탁드립니다. -->
<!-- 🚨 긴급 : 선 어프루브 후 리뷰를 부탁드립니다. (리뷰는 추후 반영)  -->
<!-- 🐢 천천히 : 급하지 않습니다. -->

<br><br>

## 📖 참고 사항

<!-- 공유할 내용, 레퍼런스, 추가로 발생할 것으로 예상되는 이슈, 스크린샷 등을 넣어 주세요.  -->
<!-- 변경사항이 큰 경우 집중해야 할 부분, 또는 불안해서 봐주었으면 하는 부분 등 -->
