### PR TITLE
[IDLE-107] feat: 팔로잉 기능 구현 

### DIFF
--- a/user-service/src/main/java/kr/mybrary/userservice/global/BaseEntity.java
+++ b/user-service/src/main/java/kr/mybrary/userservice/global/BaseEntity.java
@@ -16,6 +16,6 @@ public abstract class BaseEntity {
     private LocalDateTime createdAt;
     @LastModifiedDate
     private LocalDateTime updatedAt;
-    private Boolean isDeleted = false;
+    private boolean deleted = false;
 
 }

--- a/user-service/src/main/java/kr/mybrary/userservice/user/domain/UserServiceImpl.java
+++ b/user-service/src/main/java/kr/mybrary/userservice/user/domain/UserServiceImpl.java
@@ -226,7 +226,14 @@ public class UserServiceImpl implements UserService {
 
     @Override
     public void unfollow(FollowServiceRequest serviceRequest) {
+        User sourceUser = userRepository.findByLoginId(serviceRequest.getSourceId())
+                .orElseThrow(UserNotFoundException::new);
+        User targetUser = userRepository.findByLoginId(serviceRequest.getTargetId())
+                .orElseThrow(UserNotFoundException::new);
 
+        validateDifferentSourceTarget(sourceUser, targetUser);
+
+        sourceUser.unfollow(targetUser);
     }
 
     @Override

--- a/user-service/src/main/java/kr/mybrary/userservice/user/domain/UserServiceImpl.java
+++ b/user-service/src/main/java/kr/mybrary/userservice/user/domain/UserServiceImpl.java
@@ -181,7 +181,7 @@ public class UserServiceImpl implements UserService {
         return serviceResponse;
     }
 
-    private static List<FollowResponse> getFollowerResponses(User user) {
+    private List<FollowResponse> getFollowerResponses(User user) {
         return user.getFollowers().stream()
                 .map(follow -> FollowResponse.builder()
                         .id(follow.getId())
@@ -195,7 +195,26 @@ public class UserServiceImpl implements UserService {
     @Override
     @Transactional(readOnly = true)
     public FollowingServiceResponse getFollowings(String loginId) {
-        return null;
+        User user = userRepository.findByLoginId(loginId)
+                .orElseThrow(UserNotFoundException::new);
+
+        FollowingServiceResponse serviceResponse = FollowingServiceResponse.builder()
+                .requestLoginId(loginId)
+                .followings(getFollowingResponses(user))
+                .build();
+
+        return serviceResponse;
+    }
+
+    private List<FollowResponse> getFollowingResponses(User user) {
+        return user.getFollowings().stream()
+                .map(follow -> FollowResponse.builder()
+                        .id(follow.getId())
+                        .loginId(follow.getTarget().getLoginId())
+                        .nickname(follow.getTarget().getNickname())
+                        .profileImageUrl(follow.getTarget().getProfileImageUrl())
+                        .build())
+                .collect(Collectors.toList());
     }
 
     @Override

--- a/user-service/src/main/java/kr/mybrary/userservice/user/domain/UserServiceImpl.java
+++ b/user-service/src/main/java/kr/mybrary/userservice/user/domain/UserServiceImpl.java
@@ -200,6 +200,28 @@ public class UserServiceImpl implements UserService {
 
     @Override
     public void follow(FollowServiceRequest serviceRequest) {
+        User sourceUser = userRepository.findByLoginId(serviceRequest.getSourceId())
+                .orElseThrow(UserNotFoundException::new);
+        User targetUser = userRepository.findByLoginId(serviceRequest.getTargetId())
+                .orElseThrow(UserNotFoundException::new);
+
+        validateDifferentSourceTarget(sourceUser, targetUser);
+        validateDuplicateFollow(sourceUser, targetUser);
+
+        sourceUser.follow(targetUser);
+    }
+
+    private void validateDifferentSourceTarget(User source, User target) {
+        if (source.equals(target)) {
+            throw new SameSourceTargetUserException();
+        }
+    }
+
+    private void validateDuplicateFollow(User source, User target) {
+        if (source.getFollowings().stream()
+                .anyMatch(follow -> follow.getTarget().equals(target))) {
+            throw new DuplicateFollowException();
+        }
     }
 
     @Override

--- a/user-service/src/main/java/kr/mybrary/userservice/user/domain/UserServiceImpl.java
+++ b/user-service/src/main/java/kr/mybrary/userservice/user/domain/UserServiceImpl.java
@@ -76,17 +76,20 @@ public class UserServiceImpl implements UserService {
     @Override
     @Transactional(readOnly = true)
     public ProfileServiceResponse getProfile(String loginId) {
-        User user = userRepository.findByLoginId(loginId)
-                .orElseThrow(UserNotFoundException::new);
+        User user = getUser(loginId);
         ProfileServiceResponse serviceResponse = UserMapper.INSTANCE.toProfileServiceResponse(user);
 
         return serviceResponse;
     }
 
+    private User getUser(String loginId) {
+        return userRepository.findByLoginId(loginId)
+                .orElseThrow(UserNotFoundException::new);
+    }
+
     @Override
     public ProfileServiceResponse updateProfile(ProfileUpdateServiceRequest serviceRequest) {
-        User user = userRepository.findByLoginId(serviceRequest.getLoginId())
-                .orElseThrow(UserNotFoundException::new);
+        User user = getUser(serviceRequest.getLoginId());
 
         checkIfNicknameUpdateIsPossible(user.getNickname(), serviceRequest.getNickname());
 
@@ -105,8 +108,7 @@ public class UserServiceImpl implements UserService {
     @Override
     @Transactional(readOnly = true)
     public ProfileImageUrlServiceResponse getProfileImageUrl(String loginId) {
-        User user = userRepository.findByLoginId(loginId)
-                .orElseThrow(UserNotFoundException::new);
+        User user = getUser(loginId);
 
         checkProfileImageUrlExistence(user);
 
@@ -128,8 +130,7 @@ public class UserServiceImpl implements UserService {
         checkProfileImageExistence(serviceRequest.getProfileImage());
         checkProfileImageSize(serviceRequest.getProfileImage());
 
-        User user = userRepository.findByLoginId(serviceRequest.getLoginId())
-                .orElseThrow(UserNotFoundException::new);
+        User user = getUser(serviceRequest.getLoginId());
 
         String profileImageUrl = storageService.putFile(serviceRequest.getProfileImage(),
                 MultipartFileUtil.generateFilePath(PROFILE_IMAGE_PATH, serviceRequest.getLoginId(), serviceRequest.getProfileImage()));
@@ -156,8 +157,7 @@ public class UserServiceImpl implements UserService {
 
     @Override
     public ProfileImageUrlServiceResponse deleteProfileImage(String loginId) {
-        User user = userRepository.findByLoginId(loginId)
-                .orElseThrow(UserNotFoundException::new);
+        User user = getUser(loginId);
 
         user.updateProfileImageUrl(DEFAULT_PROFILE_IMAGE_URL);
         ProfileImageUrlServiceResponse serviceResponse = ProfileImageUrlServiceResponse.builder()
@@ -170,8 +170,7 @@ public class UserServiceImpl implements UserService {
     @Override
     @Transactional(readOnly = true)
     public FollowerServiceResponse getFollowers(String loginId) {
-        User user = userRepository.findByLoginId(loginId)
-                .orElseThrow(UserNotFoundException::new);
+        User user = getUser(loginId);
 
         FollowerServiceResponse serviceResponse = FollowerServiceResponse.builder()
                 .requestLoginId(loginId)
@@ -195,8 +194,7 @@ public class UserServiceImpl implements UserService {
     @Override
     @Transactional(readOnly = true)
     public FollowingServiceResponse getFollowings(String loginId) {
-        User user = userRepository.findByLoginId(loginId)
-                .orElseThrow(UserNotFoundException::new);
+        User user = getUser(loginId);
 
         FollowingServiceResponse serviceResponse = FollowingServiceResponse.builder()
                 .requestLoginId(loginId)
@@ -219,10 +217,8 @@ public class UserServiceImpl implements UserService {
 
     @Override
     public void follow(FollowServiceRequest serviceRequest) {
-        User sourceUser = userRepository.findByLoginId(serviceRequest.getSourceId())
-                .orElseThrow(UserNotFoundException::new);
-        User targetUser = userRepository.findByLoginId(serviceRequest.getTargetId())
-                .orElseThrow(UserNotFoundException::new);
+        User sourceUser = getUser(serviceRequest.getSourceId());
+        User targetUser = getUser(serviceRequest.getTargetId());
 
         validateDifferentSourceTarget(sourceUser, targetUser);
         validateDuplicateFollow(sourceUser, targetUser);
@@ -245,10 +241,8 @@ public class UserServiceImpl implements UserService {
 
     @Override
     public void unfollow(FollowServiceRequest serviceRequest) {
-        User sourceUser = userRepository.findByLoginId(serviceRequest.getSourceId())
-                .orElseThrow(UserNotFoundException::new);
-        User targetUser = userRepository.findByLoginId(serviceRequest.getTargetId())
-                .orElseThrow(UserNotFoundException::new);
+        User sourceUser = getUser(serviceRequest.getSourceId());
+        User targetUser = getUser(serviceRequest.getTargetId());
 
         validateDifferentSourceTarget(sourceUser, targetUser);
 
@@ -258,10 +252,8 @@ public class UserServiceImpl implements UserService {
     // TODO: deleteFollower 로직 논의 -> 해당 유저가 본인을 다시 팔로우할 수 있는가?
     @Override
     public void deleteFollower(FollowerServiceRequest serviceRequest) {
-        User sourceUser = userRepository.findByLoginId(serviceRequest.getSourceId())
-                .orElseThrow(UserNotFoundException::new);
-        User targetUser = userRepository.findByLoginId(serviceRequest.getTargetId())
-                .orElseThrow(UserNotFoundException::new);
+        User sourceUser = getUser(serviceRequest.getSourceId());
+        User targetUser = getUser(serviceRequest.getTargetId());
 
         validateDifferentSourceTarget(sourceUser, targetUser);
 

--- a/user-service/src/main/java/kr/mybrary/userservice/user/domain/UserServiceImpl.java
+++ b/user-service/src/main/java/kr/mybrary/userservice/user/domain/UserServiceImpl.java
@@ -255,9 +255,17 @@ public class UserServiceImpl implements UserService {
         sourceUser.unfollow(targetUser);
     }
 
+    // TODO: deleteFollower 로직 논의 -> 해당 유저가 본인을 다시 팔로우할 수 있는가?
     @Override
     public void deleteFollower(FollowerServiceRequest serviceRequest) {
+        User sourceUser = userRepository.findByLoginId(serviceRequest.getSourceId())
+                .orElseThrow(UserNotFoundException::new);
+        User targetUser = userRepository.findByLoginId(serviceRequest.getTargetId())
+                .orElseThrow(UserNotFoundException::new);
 
+        validateDifferentSourceTarget(sourceUser, targetUser);
+
+        sourceUser.unfollow(targetUser);
     }
 
 

--- a/user-service/src/main/java/kr/mybrary/userservice/user/domain/exception/follow/DuplicateFollowException.java
+++ b/user-service/src/main/java/kr/mybrary/userservice/user/domain/exception/follow/DuplicateFollowException.java
@@ -1,0 +1,14 @@
+package kr.mybrary.userservice.user.domain.exception.follow;
+
+import kr.mybrary.userservice.global.exception.ApplicationException;
+
+public class DuplicateFollowException extends ApplicationException {
+
+        private final static int STATUS = 400;
+        private final static String ERROR_CODE = "F-02";
+        private final static String ERROR_MESSAGE = "이미 팔로우한 사용자입니다.";
+
+        public DuplicateFollowException() {
+            super(STATUS, ERROR_CODE, ERROR_MESSAGE);
+        }
+}

--- a/user-service/src/main/java/kr/mybrary/userservice/user/domain/exception/follow/SameSourceTargetUserException.java
+++ b/user-service/src/main/java/kr/mybrary/userservice/user/domain/exception/follow/SameSourceTargetUserException.java
@@ -1,0 +1,14 @@
+package kr.mybrary.userservice.user.domain.exception.follow;
+
+import kr.mybrary.userservice.global.exception.ApplicationException;
+
+public class SameSourceTargetUserException extends ApplicationException {
+
+        private final static int STATUS = 400;
+        private final static String ERROR_CODE = "F-01";
+        private final static String ERROR_MESSAGE = "자기 자신을 팔로우할 수 없습니다.";
+
+        public SameSourceTargetUserException() {
+            super(STATUS, ERROR_CODE, ERROR_MESSAGE);
+        }
+}

--- a/user-service/src/main/java/kr/mybrary/userservice/user/domain/exception/follow/SameSourceTargetUserException.java
+++ b/user-service/src/main/java/kr/mybrary/userservice/user/domain/exception/follow/SameSourceTargetUserException.java
@@ -6,7 +6,7 @@ public class SameSourceTargetUserException extends ApplicationException {
 
         private final static int STATUS = 400;
         private final static String ERROR_CODE = "F-01";
-        private final static String ERROR_MESSAGE = "자기 자신을 팔로우할 수 없습니다.";
+        private final static String ERROR_MESSAGE = "자기 자신을 팔로우 또는 언팔로우할 수 없습니다.";
 
         public SameSourceTargetUserException() {
             super(STATUS, ERROR_CODE, ERROR_MESSAGE);

--- a/user-service/src/main/java/kr/mybrary/userservice/user/domain/exception/io/EmptyFileException.java
+++ b/user-service/src/main/java/kr/mybrary/userservice/user/domain/exception/io/EmptyFileException.java
@@ -1,11 +1,11 @@
-package kr.mybrary.userservice.user.domain.exception.file;
+package kr.mybrary.userservice.user.domain.exception.io;
 
 import kr.mybrary.userservice.global.exception.ApplicationException;
 
 public class EmptyFileException extends ApplicationException {
 
     private final static int STATUS = 400;
-    private final static String ERROR_CODE = "F-01";
+    private final static String ERROR_CODE = "IO-01";
     private final static String ERROR_MESSAGE = "파일이 비어있습니다. 파일을 선택해주세요.";
 
     public EmptyFileException() {

--- a/user-service/src/main/java/kr/mybrary/userservice/user/domain/exception/io/FileInputStreamException.java
+++ b/user-service/src/main/java/kr/mybrary/userservice/user/domain/exception/io/FileInputStreamException.java
@@ -1,11 +1,11 @@
-package kr.mybrary.userservice.user.domain.exception.file;
+package kr.mybrary.userservice.user.domain.exception.io;
 
 import kr.mybrary.userservice.global.exception.ApplicationException;
 
 public class FileInputStreamException extends ApplicationException {
 
     private final static int STATUS = 500;
-    private final static String ERROR_CODE = "F-02";
+    private final static String ERROR_CODE = "IO-02";
     private final static String ERROR_MESSAGE = "파일을 읽어오는데 실패했습니다.";
 
     public FileInputStreamException() {

--- a/user-service/src/main/java/kr/mybrary/userservice/user/domain/storage/AmazonS3Service.java
+++ b/user-service/src/main/java/kr/mybrary/userservice/user/domain/storage/AmazonS3Service.java
@@ -4,7 +4,7 @@ import io.awspring.cloud.s3.ObjectMetadata;
 import io.awspring.cloud.s3.S3Exception;
 import io.awspring.cloud.s3.S3Template;
 import java.io.IOException;
-import kr.mybrary.userservice.user.domain.exception.file.FileInputStreamException;
+import kr.mybrary.userservice.user.domain.exception.io.FileInputStreamException;
 import kr.mybrary.userservice.user.domain.exception.storage.StorageClientException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/user-service/src/main/java/kr/mybrary/userservice/user/persistence/Follow.java
+++ b/user-service/src/main/java/kr/mybrary/userservice/user/persistence/Follow.java
@@ -15,6 +15,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -22,6 +24,8 @@ import lombok.NoArgsConstructor;
 @Builder
 @Table(name = "follows")
 @AllArgsConstructor
+@SQLDelete(sql = "UPDATE follows SET deleted = true WHERE follow_id = ?")
+@Where(clause = "deleted = false")
 public class Follow extends BaseEntity {
 
     @Id

--- a/user-service/src/main/java/kr/mybrary/userservice/user/persistence/User.java
+++ b/user-service/src/main/java/kr/mybrary/userservice/user/persistence/User.java
@@ -73,4 +73,18 @@ public class User extends BaseEntity {
         this.profileImageUrl = profileImageUrl;
     }
 
+    public void follow(User target) {
+        Follow follow = Follow.builder()
+            .source(this)
+            .target(target)
+            .build();
+        this.followings.add(follow);
+        target.followers.add(follow);
+    }
+
+    public void unfollow(User target) {
+        this.followings.removeIf(follow -> follow.getTarget().equals(target));
+        target.followers.removeIf(follow -> follow.getSource().equals(this));
+    }
+
 }

--- a/user-service/src/main/java/kr/mybrary/userservice/user/persistence/User.java
+++ b/user-service/src/main/java/kr/mybrary/userservice/user/persistence/User.java
@@ -13,8 +13,9 @@ import org.hibernate.annotations.Where;
 @Builder
 @Table(name = "users")
 @AllArgsConstructor
-@SQLDelete(sql = "UPDATE users SET deleted = true WHERE user_id = ?")
-@Where(clause = "deleted = false")
+// TODO: soft delete 적용 시 unique 제약 조건 이슈
+// @SQLDelete(sql = "UPDATE users SET deleted = true WHERE user_id = ?")
+// @Where(clause = "deleted = false")
 public class User extends BaseEntity {
 
     @Id

--- a/user-service/src/main/java/kr/mybrary/userservice/user/persistence/User.java
+++ b/user-service/src/main/java/kr/mybrary/userservice/user/persistence/User.java
@@ -4,6 +4,8 @@ import jakarta.persistence.*;
 import java.util.List;
 import kr.mybrary.userservice.global.BaseEntity;
 import lombok.*;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -11,6 +13,8 @@ import lombok.*;
 @Builder
 @Table(name = "users")
 @AllArgsConstructor
+@SQLDelete(sql = "UPDATE users SET deleted = true WHERE user_id = ?")
+@Where(clause = "deleted = false")
 public class User extends BaseEntity {
 
     @Id
@@ -82,9 +86,10 @@ public class User extends BaseEntity {
         target.followers.add(follow);
     }
 
+    // TODO: 팔로우를 soft delete 해야하는지 고민해보기
     public void unfollow(User target) {
-        this.followings.removeIf(follow -> follow.getTarget().equals(target));
-        target.followers.removeIf(follow -> follow.getSource().equals(this));
+         this.followings.removeIf(follow -> follow.getTarget().equals(target));
+         target.followers.removeIf(follow -> follow.getSource().equals(this));
     }
 
 }

--- a/user-service/src/test/java/kr/mybrary/userservice/user/UserFixture.java
+++ b/user-service/src/test/java/kr/mybrary/userservice/user/UserFixture.java
@@ -1,12 +1,13 @@
 package kr.mybrary.userservice.user;
 
-import java.util.Collections;
-import java.util.List;
 import kr.mybrary.userservice.user.persistence.Follow;
 import kr.mybrary.userservice.user.persistence.Role;
 import kr.mybrary.userservice.user.persistence.SocialType;
 import kr.mybrary.userservice.user.persistence.User;
 import lombok.AllArgsConstructor;
+
+import java.util.Collections;
+import java.util.List;
 
 @AllArgsConstructor
 public enum UserFixture {
@@ -20,7 +21,17 @@ public enum UserFixture {
 
     USER_WITHOUT_EMAIL(1L, "loginId", "nickname", "encodedPassword", Role.USER,
             "socialId", SocialType.GOOGLE, "refreshToken", null, "introduction", "profileImageUrl",
-            Collections.emptyList(), Collections.emptyList());
+            Collections.emptyList(), Collections.emptyList()),
+
+    USER_WITH_FOLLOWER(1L, "followingId", "nickname", "encodedPassword", Role.USER,
+            "socialId", SocialType.GOOGLE, "refreshToken", "email@mail.com", "introduction", "profileImageUrl",
+            List.of(Follow.builder().source(User.builder().loginId("followerId").build()).target(User.builder().loginId("followingId").build()).build()),
+            Collections.emptyList()),
+
+    USER_AS_FOLLOWER(1L, "followerId", "nickname", "encodedPassword", Role.USER,
+            "socialId", SocialType.GOOGLE, "refreshToken", "email@mail.com", "introduction", "profileImageUrl",
+            Collections.emptyList(),
+            List.of(Follow.builder().source(User.builder().loginId("followerId").build()).target(User.builder().loginId("followingId").build()).build()));
 
     private final Long id;
     private final String loginId;

--- a/user-service/src/test/java/kr/mybrary/userservice/user/domain/UserServiceImplTest.java
+++ b/user-service/src/test/java/kr/mybrary/userservice/user/domain/UserServiceImplTest.java
@@ -9,7 +9,7 @@ import kr.mybrary.userservice.user.domain.dto.request.SignUpServiceRequest;
 import kr.mybrary.userservice.user.domain.dto.response.ProfileImageUrlServiceResponse;
 import kr.mybrary.userservice.user.domain.dto.response.ProfileServiceResponse;
 import kr.mybrary.userservice.user.domain.dto.response.SignUpServiceResponse;
-import kr.mybrary.userservice.user.domain.exception.file.EmptyFileException;
+import kr.mybrary.userservice.user.domain.exception.io.EmptyFileException;
 import kr.mybrary.userservice.user.domain.exception.profile.ProfileImageFileSizeExceededException;
 import kr.mybrary.userservice.user.domain.exception.profile.ProfileImageUrlNotFoundException;
 import kr.mybrary.userservice.user.domain.exception.user.DuplicateLoginIdException;
@@ -300,7 +300,7 @@ class UserServiceImplTest {
         assertThatThrownBy(() -> userService.updateProfileImage(serviceRequest))
                 .isInstanceOf(EmptyFileException.class)
                 .hasFieldOrPropertyWithValue("status", 400)
-                .hasFieldOrPropertyWithValue("errorCode", "F-01")
+                .hasFieldOrPropertyWithValue("errorCode", "IO-01")
                 .hasFieldOrPropertyWithValue("errorMessage", "파일이 비어있습니다. 파일을 선택해주세요.");
     }
 

--- a/user-service/src/test/java/kr/mybrary/userservice/user/domain/follow/FollowTest.java
+++ b/user-service/src/test/java/kr/mybrary/userservice/user/domain/follow/FollowTest.java
@@ -1,0 +1,244 @@
+package kr.mybrary.userservice.user.domain.follow;
+
+import kr.mybrary.userservice.user.domain.UserServiceImpl;
+import kr.mybrary.userservice.user.domain.dto.request.FollowServiceRequest;
+import kr.mybrary.userservice.user.domain.dto.request.FollowerServiceRequest;
+import kr.mybrary.userservice.user.domain.dto.response.FollowerServiceResponse;
+import kr.mybrary.userservice.user.domain.dto.response.FollowingServiceResponse;
+import kr.mybrary.userservice.user.domain.exception.follow.DuplicateFollowException;
+import kr.mybrary.userservice.user.domain.exception.follow.SameSourceTargetUserException;
+import kr.mybrary.userservice.user.domain.exception.user.UserNotFoundException;
+import kr.mybrary.userservice.user.persistence.User;
+import kr.mybrary.userservice.user.persistence.repository.UserRepository;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.ArrayList;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+public class FollowTest {
+
+    @Mock
+    UserRepository userRepository;
+
+    @InjectMocks
+    UserServiceImpl userService;
+
+    static User userA = User.builder()
+            .loginId("userA")
+            .followers(new ArrayList<>())
+            .followings(new ArrayList<>())
+            .build();
+
+    static User userB = User.builder()
+            .loginId("userB")
+            .followers(new ArrayList<>())
+            .followings(new ArrayList<>())
+            .build();
+
+    static User userC = User.builder()
+            .loginId("userC")
+            .followers(new ArrayList<>())
+            .followings(new ArrayList<>())
+            .build();
+
+    @Test
+    @Order(1)
+    @DisplayName("userA는 userB를 팔로우한다.")
+    void userAFollowUserB() {
+        // given
+        given(userRepository.findByLoginId(userA.getLoginId())).willReturn(Optional.of(userA));
+        given(userRepository.findByLoginId(userB.getLoginId())).willReturn(Optional.of(userB));
+
+        // when
+        userService.follow(FollowServiceRequest.of(userA.getLoginId(), userB.getLoginId()));
+
+        // then
+        assertAll(
+                () -> assertThat(userA.getFollowings()).hasSize(1),
+                () -> assertThat(userA.getFollowings().get(0).getSource()).isEqualTo(userA),
+                () -> assertThat(userA.getFollowings().get(0).getTarget()).isEqualTo(userB),
+                () -> assertThat(userB.getFollowers()).hasSize(1),
+                () -> assertThat(userB.getFollowers().get(0).getSource()).isEqualTo(userA),
+                () -> assertThat(userB.getFollowers().get(0).getTarget()).isEqualTo(userB)
+        );
+
+        verify(userRepository).findByLoginId(userA.getLoginId());
+        verify(userRepository).findByLoginId(userB.getLoginId());
+    }
+
+    @Test
+    @Order(2)
+    @DisplayName("userA의 팔로잉 목록을 조회한다.")
+    void getUserAFollowings() {
+        // given
+        given(userRepository.findByLoginId(userA.getLoginId())).willReturn(Optional.of(userA));
+
+        // when
+        FollowingServiceResponse response = userService.getFollowings(userA.getLoginId());
+
+        // then
+        assertAll(
+                () -> assertThat(response.getRequestLoginId()).isEqualTo(userA.getLoginId()),
+                () -> assertThat(response.getFollowings()).hasSize(1),
+                () -> assertThat(response.getFollowings()).extracting("loginId").contains(userB.getLoginId())
+        );
+
+        verify(userRepository).findByLoginId(userA.getLoginId());
+    }
+
+    @Test
+    @Order(3)
+    @DisplayName("userC는 userB를 팔로우한다.")
+    void userCFollowUserB() {
+        // given
+        given(userRepository.findByLoginId(userC.getLoginId())).willReturn(Optional.of(userC));
+        given(userRepository.findByLoginId(userB.getLoginId())).willReturn(Optional.of(userB));
+
+        // when
+        userService.follow(FollowServiceRequest.of(userC.getLoginId(), userB.getLoginId()));
+
+        // then
+        assertAll(
+                () -> assertThat(userC.getFollowings()).hasSize(1),
+                () -> assertThat(userC.getFollowings().get(0).getSource()).isEqualTo(userC),
+                () -> assertThat(userC.getFollowings().get(0).getTarget()).isEqualTo(userB),
+                () -> assertThat(userB.getFollowers()).hasSize(2),
+                () -> assertThat(userB.getFollowers().get(1).getSource()).isEqualTo(userC),
+                () -> assertThat(userB.getFollowers().get(1).getTarget()).isEqualTo(userB)
+        );
+
+        verify(userRepository).findByLoginId(userC.getLoginId());
+        verify(userRepository).findByLoginId(userB.getLoginId());
+    }
+
+    @Test
+    @Order(4)
+    @DisplayName("userC가 userB를 다시 팔로우하면 예외가 발생한다.")
+    void userCFollowUserBAgain() {
+        // given
+        given(userRepository.findByLoginId(userC.getLoginId())).willReturn(Optional.of(userC));
+        given(userRepository.findByLoginId(userB.getLoginId())).willReturn(Optional.of(userB));
+
+        // when then
+        assertThatThrownBy(() -> userService.follow(FollowServiceRequest.of(userC.getLoginId(), userB.getLoginId())))
+                .isInstanceOf(DuplicateFollowException.class)
+                .hasFieldOrPropertyWithValue("status", 400)
+                .hasFieldOrPropertyWithValue("errorCode", "F-02")
+                .hasFieldOrPropertyWithValue("errorMessage", "이미 팔로우한 사용자입니다.");
+
+        verify(userRepository).findByLoginId(userC.getLoginId());
+        verify(userRepository).findByLoginId(userB.getLoginId());
+    }
+
+    @Test
+    @Order(5)
+    @DisplayName("userB의 팔로워 목록을 조회한다.")
+    void getUserBFollowers() {
+        // given
+        given(userRepository.findByLoginId(userB.getLoginId())).willReturn(Optional.of(userB));
+
+        // when
+        FollowerServiceResponse response = userService.getFollowers(userB.getLoginId());
+
+        // then
+        assertAll(
+                () -> assertThat(response.getRequestLoginId()).isEqualTo(userB.getLoginId()),
+                () -> assertThat(response.getFollowers()).hasSize(2),
+                () -> assertThat(response.getFollowers()).extracting("loginId").containsExactly(userA.getLoginId(), userC.getLoginId())
+        );
+
+        verify(userRepository).findByLoginId(userB.getLoginId());
+    }
+
+    @Test
+    @Order(6)
+    @DisplayName("userA는 userB를 언팔로우한다.")
+    void userAUnfollowUserB() {
+        // given
+        given(userRepository.findByLoginId(userA.getLoginId())).willReturn(Optional.of(userA));
+        given(userRepository.findByLoginId(userB.getLoginId())).willReturn(Optional.of(userB));
+
+        // when
+        userService.unfollow(FollowServiceRequest.of(userA.getLoginId(), userB.getLoginId()));
+
+        // then
+        assertAll(
+                () -> assertThat(userA.getFollowings()).hasSize(0),
+                () -> assertThat(userB.getFollowers()).hasSize(1)
+        );
+
+        verify(userRepository).findByLoginId(userA.getLoginId());
+        verify(userRepository).findByLoginId(userB.getLoginId());
+    }
+
+    @Test
+    @Order(7)
+    @DisplayName("userB는 userC를 팔로워 목록에서 삭제한다.")
+    void userBDeletefollowerUserC() {
+        // given
+        given(userRepository.findByLoginId(userB.getLoginId())).willReturn(Optional.of(userB));
+        given(userRepository.findByLoginId(userC.getLoginId())).willReturn(Optional.of(userC));
+
+        // when
+        userService.deleteFollower(FollowerServiceRequest.of(userB.getLoginId(), userC.getLoginId()));
+
+        // then
+        assertAll(
+                () -> assertThat(userB.getFollowers()).hasSize(0),
+                () -> assertThat(userC.getFollowings()).hasSize(0)
+        );
+
+        verify(userRepository).findByLoginId(userB.getLoginId());
+        verify(userRepository).findByLoginId(userC.getLoginId());
+    }
+
+    @Test
+    @Order(8)
+    @DisplayName("userA가 userA 자신을 팔로우하면 예외가 발생한다.")
+    void userAFollowUserA() {
+        // given
+        given(userRepository.findByLoginId(userA.getLoginId())).willReturn(Optional.of(userA));
+
+        // when then
+        assertThatThrownBy(() -> userService.follow(FollowServiceRequest.of(userA.getLoginId(), userA.getLoginId())))
+                .isInstanceOf(SameSourceTargetUserException.class)
+                .hasFieldOrPropertyWithValue("status", 400)
+                .hasFieldOrPropertyWithValue("errorCode", "F-01")
+                .hasFieldOrPropertyWithValue("errorMessage", "자기 자신을 팔로우 또는 언팔로우할 수 없습니다.");
+
+        verify(userRepository, times(2)).findByLoginId(userA.getLoginId());
+    }
+
+    @Test
+    @Order(9)
+    @DisplayName("userA가 없는 사용자를 팔로우하면 예외가 발생한다.")
+    void userAFollowNonExistUser() {
+        // given
+        given(userRepository.findByLoginId(userA.getLoginId())).willReturn(Optional.of(userA));
+        given(userRepository.findByLoginId("nonExistUser")).willReturn(Optional.empty());
+
+        // when
+        assertThatThrownBy(() -> userService.follow(FollowServiceRequest.of(userA.getLoginId(), "nonExistUser")))
+                .isInstanceOf(UserNotFoundException.class)
+                .hasFieldOrPropertyWithValue("status", 404)
+                .hasFieldOrPropertyWithValue("errorCode", "U-05")
+                .hasFieldOrPropertyWithValue("errorMessage", "존재하지 않는 사용자입니다.");
+
+        verify(userRepository).findByLoginId(userA.getLoginId());
+        verify(userRepository).findByLoginId("nonExistUser");
+    }
+
+}

--- a/user-service/src/test/java/kr/mybrary/userservice/user/domain/follow/FollowTest.java
+++ b/user-service/src/test/java/kr/mybrary/userservice/user/domain/follow/FollowTest.java
@@ -81,7 +81,7 @@ public class FollowTest {
 
     @Test
     @Order(2)
-    @DisplayName("userA의 팔로잉 목록을 조회한다.")
+    @DisplayName("userA의 팔로잉 목록을 조회 하면 1명(userB)이 조회된다.")
     void getUserAFollowings() {
         // given
         given(userRepository.findByLoginId(userA.getLoginId())).willReturn(Optional.of(userA));
@@ -145,7 +145,7 @@ public class FollowTest {
 
     @Test
     @Order(5)
-    @DisplayName("userB의 팔로워 목록을 조회한다.")
+    @DisplayName("userB의 팔로워 목록을 조회하면 2명(userA, userC)이 조회된다.")
     void getUserBFollowers() {
         // given
         given(userRepository.findByLoginId(userB.getLoginId())).willReturn(Optional.of(userB));
@@ -186,6 +186,25 @@ public class FollowTest {
 
     @Test
     @Order(7)
+    @DisplayName("userA의 팔로잉 목록을 조회 하면 0명이 조회된다.")
+    void getUserAFollowingsAfterUnfollow() {
+        // given
+        given(userRepository.findByLoginId(userA.getLoginId())).willReturn(Optional.of(userA));
+
+        // when
+        FollowingServiceResponse response = userService.getFollowings(userA.getLoginId());
+
+        // then
+        assertAll(
+                () -> assertThat(response.getRequestLoginId()).isEqualTo(userA.getLoginId()),
+                () -> assertThat(response.getFollowings()).hasSize(0)
+        );
+
+        verify(userRepository).findByLoginId(userA.getLoginId());
+    }
+
+    @Test
+    @Order(8)
     @DisplayName("userB는 userC를 팔로워 목록에서 삭제한다.")
     void userBDeletefollowerUserC() {
         // given
@@ -206,7 +225,26 @@ public class FollowTest {
     }
 
     @Test
-    @Order(8)
+    @Order(9)
+    @DisplayName("userB의 팔로워 목록을 조회하면 0명이 조회된다.")
+    void getUserBFollowersAfterFollowerDelete() {
+        // given
+        given(userRepository.findByLoginId(userB.getLoginId())).willReturn(Optional.of(userB));
+
+        // when
+        FollowerServiceResponse response = userService.getFollowers(userB.getLoginId());
+
+        // then
+        assertAll(
+                () -> assertThat(response.getRequestLoginId()).isEqualTo(userB.getLoginId()),
+                () -> assertThat(response.getFollowers()).hasSize(0)
+        );
+
+        verify(userRepository).findByLoginId(userB.getLoginId());
+    }
+
+    @Test
+    @Order(10)
     @DisplayName("userA가 userA 자신을 팔로우하면 예외가 발생한다.")
     void userAFollowUserA() {
         // given
@@ -223,7 +261,7 @@ public class FollowTest {
     }
 
     @Test
-    @Order(9)
+    @Order(11)
     @DisplayName("userA가 없는 사용자를 팔로우하면 예외가 발생한다.")
     void userAFollowNonExistUser() {
         // given


### PR DESCRIPTION
## 🧑‍💻 작업 사항
### 팔로워 목록 조회
- 요청된 사용자의 팔로워 목록을 조회합니다
- follow 테이블에서 deleted가 false이면서 target_id가 자신인 데이터들만 읽어옵니다

### 팔로잉 목록 조회
- 요청된 사용자의 팔로잉 목록을 조회합니다
- follow 테이블에서 deleted가 false이면서 source_id가 자신인 데이터들만 읽어옵니다

### 팔로우
- 요청된 사용자를 팔로우 합니다
- 요청한 사용자와 요청된 사용자가 같으면 예외가 발생합니다
- 이미 팔로우 한 사용자라면 예외가 발생합니다

### 언팔로우
- 요청된 사용자를 언팔로우 합니다
- 요청한 사용자와 요청된 사용자가 같으면 예외가 발생합니다
- 이미 언팔로우 상태인 사용자라도 예외가 발생하지 않습니다 (removeIf 사용)
```
public void unfollow(User target) {
         this.followings.removeIf(follow -> follow.getTarget().equals(target));
         target.followers.removeIf(follow -> follow.getSource().equals(this));
    }
```

### 팔로워 삭제
- 요청된 사용자를 팔로워 목록에서 삭제합니다
- 요청된 사용자로 하여금 자신을 언팔로우 하도록 동작합니다
- 요청한 사용자와 요청된 사용자가 같으면 예외가 발생합니다

### 테스트
팔로우 기능 테스트 관련 이슈
1. 요청에 따라 followers, followings 변수 값이 유동적으로 바뀜 -> UserFixture 사용이 어려워짐
2. 팔로우 요청 후 팔로잉 목록에 추가된 사용자 객체와 요청된 사용자 객체가 같은 지 동일성 비교가 어려움 -> 단순히 size 정도만 확인하는데 그침

따라서 User 객체를 직접 생성하였고 팔로우 테스트 시나리오에 따라 순차적으로 실행되는 테스트를 구성했습니다.

<img width="474" alt="image" src="https://github.com/SWM-IDLE/mybrary/assets/78717113/a54c2de4-8f08-4f98-8b96-f1a87ca277d8">


<br><br>

## 🔗 링크

<br><br>

## 🐰 시급한 정도
🏃‍♂️ 보통 : 최대한 빠르게 리뷰 부탁드립니다.

<br><br>

## 📖 참고 사항
### Follow 테이블의 Soft Delete
- 팔로우/언팔로우는 사용자가 토글 버튼으로 여러 번 누를 수 있기 때문에 팔로우/언팔로우가 여러 번 요청되는 상황이 많을 것 같습니다.
- soft delete는 테이블에 한 번 기록된 데이터를 영구적으로 삭제하지 않기 때문에 팔로우 요청이 많이 들어오는 경우 db에 부담이 갈 수 있겠다는 생각이 들었습니다.
<img width="1115" alt="image" src="https://github.com/SWM-IDLE/mybrary/assets/78717113/641272f3-a514-4576-8017-a50ecac997a1">


### Soft Delete와 Unique Constraint
- user 테이블에 soft delete 적용 후 로그인/소셜 로그인 통합 테스트가 실행되는 이슈가 발생했습니다.
- 로그인/소셜 로그인 통합 테스트는 각 테스트 케이스 실행 전 회원 가입을 수행하고, 테스트가 종료되면 DB에서 가입된 유저를 삭제하는 작업이 일어납니다.
- soft delete가 적용되자 유저 정보가 삭제되지 않고 deleted만 true로 변경되어서, 다음 테스트 케이스를 위한 회원 가입 시 로그인 아이디/닉네임의 unique constraint로 인한 오류가 발생했습니다.
- 테스트 코드 상으로는 회원 가입을 전체 테스트 시작 전 1회 수행하는 것으로 고칠 수 있겠지만,
- soft delete와 unique constraint를 같이 설정해두면 서비스 운영 시 탈퇴한 사용자의 아이디, 닉네임으로는 회원 가입이 불가한 상황이 발생할 것 같습니다.
https://oraange.tistory.com/26
- 이와 유사한 이슈를 다룬 블로그 글인데 nickname과 deleted 컬럼 두개를 다중 컬럼 unique를 걸어서 해결할 수 있다고 합니다.
- 다중 컬럼 unique를 설정하는 것이 성능 상으로 문제가 없을 지, 다른 해결 방법은 없을 지 같이 의논해보면 좋겠습니다 🤔
