### PR TITLE
[IDLE-139] feat: 사용자 검색 기능 개발

### DIFF
--- a/user-service/src/main/java/kr/mybrary/userservice/global/exception/GlobalExceptionHandler.java
+++ b/user-service/src/main/java/kr/mybrary/userservice/global/exception/GlobalExceptionHandler.java
@@ -2,8 +2,11 @@ package kr.mybrary.userservice.global.exception;
 
 import kr.mybrary.userservice.global.dto.response.ErrorResponse;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.stream.Collectors;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
@@ -18,5 +21,13 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ErrorResponse> runtimeException(RuntimeException e) {
         return ResponseEntity.badRequest()
                 .body(ErrorResponse.of("RT-01", e.getMessage()));
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponse> methodArgumentNotValidException(MethodArgumentNotValidException e) {
+        return ResponseEntity.badRequest()
+                .body(ErrorResponse.of("VLD-01", e.getBindingResult().getAllErrors().stream()
+                        .map(error -> error.getDefaultMessage())
+                        .collect(Collectors.joining(", "))));
     }
 }

--- a/user-service/src/main/java/kr/mybrary/userservice/user/domain/UserService.java
+++ b/user-service/src/main/java/kr/mybrary/userservice/user/domain/UserService.java
@@ -5,11 +5,7 @@ import kr.mybrary.userservice.user.domain.dto.request.FollowerServiceRequest;
 import kr.mybrary.userservice.user.domain.dto.request.ProfileImageUpdateServiceRequest;
 import kr.mybrary.userservice.user.domain.dto.request.ProfileUpdateServiceRequest;
 import kr.mybrary.userservice.user.domain.dto.request.SignUpServiceRequest;
