### PR TITLE
[IDLE-195] feat: 사용자 관심사 등록 기능 개발

### DIFF
--- a/backend/user-service/src/main/java/kr/mybrary/userservice/interest/domain/InterestService.java
+++ b/backend/user-service/src/main/java/kr/mybrary/userservice/interest/domain/InterestService.java
@@ -1,5 +1,6 @@
 package kr.mybrary.userservice.interest.domain;
 
+import kr.mybrary.userservice.interest.domain.dto.request.UserInterestUpdateServiceRequest;
 import kr.mybrary.userservice.interest.domain.dto.response.InterestCategoryServiceResponse;
 import kr.mybrary.userservice.interest.domain.dto.response.UserInterestServiceResponse;
 
@@ -8,5 +9,7 @@ public interface InterestService {
     InterestCategoryServiceResponse getInterestCategories();
 
     UserInterestServiceResponse getUserInterests(String loginId);
+
+    UserInterestServiceResponse updateUserInterests(UserInterestUpdateServiceRequest request);
 
 }

--- a/backend/user-service/src/main/java/kr/mybrary/userservice/interest/domain/InterestServiceImpl.java
+++ b/backend/user-service/src/main/java/kr/mybrary/userservice/interest/domain/InterestServiceImpl.java
@@ -77,8 +77,7 @@ public class InterestServiceImpl implements InterestService {
         checkDuplicatedUserInterestUpdateRequest(request);
 
         User user = userService.getUserResponse(request.getLoginId()).getUser();
-        userInterestRepository.deleteAllByUser(user);
-        userInterestRepository.flush();
+        deleteOriginalUserInterests(user);
         saveRequestedUserInterests(request.getInterestIds(), user);
         return getUserInterests(request.getLoginId());
     }
