### PR TITLE
[IDLE-167] feat: openapi rest docs github actions 연동

### DIFF
--- a/backend/book-service/.github/workflows/rest-docs.yml
+++ b/backend/book-service/.github/workflows/rest-docs.yml
@@ -1,0 +1,23 @@
+name: 'rest docs'
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Openapi3
+        run: |
+          ./gradlew openapi3 --no-build-cache
+      - name: Upload OpenApi Specification to S3
+        run: |
+          aws s3 cp src/main/resources/static/docs/book-service.json s3://mybrary-swagger-ui/docs/book-service.json
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.OPEN_API_GIT_ACTIONS_ACCESS_KEY }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.OPEN_API_GIT_ACTIONS_SECRET_KEY }}


### PR DESCRIPTION
## 🧑‍💻 작업 사항

- book-service 에서 pull-request 혹은 push가 될 때, ./gradlew openapi3를 실행하여 자동으로 restdocs 파일을 s3로 올리도록 github actions 파일 생성
- 테스트 ..
- 잘 안될 수도 있어요.. 현재 master가 아닌 다른 브랜치에서 작업하여 반영이 안된 것으로 보아 리베이스합니다!

<br><br>

## 🔗 링크

<!-- 관련된 대화가 이루어진 슬랙 링크 혹은 피그마 링크를 첨부. -->
<!-- - [프레이머](https://framer.com/projects/2--gSDcZoNKqU6dqCUQUYQe-53rEr?node=tQMWSSKqy)  -->

<br><br>

## 🐰 시급한 정도

🐢 천천히 : 급하지 않습니다.

<br><br>

## 📖 참고 사항

https://tech.trenbe.com/2023/01/30/%EB%A7%88%EC%9D%B4%ED%81%AC%EB%A1%9C-%EC%84%9C%EB%B9%84%EC%8A%A4-%ED%99%98%EA%B2%BD%EC%97%90%EC%84%9C-%ED%86%B5%ED%95%A9%EB%90%9C-API-%EB%AC%B8%EC%84%9C-%EC%84%9C%EB%B2%84-%EA%B5%AC%EC%B6%95%ED%95%98%EA%B8%B0.html
<!-- 공유할 내용, 레퍼런스, 추가로 발생할 것으로 예상되는 이슈, 스크린샷 등을 넣어 주세요.  -->
<!-- 변경사항이 큰 경우 집중해야 할 부분, 또는 불안해서 봐주었으면 하는 부분 등 -->
