### PR TITLE
[IDLE-136] refactor: 4차 SPRINT까지 book-service 코드 리펙토링

### DIFF
--- a/backend/book-service/src/main/java/kr/mybrary/bookservice/mybook/domain/dto/request/MybookUpdateServiceRequest.java
+++ b/backend/book-service/src/main/java/kr/mybrary/bookservice/mybook/domain/dto/request/MybookUpdateServiceRequest.java
@@ -9,7 +9,7 @@ import lombok.Getter;
 @Builder
 public class MybookUpdateServiceRequest {
 
-    private String userId;
+    private String loginId;
     private Long myBookId;
 
     private boolean showable;

--- a/backend/book-service/src/main/java/kr/mybrary/bookservice/mybook/persistence/MyBook.java
+++ b/backend/book-service/src/main/java/kr/mybrary/bookservice/mybook/persistence/MyBook.java
@@ -13,6 +13,7 @@ import jakarta.persistence.Table;
 import java.time.LocalDateTime;
 import kr.mybrary.bookservice.book.persistence.Book;
 import kr.mybrary.bookservice.global.BaseEntity;
+import kr.mybrary.bookservice.mybook.domain.dto.request.MybookUpdateServiceRequest;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -60,16 +61,19 @@ public class MyBook extends BaseEntity {
                 .build();
     }
 
+    public boolean isPrivate() {
+        return !this.showable;
+    }
+
     public void deleteMyBook() {
         this.deleted = true;
     }
 
-    public void updateProperties(ReadStatus readStatus, LocalDateTime startDateOfPossession,
-            boolean showable, boolean exchangeable, boolean shareable) {
-        this.readStatus = readStatus;
-        this.startDateOfPossession = startDateOfPossession;
-        this.showable = showable;
-        this.exchangeable = exchangeable;
-        this.shareable = shareable;
+    public void updateFromUpdateRequest(MybookUpdateServiceRequest updateRequest) {
+        this.readStatus = updateRequest.getReadStatus();
+        this.startDateOfPossession = updateRequest.getStartDateOfPossession();
+        this.showable = updateRequest.isShowable();
+        this.exchangeable = updateRequest.isExchangeable();
+        this.shareable = updateRequest.isShareable();
     }
 }

--- a/backend/book-service/src/main/java/kr/mybrary/bookservice/mybook/presentation/dto/request/MyBookUpdateRequest.java
+++ b/backend/book-service/src/main/java/kr/mybrary/bookservice/mybook/presentation/dto/request/MyBookUpdateRequest.java
@@ -18,7 +18,7 @@ public class MyBookUpdateRequest {
 
     public MybookUpdateServiceRequest toServiceRequest(String userId, Long myBookId) {
         return MybookUpdateServiceRequest.builder()
-                .userId(userId)
+                .loginId(userId)
                 .myBookId(myBookId)
                 .showable(showable)
                 .exchangeable(exchangeable)

--- a/backend/book-service/src/main/resources/application-dev.yml
+++ b/backend/book-service/src/main/resources/application-dev.yml
@@ -2,13 +2,9 @@ server:
   port: 0
 
 spring:
-  application:
-    name: user-service
-  datasource:
-    driver-class-name: com.mysql.cj.jdbc.Driver
-    url: jdbc:mysql://localhost:3306/mybrary
-    username: ${DB_USERNAME}
-    password : ${DB_PASSWORD}
+  spring:
+    application:
+      name: book-service
 
   jpa:
     hibernate:
@@ -16,20 +12,11 @@ spring:
     properties:
       hibernate:
         show_sql: true
-        format_sql: true
+
   cloud:
     config:
       server:
         bootstrap: true
-  rabbitmq:
-    host: 127.0.0.1
-    port: 5672
-    username: guest
-    password: guest
-
-kakao:
-  api:
-    key: ${KAKAO_API_KEY}
 
 eureka:
   instance:

--- a/backend/book-service/src/main/resources/application-local.yml
+++ b/backend/book-service/src/main/resources/application-local.yml
@@ -1,0 +1,29 @@
+spring:
+  application:
+    name: book-service
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: jdbc:mysql://localhost:3306/mybrary
+    username: ${DB_USERNAME}
+    password : ${DB_PASSWORD}
+
+  jpa:
+    hibernate:
+      ddl-auto: create
+    properties:
+      hibernate:
+        format_sql: true
+
+kakao:
+  api:
+    key: ${KAKAO_API_KEY}
+
+eureka:
+  client:
+    enabled: false
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: refresh,health,beans

--- a/backend/book-service/src/main/resources/application-test.yml
+++ b/backend/book-service/src/main/resources/application-test.yml
@@ -1,0 +1,29 @@
+spring:
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: jdbc:mysql://localhost:3306/test_mybrary
+    username: root
+    password : 1234
+
+  jpa:
+    hibernate:
+      ddl-auto: create
+    properties:
+      hibernate:
+        format_sql: true
+
+kakao:
+  api:
+    key: ${KAKAO_API_KEY}
+
+eureka:
+  client:
+    enabled: false
+
+logging:
+  level:
+    org:
+      hibernate:
+        type:
+          descriptor:
+            sql: trace

--- a/backend/book-service/src/main/resources/bootstrap.yml
+++ b/backend/book-service/src/main/resources/bootstrap.yml
@@ -3,5 +3,3 @@ spring:
     config:
       uri: 127.0.0.1:8888
       name: bookservice
-  profiles:
-    active:

--- a/backend/book-service/src/test/java/kr/mybrary/bookservice/mybook/MybookDtoTestData.java
+++ b/backend/book-service/src/test/java/kr/mybrary/bookservice/mybook/MybookDtoTestData.java
@@ -116,7 +116,7 @@ public class MybookDtoTestData {
 
     public static MybookUpdateServiceRequest createMyBookUpdateServiceRequest(String loginId, Long myBookId) {
         return MybookUpdateServiceRequest.builder()
-                .userId(loginId)
+                .loginId(loginId)
                 .myBookId(myBookId)
                 .showable(true)
                 .exchangeable(false)


### PR DESCRIPTION
## 🧑‍💻 작업 사항

### 환경에 맞는 설정 파일 생성
- local : 로컬 환경에서 개발할 때 사용하는 환경
    - eurekaClient disable
    - bus-amqp 라이브러리 비활성화 실패 .. 일단 rabbitmq를 구동시키고 로컬에서 개발중입니다.
    - 환경 변수를 통해서 각 API 키를 주입
- test : 테스트 코드가 동작하는 환경
    - 테스트용 데이터 베이스 사용
    - 로깅시, sql 파라미터가 표시되도록 설정
- dev : 배포해서, 클라이언트와 API 테스트를 하기 위한 환경
    - config server로 부터 전달되는 설정 모두 삭제

prod 환경은 1차 릴리즈에 작성예정.


### 리펙토링
- 중복 코드 메서드 추출
- 조건절 !을 사용하지 않고, 의미 있는 메서드 추출

<br><br>

## 🔗 링크

<br><br>

## 🐰 시급한 정도

🐢 천천히 : 급하지 않습니다.

<br><br>

## 📖 참고 사항

### 특정 라이브러리 비활성화
```
spring:
  autoconfigure:
    exclude:
      - org.springframework.cloud.bus.autoconfigure.BusAutoConfiguration
```

application-local.yml 에 해당 코드를 작성하여, bus-amqp 라이브러리를 비활성화하려 했지만 동작하지 않음.

<!-- 공유할 내용, 레퍼런스, 추가로 발생할 것으로 예상되는 이슈, 스크린샷 등을 넣어 주세요.  -->
<!-- 변경사항이 큰 경우 집중해야 할 부분, 또는 불안해서 봐주었으면 하는 부분 등 -->