@@ -93,6 +92,11 @@ public class InterestServiceImpl implements InterestService {
         if(request.getInterestIds().stream().distinct().count() != request.getInterestIds().size()) {
             throw new DuplicateUserInterestUpdateRequestException();
         }
+    }
+
+    private void deleteOriginalUserInterests(User user) {
+        userInterestRepository.deleteAllByUser(user);
+        userInterestRepository.flush();
     }
 
     private void saveRequestedUserInterests(List<Long> interestIds, User user) {

--- a/backend/user-service/src/main/java/kr/mybrary/userservice/interest/domain/InterestServiceImpl.java
+++ b/backend/user-service/src/main/java/kr/mybrary/userservice/interest/domain/InterestServiceImpl.java
@@ -3,14 +3,21 @@ package kr.mybrary.userservice.interest.domain;
 import jakarta.validation.constraints.NotNull;
 import kr.mybrary.userservice.interest.domain.dto.InterestCategoryMapper;
 import kr.mybrary.userservice.interest.domain.dto.UserInterestMapper;
+import kr.mybrary.userservice.interest.domain.dto.request.UserInterestUpdateServiceRequest;
 import kr.mybrary.userservice.interest.domain.dto.response.InterestCategoryResponse;
 import kr.mybrary.userservice.interest.domain.dto.response.InterestCategoryServiceResponse;
 import kr.mybrary.userservice.interest.domain.dto.response.InterestResponse;
 import kr.mybrary.userservice.interest.domain.dto.response.UserInterestServiceResponse;
+import kr.mybrary.userservice.interest.domain.exception.DuplicateUserInterestUpdateRequestException;
+import kr.mybrary.userservice.interest.domain.exception.InterestNotFoundException;
+import kr.mybrary.userservice.interest.domain.exception.UserInterestUpdateRequestSizeExceededException;
+import kr.mybrary.userservice.interest.persistence.Interest;
 import kr.mybrary.userservice.interest.persistence.UserInterest;
 import kr.mybrary.userservice.interest.persistence.repository.InterestCategoryRepository;
+import kr.mybrary.userservice.interest.persistence.repository.InterestRepository;
 import kr.mybrary.userservice.interest.persistence.repository.UserInterestRepository;
 import kr.mybrary.userservice.user.domain.UserService;
+import kr.mybrary.userservice.user.persistence.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -24,6 +31,7 @@ public class InterestServiceImpl implements InterestService {
 
     private final InterestCategoryRepository interestCategoryRepository;
     private final UserInterestRepository userInterestRepository;
+    private final InterestRepository interestRepository;
     private final UserService userService;
 
     @Override
@@ -61,6 +69,43 @@ public class InterestServiceImpl implements InterestService {
         return userInterests.stream()
                 .map(UserInterestMapper.INSTANCE::toInterestResponse)
                 .toList();
+    }
+
+    @Override
+    public UserInterestServiceResponse updateUserInterests(UserInterestUpdateServiceRequest request) {
+        checkUserInterestUpdateRequestSize(request);
+        checkDuplicatedUserInterestUpdateRequest(request);
+
+        User user = userService.getUserResponse(request.getLoginId()).getUser();
+        userInterestRepository.deleteAllByUser(user);
+        userInterestRepository.flush();
+        saveRequestedUserInterests(request.getInterestIds(), user);
+        return getUserInterests(request.getLoginId());
+    }
+
+    private void checkUserInterestUpdateRequestSize(UserInterestUpdateServiceRequest request) {
+        if(request.getInterestIds().size() > 3) {
+            throw new UserInterestUpdateRequestSizeExceededException();
+        }
+    }
+
+    private void checkDuplicatedUserInterestUpdateRequest(UserInterestUpdateServiceRequest request) {
+        if(request.getInterestIds().stream().distinct().count() != request.getInterestIds().size()) {
+            throw new DuplicateUserInterestUpdateRequestException();
+        }
+    }
+
+    private void saveRequestedUserInterests(List<Long> interestIds, User user) {
+        interestIds.stream()
+                .map(interestId -> UserInterest.builder()
+                        .user(user)
+                        .interest(getInterest(interestId))
+                        .build())
+                .forEach(userInterestRepository::save);
+    }
+
+    private Interest getInterest(Long interestId) {
+        return interestRepository.findById(interestId).orElseThrow(InterestNotFoundException::new);
     }
 
 }

--- a/backend/user-service/src/main/java/kr/mybrary/userservice/interest/domain/dto/request/UserInterestUpdateServiceRequest.java
+++ b/backend/user-service/src/main/java/kr/mybrary/userservice/interest/domain/dto/request/UserInterestUpdateServiceRequest.java
@@ -1,0 +1,23 @@
+package kr.mybrary.userservice.interest.domain.dto.request;
+
+import kr.mybrary.userservice.interest.presentation.dto.request.UserInterestUpdateRequest;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class UserInterestUpdateServiceRequest {
+
+    private String loginId;
+    private List<Long> interestIds;
+
+    public static UserInterestUpdateServiceRequest of(String loginId, List<UserInterestUpdateRequest.InterestRequest> interestRequests) {
+        return UserInterestUpdateServiceRequest.builder()
+                .loginId(loginId)
+                .interestIds(interestRequests.stream().map(UserInterestUpdateRequest.InterestRequest::getId).toList())
+                .build();
+    }
+
+}

--- a/backend/user-service/src/main/java/kr/mybrary/userservice/interest/domain/exception/DuplicateUserInterestUpdateRequestException.java
+++ b/backend/user-service/src/main/java/kr/mybrary/userservice/interest/domain/exception/DuplicateUserInterestUpdateRequestException.java
@@ -6,7 +6,7 @@ public class DuplicateUserInterestUpdateRequestException extends ApplicationExce
 
     private final static int STATUS = 400;
     private final static String ERROR_CODE = "I-03";
-    private final static String ERROR_MESSAGE = "관심사는 중복해서 선택할 수 없습니다.";
+    private final static String ERROR_MESSAGE = "관심사는 중복해서 설정할 수 없습니다.";
 
     public DuplicateUserInterestUpdateRequestException() {
         super(STATUS, ERROR_CODE, ERROR_MESSAGE);

--- a/backend/user-service/src/main/java/kr/mybrary/userservice/interest/domain/exception/DuplicateUserInterestUpdateRequestException.java
+++ b/backend/user-service/src/main/java/kr/mybrary/userservice/interest/domain/exception/DuplicateUserInterestUpdateRequestException.java
@@ -1,0 +1,15 @@
+package kr.mybrary.userservice.interest.domain.exception;
+
+import kr.mybrary.userservice.global.exception.ApplicationException;
+
+public class DuplicateUserInterestUpdateRequestException extends ApplicationException {
+
+    private final static int STATUS = 400;
+    private final static String ERROR_CODE = "I-03";
+    private final static String ERROR_MESSAGE = "관심사는 중복해서 선택할 수 없습니다.";
+
+    public DuplicateUserInterestUpdateRequestException() {
+        super(STATUS, ERROR_CODE, ERROR_MESSAGE);
+    }
+
+}

--- a/backend/user-service/src/main/java/kr/mybrary/userservice/interest/domain/exception/InterestNotFoundException.java
+++ b/backend/user-service/src/main/java/kr/mybrary/userservice/interest/domain/exception/InterestNotFoundException.java
@@ -1,0 +1,15 @@
+package kr.mybrary.userservice.interest.domain.exception;
+
+import kr.mybrary.userservice.global.exception.ApplicationException;
+
+public class InterestNotFoundException extends ApplicationException {
+
+    private final static int STATUS = 404;
+    private final static String ERROR_CODE = "I-01";
+    private final static String ERROR_MESSAGE = "관심사를 찾을 수 없습니다.";
+
+    public InterestNotFoundException() {
+        super(STATUS, ERROR_CODE, ERROR_MESSAGE);
+    }
+
+}

--- a/backend/user-service/src/main/java/kr/mybrary/userservice/interest/domain/exception/UserInterestUpdateRequestSizeExceededException.java
+++ b/backend/user-service/src/main/java/kr/mybrary/userservice/interest/domain/exception/UserInterestUpdateRequestSizeExceededException.java
@@ -6,7 +6,7 @@ public class UserInterestUpdateRequestSizeExceededException extends ApplicationE
 
     private final static int STATUS = 400;
     private final static String ERROR_CODE = "I-02";
-    private final static String ERROR_MESSAGE = "관심사는 최대 3개까지 선택할 수 있습니다.";
+    private final static String ERROR_MESSAGE = "관심사는 최대 3개까지 설정할 수 있습니다.";
 
     public UserInterestUpdateRequestSizeExceededException() {
         super(STATUS, ERROR_CODE, ERROR_MESSAGE);

--- a/backend/user-service/src/main/java/kr/mybrary/userservice/interest/domain/exception/UserInterestUpdateRequestSizeExceededException.java
+++ b/backend/user-service/src/main/java/kr/mybrary/userservice/interest/domain/exception/UserInterestUpdateRequestSizeExceededException.java
@@ -1,0 +1,15 @@
+package kr.mybrary.userservice.interest.domain.exception;
+
+import kr.mybrary.userservice.global.exception.ApplicationException;
+
+public class UserInterestUpdateRequestSizeExceededException extends ApplicationException {
+
+    private final static int STATUS = 400;
+    private final static String ERROR_CODE = "I-02";
+    private final static String ERROR_MESSAGE = "관심사는 최대 3개까지 선택할 수 있습니다.";
+
+    public UserInterestUpdateRequestSizeExceededException() {
+        super(STATUS, ERROR_CODE, ERROR_MESSAGE);
+    }
+
+}

--- a/backend/user-service/src/main/java/kr/mybrary/userservice/interest/persistence/UserInterest.java
+++ b/backend/user-service/src/main/java/kr/mybrary/userservice/interest/persistence/UserInterest.java
@@ -6,7 +6,14 @@ import kr.mybrary.userservice.user.persistence.User;
 import lombok.*;
 
 @Entity
-@Table(name = "users_interests")
+@Table(name = "users_interests",
+    uniqueConstraints = {
+        @UniqueConstraint(
+                name = "uk_users_interests_user_id_interest_id",
+                columnNames = {"user_id", "interest_id"}
+        )
+    }
+)
 @Getter
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/backend/user-service/src/main/java/kr/mybrary/userservice/interest/persistence/repository/UserInterestRepository.java
+++ b/backend/user-service/src/main/java/kr/mybrary/userservice/interest/persistence/repository/UserInterestRepository.java
@@ -13,4 +13,6 @@ public interface UserInterestRepository extends JpaRepository<UserInterest, Long
     @Query("SELECT distinct ui FROM UserInterest ui join fetch ui.interest WHERE ui.user = :user")
     List<UserInterest> findAllByUserWithInterestUsingFetchJoin(@Param("user") User user);
 
+    void deleteAllByUser(User user);
+
 }

--- a/backend/user-service/src/main/java/kr/mybrary/userservice/interest/presentation/InterestController.java
+++ b/backend/user-service/src/main/java/kr/mybrary/userservice/interest/presentation/InterestController.java
@@ -2,6 +2,8 @@ package kr.mybrary.userservice.interest.presentation;
 
 import kr.mybrary.userservice.global.dto.response.SuccessResponse;
 import kr.mybrary.userservice.interest.domain.InterestService;
+import kr.mybrary.userservice.interest.domain.dto.request.UserInterestUpdateServiceRequest;
+import kr.mybrary.userservice.interest.presentation.dto.request.UserInterestUpdateRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -17,14 +19,26 @@ public class InterestController {
     @GetMapping("/interest-categories")
     public ResponseEntity<SuccessResponse> getInterestCategories() {
         return ResponseEntity.ok().body(
-                SuccessResponse.of(HttpStatus.OK.toString(), "카테고리별 관심사를 모두 조회했습니다.", interestService.getInterestCategories())
+                SuccessResponse.of(HttpStatus.OK.toString(), "카테고리별 관심사를 모두 조회했습니다.",
+                        interestService.getInterestCategories())
         );
     }
 
     @GetMapping("/users/{userId}/interests")
     public ResponseEntity<SuccessResponse> getUserInterests(@PathVariable("userId") String loginId) {
         return ResponseEntity.ok().body(
-                SuccessResponse.of(HttpStatus.OK.toString(), "사용자의 관심사를 모두 조회했습니다.", interestService.getUserInterests(loginId))
+                SuccessResponse.of(HttpStatus.OK.toString(), "사용자의 관심사를 모두 조회했습니다.",
+                        interestService.getUserInterests(loginId))
+        );
+    }
+
+    @PutMapping("/users/{userId}/interests")
+    public ResponseEntity<SuccessResponse> updateUserInterests(@PathVariable("userId") String loginId,
+                                                               @RequestBody UserInterestUpdateRequest request) {
+        return ResponseEntity.ok().body(
+                SuccessResponse.of(HttpStatus.OK.toString(), "사용자의 관심사를 수정했습니다.",
+                        interestService.updateUserInterests(
+                                UserInterestUpdateServiceRequest.of(loginId, request.getInterestRequests())))
         );
     }
 

--- a/backend/user-service/src/main/java/kr/mybrary/userservice/interest/presentation/dto/request/UserInterestUpdateRequest.java
+++ b/backend/user-service/src/main/java/kr/mybrary/userservice/interest/presentation/dto/request/UserInterestUpdateRequest.java
@@ -1,0 +1,25 @@
+package kr.mybrary.userservice.interest.presentation.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class UserInterestUpdateRequest {
+
+    private List<InterestRequest> interestRequests;
+
+    @Getter
+    @Builder
+    public static class InterestRequest {
+        private Long id;
+        private String name;
+    }
+
+}

--- a/backend/user-service/src/test/java/kr/mybrary/userservice/interest/persistence/repository/UserInterestRepositoryTest.java
+++ b/backend/user-service/src/test/java/kr/mybrary/userservice/interest/persistence/repository/UserInterestRepositoryTest.java
@@ -69,4 +69,31 @@ class UserInterestRepositoryTest {
                 () -> assertThat(foundUserInterests.get(1).getInterest()).isNotInstanceOf(HibernateProxy.class)
         );
     }
+
+    @Test
+    @DisplayName("해당 사용자의 관심사를 모두 삭제한다.")
+    void deleteAllByUser() {
+        // given
+        User savedUser = userRepository.save(UserFixture.COMMON_USER.getUser());
+        Interest savedInterest1 =  interestRepository.save(InterestFixture.DOMESTIC_NOVEL.getInterest());
+        Interest savedInterest2 =  interestRepository.save(InterestFixture.FOREIGN_NOVEL.getInterest());
+
+        userInterestRepository.save(UserInterest.builder()
+                .user(savedUser)
+                .interest(savedInterest1)
+                .build());
+        userInterestRepository.save(UserInterest.builder()
+                .user(savedUser)
+                .interest(savedInterest2)
+                .build());
+
+        entityManager.flush();
+        entityManager.clear();
+
+        // when
+        userInterestRepository.deleteAllByUser(savedUser);
+
+        // then
+        assertThat(userInterestRepository.findAll().size()).isEqualTo(0);
+    }
 }


### PR DESCRIPTION
## 🧑‍💻 작업 사항

### 사용자 관심사 수정 API
- 요청) PUT api/v1/users/{userId}/interests
```
{
    "interestRequests": [
      {
        "id": 1,
        "name": "국내소설"
      },
      {
        "id": 2,
        "name": "외국소설"
      }
    ]
}
```