-import kr.mybrary.userservice.user.domain.dto.response.FollowerServiceResponse;
-import kr.mybrary.userservice.user.domain.dto.response.FollowingServiceResponse;
-import kr.mybrary.userservice.user.domain.dto.response.ProfileImageUrlServiceResponse;
-import kr.mybrary.userservice.user.domain.dto.response.ProfileServiceResponse;
-import kr.mybrary.userservice.user.domain.dto.response.SignUpServiceResponse;
+import kr.mybrary.userservice.user.domain.dto.response.*;
 
 public interface UserService {
 
@@ -34,4 +30,7 @@ public interface UserService {
     void unfollow(FollowServiceRequest serviceRequest);
 
     void deleteFollower(FollowerServiceRequest serviceRequest);
+
+    SearchServiceResponse searchByNickname(String nickname);
+
 }

--- a/user-service/src/main/java/kr/mybrary/userservice/user/domain/UserServiceImpl.java
+++ b/user-service/src/main/java/kr/mybrary/userservice/user/domain/UserServiceImpl.java
@@ -264,11 +264,7 @@ public class UserServiceImpl implements UserService {
     @Override
     public SearchServiceResponse searchByNickname(String nickname) {
         List<SearchServiceResponse.SearchedUser> searchedUsers = userRepository.findByNicknameContaining(nickname).stream()
-                .map(user -> SearchServiceResponse.SearchedUser.builder()
-                        .loginId(user.getLoginId())
-                        .nickname(user.getNickname())
-                        .profileImageUrl(user.getProfileImageUrl())
-                        .build())
+                .map(user -> UserMapper.INSTANCE.toSearchedUser(user))
                 .collect(Collectors.toList());
 
         checkIfUserNotSearched(searchedUsers);

--- a/user-service/src/main/java/kr/mybrary/userservice/user/domain/UserServiceImpl.java
+++ b/user-service/src/main/java/kr/mybrary/userservice/user/domain/UserServiceImpl.java
@@ -260,5 +260,22 @@ public class UserServiceImpl implements UserService {
         sourceUser.unfollow(targetUser);
     }
 
+    @Override
+    public SearchServiceResponse searchByNickname(String nickname) {
+        return null;
+//        List<User> users = userRepository.findByNicknameContaining(nickname);
+//        List<SearchUserResponse> searchUserResponses = users.stream()
+//                .map(user -> SearchUserResponse.builder()
+//                        .loginId(user.getLoginId())
+//                        .nickname(user.getNickname())
+//                        .profileImageUrl(user.getProfileImageUrl())
+//                        .build())
+//                .collect(Collectors.toList());
+//
+//        return SearchServiceResponse.builder()
+//                .searchUserResponses(searchUserResponses)
+//                .build();
+    }
+
 
 }

--- a/user-service/src/main/java/kr/mybrary/userservice/user/domain/UserServiceImpl.java
+++ b/user-service/src/main/java/kr/mybrary/userservice/user/domain/UserServiceImpl.java
@@ -16,6 +16,7 @@ import kr.mybrary.userservice.user.domain.exception.io.EmptyFileException;
 import kr.mybrary.userservice.user.domain.exception.profile.ProfileImageFileSizeExceededException;
 import kr.mybrary.userservice.user.domain.exception.profile.ProfileImageUrlNotFoundException;
 import kr.mybrary.userservice.user.domain.exception.user.UserNotFoundException;
+import kr.mybrary.userservice.user.domain.exception.user.UserNotSearchedException;
 import kr.mybrary.userservice.user.domain.storage.StorageService;
 import kr.mybrary.userservice.user.persistence.Role;
 import kr.mybrary.userservice.user.persistence.User;
@@ -262,19 +263,27 @@ public class UserServiceImpl implements UserService {
 
     @Override
     public SearchServiceResponse searchByNickname(String nickname) {
-        return null;
-//        List<User> users = userRepository.findByNicknameContaining(nickname);
-//        List<SearchUserResponse> searchUserResponses = users.stream()
-//                .map(user -> SearchUserResponse.builder()
-//                        .loginId(user.getLoginId())
-//                        .nickname(user.getNickname())
-//                        .profileImageUrl(user.getProfileImageUrl())
-//                        .build())
-//                .collect(Collectors.toList());
-//
-//        return SearchServiceResponse.builder()
-//                .searchUserResponses(searchUserResponses)
-//                .build();
+        List<SearchServiceResponse.SearchedUser> searchedUsers = userRepository.findByNicknameContaining(nickname).stream()
+                .map(user -> SearchServiceResponse.SearchedUser.builder()
+                        .loginId(user.getLoginId())
+                        .nickname(user.getNickname())
+                        .profileImageUrl(user.getProfileImageUrl())
+                        .build())
+                .collect(Collectors.toList());
+
+        checkIfUserNotSearched(searchedUsers);
+
+        SearchServiceResponse serviceResponse = SearchServiceResponse.builder()
+                .searchedUsers(searchedUsers)
+                .build();
+
+        return serviceResponse;
+    }
+
+    private static void checkIfUserNotSearched(List<SearchServiceResponse.SearchedUser> searchedUsers) {
+        if(searchedUsers.isEmpty()) {
+            throw new UserNotSearchedException();
+        }
     }
 
 

--- a/user-service/src/main/java/kr/mybrary/userservice/user/domain/dto/UserMapper.java
+++ b/user-service/src/main/java/kr/mybrary/userservice/user/domain/dto/UserMapper.java
@@ -2,6 +2,7 @@ package kr.mybrary.userservice.user.domain.dto;
 
 import kr.mybrary.userservice.user.domain.dto.request.SignUpServiceRequest;
 import kr.mybrary.userservice.user.domain.dto.response.ProfileServiceResponse;
+import kr.mybrary.userservice.user.domain.dto.response.SearchServiceResponse;
 import kr.mybrary.userservice.user.domain.dto.response.SignUpServiceResponse;
 import kr.mybrary.userservice.user.persistence.User;
 import org.mapstruct.Mapper;
@@ -18,4 +19,6 @@ public interface UserMapper {
     SignUpServiceResponse toSignUpServiceResponse(User user);
 
     ProfileServiceResponse toProfileServiceResponse(User user);
+
+    SearchServiceResponse.SearchedUser toSearchedUser(User user);
 }

--- a/user-service/src/main/java/kr/mybrary/userservice/user/domain/dto/response/SearchServiceResponse.java
+++ b/user-service/src/main/java/kr/mybrary/userservice/user/domain/dto/response/SearchServiceResponse.java
@@ -1,0 +1,22 @@
+package kr.mybrary.userservice.user.domain.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class SearchServiceResponse {
+
+    private List<SearchedUser> searchedUsers;
+
+    @Getter
+    @Builder
+    public static class SearchedUser {
+        private String loginId;
+        private String nickname;
+        private String profileImageUrl;
+    }
+
+}

--- a/user-service/src/main/java/kr/mybrary/userservice/user/domain/exception/user/UserNotSearchedException.java
+++ b/user-service/src/main/java/kr/mybrary/userservice/user/domain/exception/user/UserNotSearchedException.java
@@ -1,0 +1,15 @@
+package kr.mybrary.userservice.user.domain.exception.user;
+
+import kr.mybrary.userservice.global.exception.ApplicationException;
+
+public class UserNotSearchedException extends ApplicationException {
+
+    private final static int STATUS = 404;
+    private final static String ERROR_CODE = "U-07";
+    private final static String ERROR_MESSAGE = "검색된 사용자가 없습니다.";
+
+    public UserNotSearchedException() {
+        super(STATUS, ERROR_CODE, ERROR_MESSAGE);
+    }
+
+}

--- a/user-service/src/main/java/kr/mybrary/userservice/user/persistence/repository/UserRepository.java
+++ b/user-service/src/main/java/kr/mybrary/userservice/user/persistence/repository/UserRepository.java
@@ -4,23 +4,24 @@ import kr.mybrary.userservice.user.persistence.SocialType;
 import kr.mybrary.userservice.user.persistence.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
 
     Optional<User> findByLoginId(String loginId);
+
     Optional<User> findByEmail(String email);
+
     Optional<User> findByNickname(String nickname);
 
     boolean existsByLoginId(String loginId);
+
     boolean existsByEmail(String email);
+
     boolean existsByNickname(String nickname);
 
-    /**
-     * 소셜 타입과 소셜의 식별값으로 회원 찾는 메소드
-     * 정보 제공을 동의한 순간 DB에 저장해야하지만, 아직 추가 정보(사는 도시, 나이 등)를 입력받지 않았으므로
-     * 유저 객체는 DB에 있지만, 추가 정보가 빠진 상태이다.
-     * 따라서 추가 정보를 입력받아 회원 가입을 진행할 때 소셜 타입, 식별자로 해당 회원을 찾기 위한 메소드
-     */
     Optional<User> findBySocialTypeAndSocialId(SocialType socialType, String socialId);
+
+    List<User> findByNicknameContaining(String nickname);
 }

--- a/user-service/src/main/java/kr/mybrary/userservice/user/presentation/UserController.java
+++ b/user-service/src/main/java/kr/mybrary/userservice/user/presentation/UserController.java
@@ -44,16 +44,7 @@ public class UserController {
         );
     }
 
-    /*
-    - Profile API 문서 작성
-        - 프로필 조회: get users/profile
-        - 프로필 수정: put users/profile
-        - 프로필 이미지 조회: get users/profile/image
-        - 프로필 이미지 등록: put users/profile/image
-        - 프로필 이미지 삭제: delete users/profile/image
-     */
-
-    @GetMapping("/profile")
+     @GetMapping("/profile")
     public ResponseEntity<SuccessResponse> getProfile(@RequestHeader("USER-ID") String loginId) {
         ProfileServiceResponse serviceResponse = userService.getProfile(loginId);
 
@@ -111,15 +102,6 @@ public class UserController {
                         serviceResponse)
         );
     }