- 응답
```
{
  "status": "200 OK",
  "message": "사용자의 관심사를 수정했습니다.",
  "data": {
    "loginId": "loginId",
    "userInterests": [
      {
        "id": 1,
        "name": "국내소설"
      },
      {
        "id": 2,
        "name": "외국소설"
      }
    ]
  }
}
```
- 삭제 API는 따로 없습니다. 요청 시 interestRequests를 빈 배열로 보내주시면 삭제 처리 됩니다!

### UserInterest 엔티티 Unique Constraint 추가
- 사용자에게 중복된 관심사가 저장될 수 없도록 user_id와 interest_id를 묶어 unique 제약 조건을 걸어주었습니다.
```
@Table(name = "users_interests",
    uniqueConstraints = {
        @UniqueConstraint(
                name = "uk_users_interests_user_id_interest_id",
                columnNames = {"user_id", "interest_id"}
        )
    }
)
```


### 관심사 등록 시 발생 예외 세분화
- 요청된 사용자 찾을 수 없음 -> UserNotFoundException
- 요청된 관심사 찾을 수 없음 -> InterestNotFoundException
- 관심사 4개 이상 요청됨 -> UserInterestUpdateRequestSizeExceededException
- 중복된 관심사 존재함 -> DuplicateUserInterestUpdateRequestException

### 관심사 업데이트 기능 동작 방식
```
@Override
    public UserInterestServiceResponse updateUserInterests(UserInterestUpdateServiceRequest request) {
        checkUserInterestUpdateRequestSize(request);
        checkDuplicatedUserInterestUpdateRequest(request);

        User user = userService.getUserResponse(request.getLoginId()).getUser();
        deleteOriginalUserInterests(user);
        saveRequestedUserInterests(request.getInterestIds(), user);
        return getUserInterests(request.getLoginId());
    }
```

1. 요청된 관심사가 3개보다 많은지 확인한다
2. 중복된 관심사가 있는지 확인한다
3. UserService로부터 loginId를 통해 사용자를 가져온다
4. 해당 사용자의 기존 관심사를 삭제한다
5. 새로 요청된 사용자 관심사를 저장한다
6. 해당 사용자의 관심사를 가져와 반환한다

<br><br>

## 🔗 링크

<br><br>

## 🐰 시급한 정도
🐢 천천히 : 급하지 않습니다.

<br><br>

## 📖 참고 사항
- 별다른 이슈는 없습니다~!
- 다만 관심사 업데이트 기능을 기존 관심사 삭제 -> 새로운 관심사 저장 방식으로 구현했는데, JpaRepository의 delete 메서드를 썼음에도 delete 쿼리가 날아가지 않아 insert 시 unique 제약 조건 따른 에러가 발생했었습니다.
- 관련 레퍼런스입니다: [JPA Delete 동작이 궁금합니다.](https://www.inflearn.com/questions/46312/jpa-delete-%EB%8F%99%EC%9E%91%EC%9D%B4-%EA%B6%81%EA%B8%88%ED%95%A9%EB%8B%88%EB%8B%A4)
- 김영한님이 남겨주신 코멘트대로 간단하게 flush() 를 추가해 해결했습니다!