-
-    /*
-    - Follow API 문서 작성
-        - 팔로워 목록 조회: get users/followers
-        - 팔로잉 목록 조회: get users/followings
-        - 팔로우: post users/follow
-        - 언팔로우: delete users/follow
-        - 언팔로잉: delete users/following
-     */
 
     @GetMapping("/followers")
     public ResponseEntity<SuccessResponse> getFollowers(@RequestHeader("USER-ID") String loginId) {

--- a/user-service/src/main/java/kr/mybrary/userservice/user/presentation/UserController.java
+++ b/user-service/src/main/java/kr/mybrary/userservice/user/presentation/UserController.java
@@ -8,11 +8,7 @@ import kr.mybrary.userservice.user.domain.dto.request.FollowerServiceRequest;
 import kr.mybrary.userservice.user.domain.dto.request.ProfileImageUpdateServiceRequest;
 import kr.mybrary.userservice.user.domain.dto.request.ProfileUpdateServiceRequest;
 import kr.mybrary.userservice.user.domain.dto.request.SignUpServiceRequest;
-import kr.mybrary.userservice.user.domain.dto.response.FollowerServiceResponse;
-import kr.mybrary.userservice.user.domain.dto.response.FollowingServiceResponse;
-import kr.mybrary.userservice.user.domain.dto.response.ProfileImageUrlServiceResponse;
-import kr.mybrary.userservice.user.domain.dto.response.ProfileServiceResponse;
-import kr.mybrary.userservice.user.domain.dto.response.SignUpServiceResponse;
+import kr.mybrary.userservice.user.domain.dto.response.*;
 import kr.mybrary.userservice.user.presentation.dto.request.FollowRequest;
 import kr.mybrary.userservice.user.presentation.dto.request.FollowerRequest;
 import kr.mybrary.userservice.user.presentation.dto.request.ProfileUpdateRequest;
@@ -178,6 +174,16 @@ public class UserController {
 
         return ResponseEntity.ok().body(
                 SuccessResponse.of(HttpStatus.OK.toString(), "사용자를 팔로워 목록에서 삭제했습니다.", null)
+        );
+    }
+
+    @GetMapping("/search")
+    public ResponseEntity<SuccessResponse> searchByNickname(@RequestParam(value = "nickname") String nickname) {
+        SearchServiceResponse serviceResponse = userService.searchByNickname(nickname);
+
+        return ResponseEntity.ok().body(
+                SuccessResponse.of(HttpStatus.OK.toString(), "닉네임으로 사용자를 검색했습니다.",
+                        serviceResponse)
         );
     }
 

--- a/user-service/src/main/java/kr/mybrary/userservice/user/presentation/dto/request/SignUpRequest.java
+++ b/user-service/src/main/java/kr/mybrary/userservice/user/presentation/dto/request/SignUpRequest.java
@@ -17,16 +17,17 @@ public class SignUpRequest {
 
     @NotNull
     @NotBlank(message = "로그인 아이디는 필수입니다.")
+    @Pattern(regexp = "^[A-Za-z0-9_-]{6,}$", message = "로그인 아이디는 6자 이상의 영문, 숫자 구성이어야 합니다. (하이픈과 언더바는 허용)")
     private String loginId;
 
     @NotNull
     @NotBlank(message = "비밀번호는 필수입니다.")
-    @Pattern(regexp = "(?=.*[0-9])(?=.*[a-zA-Z])(?=.*\\W)(?=\\S+$).{8,16}", message = "비밀번호는 8~16자 영문 대 소문자, 숫자, 특수문자를 사용하세요.")
+    @Pattern(regexp = "^(?=.*[0-9])(?=.*[a-zA-Z])(?=.*\\W)(?=\\S+$).{8,16}$", message = "비밀번호는 8~16자 영문, 숫자, 특수문자 구성이어야 합니다.")
     private String password;
 
     @NotNull
     @NotBlank(message = "닉네임은 필수입니다.")
-    @Pattern(regexp = "^[ㄱ-ㅎ가-힣a-zA-Z0-9-_]{2,20}$", message = "닉네임은 특수문자를 제외한 2~20자리여야 합니다.")
+    @Pattern(regexp = "^[ㄱ-ㅎ가-힣a-zA-Z0-9_-]{2,20}$", message = "닉네임은 특수문자를 제외한 2~20자리여야 합니다.")
     private String nickname;
 
     @Email(message = "이메일 형식이 올바르지 않습니다.")

--- a/user-service/src/test/java/kr/mybrary/userservice/user/UserFixture.java
+++ b/user-service/src/test/java/kr/mybrary/userservice/user/UserFixture.java
@@ -33,7 +33,7 @@ public enum UserFixture {
             Collections.emptyList(),
             List.of(Follow.builder().source(User.builder().loginId("followerId").build()).target(User.builder().loginId("followingId").build()).build())),
 
-    USER_WITH_SIMILAR_NICKNAME(1L, "loginId123", "nickname123", "encodedPassword", Role.USER,
+    USER_WITH_SIMILAR_NICKNAME(2L, "loginId123", "nickname123", "encodedPassword", Role.USER,
             "socialId123", SocialType.GOOGLE, "email@mail.com", "introduction", "profileImageUrl",
             Collections.emptyList(), Collections.emptyList());
 

--- a/user-service/src/test/java/kr/mybrary/userservice/user/UserFixture.java
+++ b/user-service/src/test/java/kr/mybrary/userservice/user/UserFixture.java
@@ -33,8 +33,8 @@ public enum UserFixture {
             Collections.emptyList(),
             List.of(Follow.builder().source(User.builder().loginId("followerId").build()).target(User.builder().loginId("followingId").build()).build())),
 
-    USER_WITH_SIMILAR_NICKNAME(1L, "loginId", "nickname123", "encodedPassword", Role.USER,
-            "socialId", SocialType.GOOGLE, "email@mail.com", "introduction", "profileImageUrl",
+    USER_WITH_SIMILAR_NICKNAME(1L, "loginId123", "nickname123", "encodedPassword", Role.USER,
+            "socialId123", SocialType.GOOGLE, "email@mail.com", "introduction", "profileImageUrl",
             Collections.emptyList(), Collections.emptyList());
 
     private final Long id;

--- a/user-service/src/test/java/kr/mybrary/userservice/user/UserFixture.java
+++ b/user-service/src/test/java/kr/mybrary/userservice/user/UserFixture.java
@@ -12,8 +12,8 @@ import java.util.List;
 @AllArgsConstructor
 public enum UserFixture {
 
-    COMMON_USER(1L, "loginId", "nickname", "encodedPassword", Role.USER, "socialId",
-            SocialType.GOOGLE, "email@mail.com", "introduction", "profileImageUrl",
+    COMMON_USER(1L, "loginId", "nickname", "encodedPassword", Role.USER,
+            "socialId", SocialType.GOOGLE, "email@mail.com", "introduction", "profileImageUrl",
             Collections.emptyList(), Collections.emptyList()),
     USER_WITHOUT_PROFILE_IMAGE_URL(1L, "loginId", "nickname", "encodedPassword", Role.USER,
             "socialId", SocialType.GOOGLE, "email@mail.com", "introduction", null,
@@ -31,7 +31,11 @@ public enum UserFixture {
     USER_AS_FOLLOWER(1L, "followerId", "nickname", "encodedPassword", Role.USER,
             "socialId", SocialType.GOOGLE, "email@mail.com", "introduction", "profileImageUrl",
             Collections.emptyList(),
-            List.of(Follow.builder().source(User.builder().loginId("followerId").build()).target(User.builder().loginId("followingId").build()).build()));
+            List.of(Follow.builder().source(User.builder().loginId("followerId").build()).target(User.builder().loginId("followingId").build()).build())),
+
+    USER_WITH_SIMILAR_NICKNAME(1L, "loginId", "nickname123", "encodedPassword", Role.USER,
+            "socialId", SocialType.GOOGLE, "email@mail.com", "introduction", "profileImageUrl",
+            Collections.emptyList(), Collections.emptyList());
 
     private final Long id;
     private final String loginId;

--- a/user-service/src/test/java/kr/mybrary/userservice/user/domain/dto/UserMapperTest.java
+++ b/user-service/src/test/java/kr/mybrary/userservice/user/domain/dto/UserMapperTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import kr.mybrary.userservice.user.UserFixture;
 import kr.mybrary.userservice.user.domain.dto.request.SignUpServiceRequest;
 import kr.mybrary.userservice.user.domain.dto.response.ProfileServiceResponse;
+import kr.mybrary.userservice.user.domain.dto.response.SearchServiceResponse;
 import kr.mybrary.userservice.user.domain.dto.response.SignUpServiceResponse;
 import kr.mybrary.userservice.user.persistence.User;
 import org.junit.jupiter.api.DisplayName;
@@ -67,6 +68,23 @@ class UserMapperTest {
             () -> assertEquals(user.getNickname(), serviceResponse.getNickname()),
             () -> assertEquals(user.getProfileImageUrl(), serviceResponse.getProfileImageUrl()),
             () -> assertEquals(user.getIntroduction(), serviceResponse.getIntroduction())
+        );
+    }
+
+    @Test
+    @DisplayName("User 엔티티를 검색된 사용자 DTO로 변환한다.")
+    void toSearchedUser() {
+        // given
+        User user = UserFixture.COMMON_USER.getUser();
+
+        // when
+        SearchServiceResponse.SearchedUser searchedUser = UserMapper.INSTANCE.toSearchedUser(user);
+
+        // then
+        assertAll(
+            () -> assertEquals(user.getLoginId(), searchedUser.getLoginId()),
+            () -> assertEquals(user.getNickname(), searchedUser.getNickname()),
+            () -> assertEquals(user.getProfileImageUrl(), searchedUser.getProfileImageUrl())
         );
     }
 }

--- a/user-service/src/test/java/kr/mybrary/userservice/user/persistence/repository/UserRepositoryTest.java
+++ b/user-service/src/test/java/kr/mybrary/userservice/user/persistence/repository/UserRepositoryTest.java
@@ -3,6 +3,7 @@ package kr.mybrary.userservice.user.persistence.repository;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
+import java.util.List;
 import java.util.Optional;
 import kr.mybrary.userservice.user.UserFixture;
 import kr.mybrary.userservice.user.persistence.User;
@@ -127,6 +128,26 @@ class UserRepositoryTest {
             () -> assertThat(foundUser.get().getId()).isEqualTo(savedUser.getId()),
             () -> assertThat(foundUser.get().getSocialType()).isEqualTo(savedUser.getSocialType()),
             () -> assertThat(foundUser.get().getSocialId()).isEqualTo(savedUser.getSocialId())
+        );
+    }
+
+    @Test
+    @DisplayName("닉네임에 해당 문자열을 포함하는 사용자를 가져온다.")
+    void findByNicknameContaining() {
+        // given
+        User savedUser = userRepository.save(UserFixture.COMMON_USER.getUser());
+        User savedUser2 = userRepository.save(UserFixture.USER_WITH_SIMILAR_NICKNAME.getUser());
+
+        // when
+        List<User> foundUser = userRepository.findByNicknameContaining(savedUser.getNickname());
+
+        // then
+        assertAll(
+            () -> assertThat(foundUser).hasSize(2),
+            () -> assertThat(foundUser.get(0).getId()).isEqualTo(savedUser.getId()),
+            () -> assertThat(foundUser.get(0).getNickname()).contains(savedUser.getNickname()),
+            () -> assertThat(foundUser.get(1).getId()).isEqualTo(savedUser2.getId()),
+            () -> assertThat(foundUser.get(1).getNickname()).contains(savedUser.getNickname())
         );
     }
 }

--- a/user-service/src/test/java/kr/mybrary/userservice/user/presentation/UserControllerTest.java
+++ b/user-service/src/test/java/kr/mybrary/userservice/user/presentation/UserControllerTest.java
@@ -827,8 +827,7 @@ class UserControllerTest {
                                 .build()
                 )).build();
 
-        given(userService.searchByNickname(any()))
-                .willReturn(searchServiceResponse);
+        given(userService.searchByNickname(any())).willReturn(searchServiceResponse);
 
         // when
         ResultActions actions = mockMvc.perform(

--- a/user-service/src/test/java/kr/mybrary/userservice/user/presentation/dto/request/ProfileUpdateRequestValidationTest.java
+++ b/user-service/src/test/java/kr/mybrary/userservice/user/presentation/dto/request/ProfileUpdateRequestValidationTest.java
@@ -1,0 +1,70 @@
+package kr.mybrary.userservice.user.presentation.dto.request;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ProfileUpdateRequestValidationTest {
+
+    private static Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+
+    @DisplayName("닉네임은 필수이다.")
+    @Test
+    void profileUpdateValidationTest() {
+        // given
+        ProfileUpdateRequest profileUpdateRequest = ProfileUpdateRequest.builder()
+                .nickname(null)
+                .build();
+
+        // when
+        Set<ConstraintViolation<ProfileUpdateRequest>> constraintViolations = validator.validate(profileUpdateRequest);
+
+        // then
+        assertThat(constraintViolations)
+                .extracting(ConstraintViolation::getMessage)
+                .containsOnly("닉네임은 필수입니다.", "널이어서는 안됩니다");
+    }
+
+    @DisplayName("닉네임은 특수문자를 제외한 2~20자리여야 한다.")
+    @Test
+    void profileUpdateValidationTest2() {
+        // given
+        ProfileUpdateRequest profileUpdateRequest = ProfileUpdateRequest.builder()
+                .nickname("닉네임##")
+                .build();
+
+        // when
+        Set<ConstraintViolation<ProfileUpdateRequest>> constraintViolations = validator.validate(profileUpdateRequest);
+
+        // then
+        assertThat(constraintViolations)
+                .extracting(ConstraintViolation::getMessage)
+                .containsOnly("닉네임은 특수문자를 제외한 2~20자리여야 합니다.");
+    }
+
+    @DisplayName("소개는 100자 이내로 작성해야 한다.")
+    @Test
+    void profileUpdateValidationTest3() {
+        // given
+        ProfileUpdateRequest profileUpdateRequest = ProfileUpdateRequest.builder()
+                .nickname("nickname")
+                .introduction("############################################################" +
+                        "############################################################")
+                .build();
+
+        // when
+        Set<ConstraintViolation<ProfileUpdateRequest>> constraintViolations = validator.validate(profileUpdateRequest);
+
+        // then
+        assertThat(constraintViolations)
+                .extracting(ConstraintViolation::getMessage)
+                .containsOnly("소개는 100자 이내로 작성해주세요.");
+    }
+
+}

--- a/user-service/src/test/java/kr/mybrary/userservice/user/presentation/dto/request/ProfileUpdateRequestValidationTest.java
+++ b/user-service/src/test/java/kr/mybrary/userservice/user/presentation/dto/request/ProfileUpdateRequestValidationTest.java
@@ -6,6 +6,7 @@ import jakarta.validation.Validator;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import java.util.Random;
 import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -54,8 +55,7 @@ class ProfileUpdateRequestValidationTest {
         // given
         ProfileUpdateRequest profileUpdateRequest = ProfileUpdateRequest.builder()
                 .nickname("nickname")
-                .introduction("############################################################" +
-                        "############################################################")
+                .introduction(generateRandomString(101))
                 .build();
 
         // when
@@ -65,6 +65,15 @@ class ProfileUpdateRequestValidationTest {
         assertThat(constraintViolations)
                 .extracting(ConstraintViolation::getMessage)
                 .containsOnly("소개는 100자 이내로 작성해주세요.");
+    }
+
+    private String generateRandomString(int targetLength) {
+        Random random = new Random();
+        StringBuilder buffer = new StringBuilder(targetLength);
+        for (int i = 0; i < targetLength; i++) {
+            buffer.append((char) ('a' + random.nextInt('z' - 'a' + 1)));
+        }
+        return buffer.toString();
     }
 
 }

--- a/user-service/src/test/java/kr/mybrary/userservice/user/presentation/dto/request/SignUpRequestValidationTest.java
+++ b/user-service/src/test/java/kr/mybrary/userservice/user/presentation/dto/request/SignUpRequestValidationTest.java
@@ -1,0 +1,161 @@
+package kr.mybrary.userservice.user.presentation.dto.request;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SignUpRequestValidationTest {
+
+    private static Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+    private static final String VALID_LOGIN_ID = "loginId";
+    private static final String VALID_PASSWORD = "password123!";
+    private static final String VALID_NICKNAME = "nickname";
+    private static final String VALID_EMAIL = "email@mail.com";
+
+    @DisplayName("로그인 아이디는 필수이다.")
+    @Test
+    void signUpValidationTest() {
+        // given
+        SignUpRequest signUpRequest = SignUpRequest.builder()
+                .loginId(null)
+                .email(VALID_EMAIL)
+                .password(VALID_PASSWORD)
+                .nickname(VALID_NICKNAME)
+                .build();
+
+        // when
+        Set<ConstraintViolation<SignUpRequest>> constraintViolations = validator.validate(signUpRequest);
+
+        // then
+        assertThat(constraintViolations)
+                .extracting(ConstraintViolation::getMessage)
+                .containsOnly("로그인 아이디는 필수입니다.", "널이어서는 안됩니다");
+    }
+
+    @DisplayName("로그인 아이디는 6자 이상의 영문, 숫자 구성이어야 한다 (하이픈과 언더바는 허용)")
+    @Test
+    void signUpValidationTest2() {
+        // given
+        SignUpRequest signUpRequest = SignUpRequest.builder()
+                .loginId("로그인아이디##")
+                .email(VALID_EMAIL)
+                .password(VALID_PASSWORD)
+                .nickname(VALID_NICKNAME)
+                .build();
+
+        // when
+        Set<ConstraintViolation<SignUpRequest>> constraintViolations = validator.validate(signUpRequest);
+
+        // then
+        assertThat(constraintViolations)
+                .extracting(ConstraintViolation::getMessage)
+                .containsOnly("로그인 아이디는 6자 이상의 영문, 숫자 구성이어야 합니다. (하이픈과 언더바는 허용)");
+    }
+
+    @DisplayName("비밀번호는 필수이다.")
+    @Test
+    void signUpValidationTest3() {
+        // given
+        SignUpRequest signUpRequest = SignUpRequest.builder()
+                .loginId(VALID_LOGIN_ID)
+                .email(VALID_EMAIL)
+                .password(null)
+                .nickname(VALID_NICKNAME)
+                .build();
+
+        // when
+        Set<ConstraintViolation<SignUpRequest>> constraintViolations = validator.validate(signUpRequest);
+
+        // then
+        assertThat(constraintViolations)
+                .extracting(ConstraintViolation::getMessage)
+                .containsOnly("비밀번호는 필수입니다.", "널이어서는 안됩니다");
+    }
+
+    @DisplayName("비밀번호는 8~16자 영문, 숫자, 특수문자 구성이어야 한다.")
+    @Test
+    void signUpValidationTest4() {
+        // given
+        SignUpRequest signUpRequest = SignUpRequest.builder()
+                .loginId(VALID_LOGIN_ID)
+                .email(VALID_EMAIL)
+                .password("password 123!")
+                .nickname(VALID_NICKNAME)
+                .build();
+
+        // when
+        Set<ConstraintViolation<SignUpRequest>> constraintViolations = validator.validate(signUpRequest);
+
+        // then
+        assertThat(constraintViolations)
+                .extracting(ConstraintViolation::getMessage)
+                .containsOnly("비밀번호는 8~16자 영문, 숫자, 특수문자 구성이어야 합니다.");
+    }
+
+    @DisplayName("닉네임은 필수이다.")
+    @Test
+    void signUpValidationTest5() {
+        // given
+        SignUpRequest signUpRequest = SignUpRequest.builder()
+                .loginId(VALID_LOGIN_ID)
+                .email(VALID_EMAIL)
+                .password(VALID_PASSWORD)
+                .nickname(null)
+                .build();
+
+        // when
+        Set<ConstraintViolation<SignUpRequest>> constraintViolations = validator.validate(signUpRequest);
+
+        // then
+        assertThat(constraintViolations)
+                .extracting(ConstraintViolation::getMessage)
+                .containsOnly("닉네임은 필수입니다.", "널이어서는 안됩니다");
+    }
+
+    @DisplayName("닉네임은 특수문자를 제외한 2~20자리여야 한다.")
+    @Test
+    void signUpValidationTest6() {
+        // given
+        SignUpRequest signUpRequest = SignUpRequest.builder()
+                .loginId(VALID_LOGIN_ID)
+                .email(VALID_EMAIL)
+                .password(VALID_PASSWORD)
+                .nickname("~")
+                .build();
+
+        // when
+        Set<ConstraintViolation<SignUpRequest>> constraintViolations = validator.validate(signUpRequest);
+
+        // then
+        assertThat(constraintViolations)
+                .extracting(ConstraintViolation::getMessage)
+                .containsOnly("닉네임은 특수문자를 제외한 2~20자리여야 합니다.");
+    }
+
+    @DisplayName("이메일은 이메일 형식에 맞아야 한다.")
+    @Test
+    void signUpValidationTest7() {
+        // given
+        SignUpRequest signUpRequest = SignUpRequest.builder()
+                .loginId(VALID_LOGIN_ID)
+                .email("invalid-email")
+                .password(VALID_PASSWORD)
+                .nickname(VALID_NICKNAME)
+                .build();
+
+        // when
+        Set<ConstraintViolation<SignUpRequest>> constraintViolations = validator.validate(signUpRequest);
+
+        // then
+        assertThat(constraintViolations)
+                .extracting(ConstraintViolation::getMessage)
+                .containsOnly("이메일 형식이 올바르지 않습니다.");
+    }
+
+}


### PR DESCRIPTION
## 🧑‍💻 작업 사항

### 사용자 검색 API 생성
- 요청
  - GET api/v1/users/search?nickname={검색할 닉네임}
- 응답
  - {로그인 아이디, 닉네임, 프로필 이미지 url}
  - 검색된 사용자가 없다면 예외 발생

### MethodArgumentNotValidException 핸들러 생성
- Validator 에서 발생한 예외 처리 (예외 원인들을 모두 메시지로 반환)
- 예) 닉네임, 비밀번호 형식이 맞지 않는 경우
<img width="1025" alt="image" src="https://github.com/SWM-IDLE/mybrary/assets/78717113/a98c3ee9-7bbd-4368-adb0-2404fe1b307b">


### Validator 테스트 작성
- SignUpRequest Validation 테스트
<img width="472" alt="image" src="https://github.com/SWM-IDLE/mybrary/assets/78717113/c79db2ae-3b6d-410d-b28c-4618153a8daf">

- ProfileUpdateRequest Validation 테스트
<img width="474" alt="image" src="https://github.com/SWM-IDLE/mybrary/assets/78717113/b8901d6a-3158-46d6-9d94-dfdfc35fb7f3">

- 추후 다른 요청 DTO 에도 Validator 설정 및 Validation 테스트 진행 예정

### 사용자 검색 API 테스트
- 저장된 회원 닉네임이 nickname, nickname123, nick, 닉네임, hellohello, hihihihi 일 때, nickname 으로 회원 검색 시 nickname, nickname123 회원 반환
<img width="1490" alt="image" src="https://github.com/SWM-IDLE/mybrary/assets/78717113/20408378-8af5-45b7-ab02-2f85e98b34ea">

- 검색된 사용자가 없으면 예외 발생
<img width="1490" alt="image" src="https://github.com/SWM-IDLE/mybrary/assets/78717113/710ccd71-813d-46dc-b544-10909386cca0">

<br><br>

## 🔗 링크

<br><br>

## 🐰 시급한 정도
🐢 천천히 : 급하지 않습니다.

<br><br>

## 📖 참고 사항
- 사용자 검색 결과에 리턴할 프로필 이미지는 썸네일용 작은 이미지여도 될 것 같습니다. 다음에 이미지 압축해서 썸네일용 프로필 이미지를 따로 저장하는 것을 고려해보겠습니다.
- 이미지 url로 s3 오브젝트 url을 리턴하고 있는데, 버킷을 private으로 보호하기 위해 자체 이미지 호출 api를 생성하는 것을 고려해보겠습니다.
