### PR TITLE
[IDLE-177] feat: 팔로우/팔로잉 UI 구현 및 user API 연동

### DIFF
--- a/frontend/lib/data/datasource/profile/follow_datasource.dart
+++ b/frontend/lib/data/datasource/profile/follow_datasource.dart
@@ -1,0 +1,134 @@
+import 'dart:developer';
+
+import 'package:dio/dio.dart';
+import 'package:mybrary/data/model/profile/follower_response.dart';
+import 'package:mybrary/data/model/profile/following_response.dart';
+import 'package:mybrary/data/network/api.dart';
+
+class FollowDataSource {
+  Future<FollowerResponseData> getFollower(String userId) async {
+    final dio = Dio();
+    final userFollowerResponse = await dio.get(
+      getApi(API.getUserFollowers),
+      options: Options(
+        headers: {'User-Id': userId},
+      ),
+    );
+
+    log('유저 팔로워 응답값: $userFollowerResponse');
+    final FollowerResponse result = commonResponseResult(
+      userFollowerResponse,
+      () => FollowerResponse(
+        status: userFollowerResponse.data['status'],
+        message: userFollowerResponse.data['message'],
+        data: FollowerResponseData.fromJson(
+          userFollowerResponse.data['data'],
+        ),
+      ),
+    );
+
+    return result.data!;
+  }
+
+  Future<FollowingResponseData> getFollowings(String userId) async {
+    final dio = Dio();
+    final userFollowingResponse = await dio.get(
+      getApi(API.getUserFollowings),
+      options: Options(
+        headers: {'User-Id': userId},
+      ),
+    );
+
+    log('유저 팔로잉 응답값: $userFollowingResponse');
+    final FollowingResponse result = commonResponseResult(
+      userFollowingResponse,
+      () => FollowingResponse(
+        status: userFollowingResponse.data['status'],
+        message: userFollowingResponse.data['message'],
+        data: FollowingResponseData.fromJson(
+          userFollowingResponse.data['data'],
+        ),
+      ),
+    );
+
+    return result.data!;
+  }
+
+  Future<FollowingResponseData?> updateFollowing(
+    String userId,
+    String targetId,
+  ) async {
+    final dio = Dio();
+    final updateFollowingResponse = await dio.post(
+      getApi(API.updateUserFollowing),
+      options: Options(
+        headers: {'User-Id': userId},
+      ),
+      data: {'targetId': targetId},
+    );
+
+    log('사용자 팔로우 응답값: $updateFollowingResponse');
+    final FollowingResponse result = commonResponseResult(
+      updateFollowingResponse,
+      () => FollowingResponse(
+        status: updateFollowingResponse.data['status'],
+        message: updateFollowingResponse.data['message'],
+        data: updateFollowingResponse.data['data'],
+      ),
+    );
+
+    return result.data;
+  }
+
+  Future<FollowerResponseData?> deleteFollower(
+    String userId,
+    String targetId,
+  ) async {
+    final dio = Dio();
+    final deleteFollowerResponse = await dio.delete(
+      getApi(API.deleteUserFollower),
+      options: Options(
+        headers: {'User-Id': userId},
+      ),
+      data: {'sourceId': targetId},
+    );
+
+    log('팔로워 삭제 응답값: $deleteFollowerResponse');
+    final FollowerResponse result = commonResponseResult(
+      deleteFollowerResponse,
+      () => FollowerResponse(
+        status: deleteFollowerResponse.data['status'],
+        message: deleteFollowerResponse.data['message'],
+        data: deleteFollowerResponse.data['data'],
+      ),
+    );
+
+    return result.data;
+  }
+
+  Future<FollowingResponseData?> deleteFollowing(
+    String userId,
+    String targetId,
+  ) async {
+    final dio = Dio();
+    final deleteFollowingResponse = await dio.delete(
+      getApi(API.deleteUserFollowing),
+      options: Options(
+        headers: {'User-Id': userId},
+      ),
+      data: {'targetId': targetId},
+    );
+
+    log('팔로잉 삭제 응답값: $deleteFollowingResponse');
+    final FollowingResponse result = commonResponseResult(
+      deleteFollowingResponse,
+      () => FollowingResponse(
+        status: deleteFollowingResponse.data['status'],
+        message: deleteFollowingResponse.data['message'],
+        data: deleteFollowingResponse.data['data'],
+      ),
+    );
+
+    return result.data;
+  }
+}

--- a/frontend/lib/data/datasource/profile/follow_datasource.dart
+++ b/frontend/lib/data/datasource/profile/follow_datasource.dart
@@ -82,7 +82,7 @@ class FollowDataSource {
 
   Future<FollowerResponseData?> deleteFollower(
     String userId,
-    String targetId,
+    String sourceId,
   ) async {
     final dio = Dio();
     final deleteFollowerResponse = await dio.delete(
@@ -90,7 +90,7 @@ class FollowDataSource {
       options: Options(
         headers: {'User-Id': userId},
       ),
-      data: {'sourceId': targetId},
+      data: {'sourceId': sourceId},
     );
 
     log('팔로워 삭제 응답값: $deleteFollowerResponse');

--- a/frontend/lib/data/datasource/profile/follow_datasource.dart
+++ b/frontend/lib/data/datasource/profile/follow_datasource.dart
@@ -4,10 +4,11 @@ import 'package:dio/dio.dart';
 import 'package:mybrary/data/model/profile/follower_response.dart';
 import 'package:mybrary/data/model/profile/following_response.dart';
 import 'package:mybrary/data/network/api.dart';
+import 'package:mybrary/utils/dios/dio_service.dart';
 
 class FollowDataSource {
   Future<FollowerResponseData> getFollower(String userId) async {
-    final dio = Dio();
+    Dio dio = DioService().to();
     final userFollowerResponse = await dio.get(
       getApi(API.getUserFollowers),
       options: Options(
@@ -31,7 +32,7 @@ class FollowDataSource {
   }
 
   Future<FollowingResponseData> getFollowings(String userId) async {
-    final dio = Dio();
+    Dio dio = DioService().to();
     final userFollowingResponse = await dio.get(
       getApi(API.getUserFollowings),
       options: Options(
@@ -58,7 +59,7 @@ class FollowDataSource {
     String userId,
     String targetId,
   ) async {
-    final dio = Dio();
+    Dio dio = DioService().to();
     final updateFollowingResponse = await dio.post(
       getApi(API.updateUserFollowing),
       options: Options(
@@ -84,7 +85,7 @@ class FollowDataSource {
     String userId,
     String sourceId,
   ) async {
-    final dio = Dio();
+    Dio dio = DioService().to();
     final deleteFollowerResponse = await dio.delete(
       getApi(API.deleteUserFollower),
       options: Options(
@@ -110,7 +111,7 @@ class FollowDataSource {
     String userId,
     String targetId,
   ) async {
-    final dio = Dio();
+    Dio dio = DioService().to();
     final deleteFollowingResponse = await dio.delete(
       getApi(API.deleteUserFollowing),
       options: Options(

--- a/frontend/lib/data/datasource/profile/interests_datasource.dart
+++ b/frontend/lib/data/datasource/profile/interests_datasource.dart
@@ -4,10 +4,11 @@ import 'package:dio/dio.dart';
 import 'package:mybrary/data/model/profile/interest_categories_response.dart';
 import 'package:mybrary/data/model/profile/my_interests_response.dart';
 import 'package:mybrary/data/network/api.dart';
+import 'package:mybrary/utils/dios/dio_service.dart';
 
 class InterestsDataSource {
   Future<InterestCategoriesResponseData> getInterestCategories() async {
-    final dio = Dio();
+    Dio dio = DioService().to();
     final interestCategoriesResponse = await dio.get(
       getApi(API.getInterestCategories),
     );
@@ -30,7 +31,7 @@ class InterestsDataSource {
   Future<MyInterestsResponseData> getMyInterestsCategories(
     String userId,
   ) async {
-    final dio = Dio();
+    Dio dio = DioService().to();
     final myInterestsResponse = await dio.get(
       '${getApi(API.getUserInterests)}/$userId/interests',
     );
@@ -54,7 +55,7 @@ class InterestsDataSource {
     String userId,
     List<CategoriesResponses> categoriesResponses,
   ) async {
-    final dio = Dio();
+    Dio dio = DioService().to();
     final myInterestsEditResponse = await dio.put(
       '${getApi(API.getUserInterests)}/$userId/interests',
       options: Options(headers: {'User-Id': 'testId'}),

--- a/frontend/lib/data/datasource/profile/profile_datasource.dart
+++ b/frontend/lib/data/datasource/profile/profile_datasource.dart
@@ -57,7 +57,7 @@ class ProfileDataSource {
     final profileImageResponse = await dio.get(getApi(API.getUserProfileImage),
         options: Options(headers: {'User-Id': 'testId'}));
 
-    log('프로필 사진 조회 응답값: $profileImageResponse');
+    log('프로필 이미지 조회 응답값: $profileImageResponse');
     final ProfileImageResponse result = commonResponseResult(
       profileImageResponse,
       () => ProfileResponse(

--- a/frontend/lib/data/datasource/profile/profile_datasource.dart
+++ b/frontend/lib/data/datasource/profile/profile_datasource.dart
@@ -4,10 +4,11 @@ import 'package:dio/dio.dart';
 import 'package:mybrary/data/model/profile/profile_image_response.dart';
 import 'package:mybrary/data/model/profile/profile_response.dart';
 import 'package:mybrary/data/network/api.dart';
+import 'package:mybrary/utils/dios/dio_service.dart';
 
 class ProfileDataSource {
   Future<ProfileResponseData> getProfileData() async {
-    final dio = Dio();
+    Dio dio = DioService().to();
     final profileResponse = await dio.get(getApi(API.getUserProfile),
         options: Options(headers: {'User-Id': 'testId'}));
 
@@ -30,7 +31,7 @@ class ProfileDataSource {
     String newNickname,
     String introduction,
   ) async {
-    final dio = Dio();
+    Dio dio = DioService().to();
     final profileEditResponse = await dio.put(
       getApi(API.editUserProfile),
       options: Options(headers: {'User-Id': 'testId'}),
@@ -53,7 +54,7 @@ class ProfileDataSource {
   }
 
   Future<ProfileImageResponseData> getProfileImage() async {
-    final dio = Dio();
+    Dio dio = DioService().to();
     final profileImageResponse = await dio.get(getApi(API.getUserProfileImage),
         options: Options(headers: {'User-Id': 'testId'}));
 
@@ -74,8 +75,7 @@ class ProfileDataSource {
 
   Future<ProfileImageResponseData> editProfileImage(
       FormData newProfileImage) async {
-    final dio = Dio();
-
+    Dio dio = DioService().to();
     final profileImageEditResponse = await dio.put(
       getApi(API.editUserProfileImage),
       options: Options(
@@ -101,8 +101,7 @@ class ProfileDataSource {
   }
 
   Future<ProfileImageResponseData> deleteProfileImage() async {
-    final dio = Dio();
-
+    Dio dio = DioService().to();
     final profileImageDeleteResponse = await dio.delete(
       getApi(API.editUserProfileImage),
       options: Options(

--- a/frontend/lib/data/datasource/search/search_datasource.dart
+++ b/frontend/lib/data/datasource/search/search_datasource.dart
@@ -2,11 +2,12 @@ import 'dart:developer';
 
 import 'package:dio/dio.dart';
 import 'package:mybrary/data/model/search/book_search_response.dart';
+import 'package:mybrary/utils/dios/dio_service.dart';
 
 class SearchDataSource {
   static Future<BookSearchResponse> getBookSearchResponse(
       String requestUrl) async {
-    final dio = Dio();
+    Dio dio = DioService().to();
     final bookSearchResponse = await dio.get(requestUrl);
 
     try {

--- a/frontend/lib/data/model/profile/follower_response.dart
+++ b/frontend/lib/data/model/profile/follower_response.dart
@@ -1,0 +1,88 @@
+class FollowerResponse {
+  String status;
+  String message;
+  FollowerResponseData? data;
+
+  FollowerResponse({
+    required this.status,
+    required this.message,
+    this.data,
+  });
+
+  factory FollowerResponse.fromJson(Map<String, dynamic> json) {
+    return FollowerResponse(
+      status: json['status'],
+      message: json['message'],
+      data: json['data'] != null
+          ? FollowerResponseData.fromJson(json['data'])
+          : null,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    final Map<String, dynamic> data = <String, dynamic>{};
+    data['status'] = status;
+    data['message'] = message;
+    if (this.data != null) {
+      data['data'] = this.data!.toJson();
+    }
+    return data;
+  }
+}
+
+class FollowerResponseData {
+  String requestLoginId;
+  List<Followers>? followers;
+
+  FollowerResponseData({required this.requestLoginId, this.followers});
+
+  factory FollowerResponseData.fromJson(Map<String, dynamic> json) {
+    return FollowerResponseData(
+      requestLoginId: json['requestLoginId'],
+      followers: json['followers'] != null
+          ? (json['followers'] as List)
+              .map((i) => Followers.fromJson(i))
+              .toList()
+          : null,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    final Map<String, dynamic> data = <String, dynamic>{};
+    data['requestLoginId'] = requestLoginId;
+    if (followers != null) {
+      data['followers'] = followers!.map((v) => v.toJson()).toList();
+    }
+    return data;
+  }
+}
+
+class Followers {
+  int? id;
+  String? loginId;
+  String? nickname;
+  String? profileImageUrl;
+
+  Followers({
+    this.id,
+    this.loginId,
+    this.nickname,
+    this.profileImageUrl,
+  });
+
+  Followers.fromJson(Map<String, dynamic> json) {
+    id = json['id'];
+    loginId = json['loginId'];
+    nickname = json['nickname'];
+    profileImageUrl = json['profileImageUrl'];
+  }
+
+  Map<String, dynamic> toJson() {
+    final Map<String, dynamic> data = <String, dynamic>{};
+    data['id'] = id;
+    data['loginId'] = loginId;
+    data['nickname'] = nickname;
+    data['profileImageUrl'] = profileImageUrl;
+    return data;
+  }
+}

--- a/frontend/lib/data/model/profile/following_response.dart
+++ b/frontend/lib/data/model/profile/following_response.dart
@@ -1,0 +1,86 @@
+class FollowingResponse {
+  String status;
+  String message;
+  FollowingResponseData? data;
+
+  FollowingResponse({
+    required this.status,
+    required this.message,
+    this.data,
+  });
+
+  factory FollowingResponse.fromJson(Map<String, dynamic> json) {
+    return FollowingResponse(
+      status: json['status'],
+      message: json['message'],
+      data: json['data'] != null
+          ? FollowingResponseData.fromJson(json['data'])
+          : null,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    final Map<String, dynamic> data = <String, dynamic>{};
+    data['status'] = status;
+    data['message'] = message;
+    if (this.data != null) {
+      data['data'] = this.data!.toJson();
+    }
+    return data;
+  }
+}
+
+class FollowingResponseData {
+  String requestLoginId;
+  List<Followings>? followings;
+
+  FollowingResponseData({
+    required this.requestLoginId,
+    this.followings,
+  });
+
+  factory FollowingResponseData.fromJson(Map<String, dynamic> json) {
+    return FollowingResponseData(
+      requestLoginId: json['requestLoginId'],
+      followings: json['followings'] != null
+          ? (json['followings'] as List)
+              .map((i) => Followings.fromJson(i))
+              .toList()
+          : null,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    final Map<String, dynamic> data = <String, dynamic>{};
+    data['requestLoginId'] = requestLoginId;
+    if (followings != null) {
+      data['followings'] = followings!.map((v) => v.toJson()).toList();
+    }
+    return data;
+  }
+}
+
+class Followings {
+  int? id;
+  String? loginId;
+  String? nickname;
+  String? profileImageUrl;
+
+  Followings({this.id, this.loginId, this.nickname, this.profileImageUrl});
+
+  Followings.fromJson(Map<String, dynamic> json) {
+    id = json['id'];
+    loginId = json['loginId'];
+    nickname = json['nickname'];
+    profileImageUrl = json['profileImageUrl'];
+  }
+
+  Map<String, dynamic> toJson() {
+    final Map<String, dynamic> data = <String, dynamic>{};
+    data['id'] = id;
+    data['loginId'] = loginId;
+    data['nickname'] = nickname;
+    data['profileImageUrl'] = profileImageUrl;
+    return data;
+  }
+}

--- a/frontend/lib/data/model/profile/profile_common_response.dart
+++ b/frontend/lib/data/model/profile/profile_common_response.dart
@@ -1,12 +1,28 @@
+import 'package:mybrary/data/model/profile/follower_response.dart';
+import 'package:mybrary/data/model/profile/following_response.dart';
 import 'package:mybrary/data/model/profile/my_interests_response.dart';
 import 'package:mybrary/data/model/profile/profile_response.dart';
 
 class ProfileCommonData {
   ProfileResponseData profileData;
   MyInterestsResponseData myInterestsData;
+  FollowerResponseData followerData;
+  FollowingResponseData followingData;
 
   ProfileCommonData({
     required this.profileData,
     required this.myInterestsData,
+    required this.followerData,
+    required this.followingData,
+  });
+}
+
+class FollowCommonData {
+  FollowerResponseData followerData;
+  FollowingResponseData followingData;
+
+  FollowCommonData({
+    required this.followerData,
+    required this.followingData,
   });
 }

--- a/frontend/lib/data/network/api.dart
+++ b/frontend/lib/data/network/api.dart
@@ -13,6 +13,11 @@ enum API {
   // user-service
   getInterestCategories,
   getUserInterests,
+  getUserFollowers,
+  getUserFollowings,
+  updateUserFollowing,
+  deleteUserFollower,
+  deleteUserFollowing,
   getUserProfile,
   getUserProfileImage,
   editUserProfile,
@@ -32,6 +37,11 @@ Map<API, String> apiMap = {
   // user-service
   API.getInterestCategories: "/api/v1/interest-categories",
   API.getUserInterests: "/api/v1/users", // '/{userId}/interests'
+  API.getUserFollowers: "/api/v1/users/followers",
+  API.getUserFollowings: "/api/v1/users/followings",
+  API.updateUserFollowing: "/api/v1/users/follow",
+  API.deleteUserFollower: "/api/v1/users/follower",
+  API.deleteUserFollowing: "/api/v1/users/follow",
   API.getUserProfile: "/api/v1/users/profile",
   API.getUserProfileImage: "/api/v1/users/profile/image",
   API.editUserProfile: "/api/v1/users/profile",

--- a/frontend/lib/data/repository/follow_repository.dart
+++ b/frontend/lib/data/repository/follow_repository.dart
@@ -33,8 +33,8 @@ class FollowRepository {
 
   Future<FollowerResponseData?> deleteFollower({
     required String userId,
-    required String targetId,
+    required String sourceId,
   }) {
-    return _followDataSource.deleteFollower(userId, targetId);
+    return _followDataSource.deleteFollower(userId, sourceId);
   }
 }

--- a/frontend/lib/data/repository/follow_repository.dart
+++ b/frontend/lib/data/repository/follow_repository.dart
@@ -1,0 +1,40 @@
+import 'package:mybrary/data/datasource/profile/follow_datasource.dart';
+import 'package:mybrary/data/model/profile/follower_response.dart';
+import 'package:mybrary/data/model/profile/following_response.dart';
+
+class FollowRepository {
+  final FollowDataSource _followDataSource = FollowDataSource();
+
+  Future<FollowerResponseData> getFollower({
+    required String userId,
+  }) {
+    return _followDataSource.getFollower(userId);
+  }
+
+  Future<FollowingResponseData> getFollowings({
+    required String userId,
+  }) {
+    return _followDataSource.getFollowings(userId);
+  }
+
+  Future<FollowingResponseData?> updateFollowing({
+    required String userId,
+    required String targetId,
+  }) {
+    return _followDataSource.updateFollowing(userId, targetId);
+  }
+
+  Future<FollowingResponseData?> deleteFollowing({
+    required String userId,
+    required String targetId,
+  }) {
+    return _followDataSource.deleteFollowing(userId, targetId);
+  }
+
+  Future<FollowerResponseData?> deleteFollower({
+    required String userId,
+    required String targetId,
+  }) {
+    return _followDataSource.deleteFollower(userId, targetId);
+  }
+}

--- a/frontend/lib/res/constants/enum.dart
+++ b/frontend/lib/res/constants/enum.dart
@@ -1,0 +1,4 @@
+enum FollowPageType {
+  follower,
+  following,
+}

--- a/frontend/lib/res/constants/style.dart
+++ b/frontend/lib/res/constants/style.dart
@@ -138,3 +138,7 @@ final disableAnimationButtonStyle = ButtonStyle(
   splashFactory: NoSplash.splashFactory,
   overlayColor: MaterialStateProperty.all(Colors.transparent),
 );
+
+final followButtonRoundStyle = RoundedRectangleBorder(
+  borderRadius: BorderRadius.circular(10.0),
+);

--- a/frontend/lib/res/constants/style.dart
+++ b/frontend/lib/res/constants/style.dart
@@ -119,6 +119,18 @@ const interestDescriptionStyle = TextStyle(
   fontWeight: FontWeight.w400,
 );
 
+const followNicknameStyle = TextStyle(
+  color: BLACK_COLOR,
+  fontSize: 15.0,
+  fontWeight: FontWeight.w400,
+);
+
+const followButtonTextStyle = TextStyle(
+  color: BLACK_COLOR,
+  fontSize: 12.0,
+  fontWeight: FontWeight.w400,
+);
+
 // button style
 final disableAnimationButtonStyle = ButtonStyle(
   backgroundColor: MaterialStateProperty.all(Colors.transparent),

--- a/frontend/lib/ui/profile/components/profile_header.dart
+++ b/frontend/lib/ui/profile/components/profile_header.dart
@@ -1,14 +1,19 @@
 import 'package:flutter/material.dart';
 import 'package:mybrary/res/colors/color.dart';
 import 'package:mybrary/res/constants/style.dart';
+import 'package:mybrary/ui/profile/follow/follower_screen.dart';
 
 class ProfileHeader extends StatelessWidget {
   final String nickname;
   final String profileImageUrl;
+  final String followerCount;
+  final String followingCount;
 
   const ProfileHeader({
     required this.nickname,
     required this.profileImageUrl,
+    required this.followerCount,
+    required this.followingCount,
     super.key,
   });
 
@@ -23,6 +28,7 @@ class ProfileHeader extends StatelessWidget {
         padding: const EdgeInsets.symmetric(vertical: 16.0),
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,
+          crossAxisAlignment: CrossAxisAlignment.center,
           children: [
             Container(
               width: 82.0,
@@ -49,14 +55,41 @@ class ProfileHeader extends StatelessWidget {
                   fontSize: 18.0,
                 )),
             const SizedBox(height: 2.0),
-            Wrap(
-              spacing: 5,
+            Row(
+              mainAxisAlignment: MainAxisAlignment.center,
               children: [
-                Text('팔로워', style: followTextStyle),
-                Text('264', style: followTextStyle),
-                SizedBox(width: 6.0),
-                Text('팔로잉', style: followTextStyle),
-                Text('123', style: followTextStyle),
+                InkWell(
+                  onTap: () {
+                    Navigator.push(
+                      context,
+                      MaterialPageRoute(
+                        builder: (_) => FollowerScreen(
+                          nickname: nickname,
+                        ),
+                      ),
+                    );
+                  },
+                  child: Row(
+                    children: [
+                      Text('팔로워', style: followTextStyle),
+                      const SizedBox(width: 6.0),
+                      Text(followerCount, style: followTextStyle),
+                    ],
+                  ),
+                ),
+                const SizedBox(width: 6.0),
+                Text(
+                  '·',
+                  style: followTextStyle,
+                ),
+                const SizedBox(width: 6.0),
+                Row(
+                  children: [
+                    Text('팔로잉', style: followTextStyle),
+                    const SizedBox(width: 6.0),
+                    Text(followingCount, style: followTextStyle),
+                  ],
+                ),
               ],
             ),
             const SizedBox(height: 8.0),

--- a/frontend/lib/ui/profile/components/profile_header.dart
+++ b/frontend/lib/ui/profile/components/profile_header.dart
@@ -1,19 +1,22 @@
 import 'package:flutter/material.dart';
 import 'package:mybrary/res/colors/color.dart';
 import 'package:mybrary/res/constants/style.dart';
-import 'package:mybrary/ui/profile/follow/follower_screen.dart';
 
 class ProfileHeader extends StatelessWidget {
   final String nickname;
   final String profileImageUrl;
   final String followerCount;
   final String followingCount;
+  final VoidCallback navigateToFollowScreen;
+  final VoidCallback navigateToFollowingScreen;
 
   const ProfileHeader({
     required this.nickname,
     required this.profileImageUrl,
     required this.followerCount,
     required this.followingCount,
+    required this.navigateToFollowScreen,
+    required this.navigateToFollowingScreen,
     super.key,
   });
 
@@ -50,50 +53,50 @@ class ProfileHeader extends StatelessWidget {
               ),
             ),
             const SizedBox(height: 10.0),
-            Text(nickname,
-                style: commonSubTitleStyle.copyWith(
-                  fontSize: 18.0,
-                )),
+            Text(
+              nickname,
+              style: commonSubTitleStyle.copyWith(
+                fontSize: 18.0,
+              ),
+            ),
             const SizedBox(height: 2.0),
             Row(
               mainAxisAlignment: MainAxisAlignment.center,
               children: [
                 InkWell(
                   onTap: () {
-                    Navigator.push(
-                      context,
-                      MaterialPageRoute(
-                        builder: (_) => FollowerScreen(
-                          nickname: nickname,
-                        ),
-                      ),
-                    );
+                    navigateToFollowScreen();
                   },
                   child: Row(
                     children: [
-                      Text('팔로워', style: followTextStyle),
+                      const Text('팔로워', style: followTextStyle),
                       const SizedBox(width: 6.0),
                       Text(followerCount, style: followTextStyle),
                     ],
                   ),
                 ),
                 const SizedBox(width: 6.0),
-                Text(
+                const Text(
                   '·',
                   style: followTextStyle,
                 ),
                 const SizedBox(width: 6.0),
-                Row(
-                  children: [
-                    Text('팔로잉', style: followTextStyle),
-                    const SizedBox(width: 6.0),
-                    Text(followingCount, style: followTextStyle),
-                  ],
+                InkWell(
+                  onTap: () {
+                    navigateToFollowingScreen();
+                  },
+                  child: Row(
+                    children: [
+                      const Text('팔로잉', style: followTextStyle),
+                      const SizedBox(width: 6.0),
+                      Text(followingCount, style: followTextStyle),
+                    ],
+                  ),
                 ),
               ],
             ),
             const SizedBox(height: 8.0),
-            Text(
+            const Text(
               '#초보 리뷰어',
               style: commonSubThinStyle,
             )

--- a/frontend/lib/ui/profile/follow/components/follow_layout.dart
+++ b/frontend/lib/ui/profile/follow/components/follow_layout.dart
@@ -1,0 +1,25 @@
+import 'package:flutter/material.dart';
+
+class FollowLayout extends StatelessWidget {
+  final List<Widget> children;
+
+  const FollowLayout({
+    required this.children,
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(
+        horizontal: 16.0,
+        vertical: 8.0,
+      ),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        crossAxisAlignment: CrossAxisAlignment.center,
+        children: children,
+      ),
+    );
+  }
+}

--- a/frontend/lib/ui/profile/follow/components/follow_user_info.dart
+++ b/frontend/lib/ui/profile/follow/components/follow_user_info.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/material.dart';
+import 'package:mybrary/res/colors/color.dart';
+import 'package:mybrary/res/constants/style.dart';
+
+class FollowUserInfo extends StatelessWidget {
+  final String nickname;
+  final String profileImageUrl;
+
+  const FollowUserInfo({
+    required this.nickname,
+    required this.profileImageUrl,
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        CircleAvatar(
+          radius: 20.0,
+          backgroundColor: GREY_03_COLOR,
+          backgroundImage: NetworkImage(
+            profileImageUrl,
+          ),
+        ),
+        const SizedBox(
+          width: 16.0,
+        ),
+        Text(
+          nickname,
+          style: followNicknameStyle,
+        ),
+      ],
+    );
+  }
+}

--- a/frontend/lib/ui/profile/follow/follower_screen.dart
+++ b/frontend/lib/ui/profile/follow/follower_screen.dart
@@ -1,0 +1,290 @@
+import 'package:flutter/material.dart';
+import 'package:mybrary/data/model/profile/follower_response.dart';
+import 'package:mybrary/data/model/profile/following_response.dart';
+import 'package:mybrary/data/model/profile/profile_common_response.dart';
+import 'package:mybrary/data/repository/follow_repository.dart';
+import 'package:mybrary/res/colors/color.dart';
+import 'package:mybrary/res/constants/style.dart';
+import 'package:mybrary/ui/common/components/circular_loading.dart';
+import 'package:mybrary/ui/common/layout/subpage_layout.dart';
+
+class FollowerScreen extends StatefulWidget {
+  final String nickname;
+
+  const FollowerScreen({
+    required this.nickname,
+    super.key,
+  });
+
+  @override
+  State<FollowerScreen> createState() => _FollowerScreenState();
+}
+
+class _FollowerScreenState extends State<FollowerScreen>
+    with TickerProviderStateMixin {
+  late List<String> _followTabs = ['팔로워', '팔로잉'];
+
+  late final TabController _tabController = TabController(
+    length: _followTabs.length,
+    vsync: this,
+  );
+
+  final ScrollController _scrollController = ScrollController();
+  final double _height = Size.fromHeight(
+        const SliverAppBar().toolbarHeight,
+      ).height *
+      1.9;
+
+  final _followRepository = FollowRepository();
+
+  late Future<FollowerResponseData> _followerResponseData;
+  late Future<FollowingResponseData> _followingResponseData;
+
+  @override
+  void initState() {
+    super.initState();
+
+    _followerResponseData = _followRepository.getFollower(
+      userId: 'testId',
+    );
+    _followingResponseData = _followRepository.getFollowings(
+      userId: 'testId',
+    );
+  }
+
+  @override
+  void dispose() {
+    _tabController.dispose();
+    _scrollController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SafeArea(
+      top: false,
+      bottom: false,
+      child: SubPageLayout(
+        child: FutureBuilder<FollowCommonData>(
+          future: Future.wait([_followerResponseData, _followingResponseData])
+              .then((followData) => FollowCommonData(
+                    followerData: followData[0] as FollowerResponseData,
+                    followingData: followData[1] as FollowingResponseData,
+                  )),
+          builder: (context, snapshot) {
+            if (snapshot.hasData) {
+              FollowCommonData data = snapshot.data!;
+              final followers = data.followerData.followers!;
+              final followings = data.followingData.followings!;
+
+              _followTabs = <String>[
+                '팔로워 ${followers.length}',
+                '팔로잉 ${followings.length}',
+              ];
+
+              isFollowing(String loginId) {
+                return followings
+                    .any((following) => following.loginId == loginId);
+              }
+
+              return NestedScrollView(
+                controller: _scrollController,
+                headerSliverBuilder:
+                    (BuildContext context, bool innerBoxIsScrolled) {
+                  return followPageSliverBuilder(
+                    context,
+                    innerBoxIsScrolled,
+                    _followTabs,
+                    _tabController,
+                  );
+                },
+                body: TabBarView(
+                  controller: _tabController,
+                  children: <Widget>[
+                    Padding(
+                      padding: EdgeInsets.only(top: _height),
+                      child: ListView.builder(
+                        itemCount: followers.length,
+                        itemBuilder: (context, index) {
+                          return Padding(
+                            padding: const EdgeInsets.symmetric(
+                              horizontal: 16.0,
+                              vertical: 8.0,
+                            ),
+                            child: Row(
+                              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                              crossAxisAlignment: CrossAxisAlignment.center,
+                              children: [
+                                Row(
+                                  children: [
+                                    CircleAvatar(
+                                      radius: 20.0,
+                                      backgroundColor: GREY_03_COLOR,
+                                      backgroundImage: NetworkImage(
+                                        followers[index].profileImageUrl!,
+                                      ),
+                                    ),
+                                    SizedBox(
+                                      width: 16.0,
+                                    ),
+                                    Text(
+                                      followers[index].nickname!,
+                                      style: followNicknameStyle,
+                                    ),
+                                  ],
+                                ),
+                                ElevatedButton(
+                                  onPressed: () {
+                                    setState(() {
+                                      if (isFollowing(
+                                        followers[index].loginId!,
+                                      )) {
+                                        _followRepository.deleteFollower(
+                                          userId: 'testId',
+                                          targetId: followers[index].loginId!,
+                                        );
+                                      } else {
+                                        _followRepository.updateFollowing(
+                                          userId: 'testId',
+                                          targetId: followers[index].loginId!,
+                                        );
+                                      }
+                                    });
+                                  },
+                                  style: ElevatedButton.styleFrom(
+                                    elevation: 0,
+                                    backgroundColor: GREY_02_COLOR,
+                                    foregroundColor: BLACK_COLOR,
+                                    padding: EdgeInsets.symmetric(
+                                      horizontal: 16.0,
+                                      vertical: 8.0,
+                                    ),
+                                    minimumSize: Size(60.0, 10.0),
+                                  ),
+                                  child: Text(
+                                    isFollowing(followers[index].loginId!)
+                                        ? '삭제'
+                                        : '팔로우',
+                                    style: followButtonTextStyle,
+                                  ),
+                                ),
+                              ],
+                            ),
+                          );
+                        },
+                      ),
+                    ),
+                    Padding(
+                      padding: EdgeInsets.only(top: _height),
+                      child: ListView.builder(
+                        itemCount: followings.length,
+                        itemBuilder: (context, index) {
+                          return Padding(
+                            padding: const EdgeInsets.symmetric(
+                              horizontal: 16.0,
+                              vertical: 8.0,
+                            ),
+                            child: Row(
+                              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                              crossAxisAlignment: CrossAxisAlignment.center,
+                              children: [
+                                Row(
+                                  children: [
+                                    CircleAvatar(
+                                      radius: 20.0,
+                                      backgroundColor: GREY_03_COLOR,
+                                      backgroundImage: NetworkImage(
+                                        followings[index].profileImageUrl!,
+                                      ),
+                                    ),
+                                    SizedBox(
+                                      width: 16.0,
+                                    ),
+                                    Text(
+                                      followings[index].nickname!,
+                                      style: followNicknameStyle,
+                                    ),
+                                  ],
+                                ),
+                                ElevatedButton(
+                                  onPressed: () {},
+                                  style: ElevatedButton.styleFrom(
+                                    elevation: 0,
+                                    backgroundColor: GREY_02_COLOR,
+                                    foregroundColor: BLACK_COLOR,
+                                    padding: EdgeInsets.symmetric(
+                                      horizontal: 16.0,
+                                      vertical: 8.0,
+                                    ),
+                                    minimumSize: Size(60.0, 10.0),
+                                    splashFactory: NoSplash.splashFactory,
+                                  ),
+                                  child: Text(
+                                    '팔로잉',
+                                    style: followButtonTextStyle,
+                                  ),
+                                ),
+                              ],
+                            ),
+                          );
+                        },
+                      ),
+                    ),
+                  ],
+                ),
+              );
+            }
+            return const CircularLoading();
+          },
+        ),
+      ),
+    );
+  }
+
+  List<Widget> followPageSliverBuilder(
+    BuildContext context,
+    bool innerBoxIsScrolled,
+    List<String> followerTabs,
+    TabController tabController,
+  ) {
+    return <Widget>[
+      SliverOverlapAbsorber(
+        handle: NestedScrollView.sliverOverlapAbsorberHandleFor(context),
+        sliver: SliverAppBar(
+          elevation: 0,
+          foregroundColor: BLACK_COLOR,
+          backgroundColor: WHITE_COLOR,
+          // expandedHeight: 120,
+          flexibleSpace: FlexibleSpaceBar(
+            background: Container(
+              color: WHITE_COLOR,
+            ),
+          ),
+          title: Text(widget.nickname),
+          titleTextStyle: appBarTitleStyle.copyWith(
+            fontSize: 16.0,
+          ),
+          centerTitle: true,
+          pinned: true,
+          expandedHeight: 104.01,
+          forceElevated: innerBoxIsScrolled,
+          bottom: TabBar(
+            controller: tabController,
+            indicatorColor: GREY_06_COLOR,
+            labelColor: GREY_06_COLOR,
+            labelStyle: commonButtonTextStyle,
+            unselectedLabelColor: GREY_03_COLOR,
+            unselectedLabelStyle: commonButtonTextStyle.copyWith(
+              fontWeight: FontWeight.w400,
+            ),
+            tabs: followerTabs
+                .map((String name) => Tab(
+                      text: name,
+                    ))
+                .toList(),
+          ),
+        ),
+      ),
+    ];
+  }
+}

--- a/frontend/lib/ui/profile/follow/follower_screen.dart
+++ b/frontend/lib/ui/profile/follow/follower_screen.dart
@@ -59,10 +59,8 @@ class _FollowerScreenState extends State<FollowerScreen>
   );
 
   final ScrollController _scrollController = ScrollController();
-  final double _paddingTopHeight = Size.fromHeight(
-        const SliverAppBar().toolbarHeight,
-      ).height *
-      1.9;
+  final double _paddingTopHeight =
+      Size.fromHeight(const SliverAppBar().toolbarHeight).height * 1.9;
 
   final _followRepository = FollowRepository();
 

--- a/frontend/lib/ui/profile/follow/follower_screen.dart
+++ b/frontend/lib/ui/profile/follow/follower_screen.dart
@@ -31,10 +31,8 @@ class _FollowerScreenState extends State<FollowerScreen>
 
   Set<String> notFollowingUsers = {};
 
-  bool isFollowingUser(String loginId) => !notFollowingUsers.contains(loginId);
-
   bool isFollowing(String loginId) {
-    return isFollowingUser(loginId);
+    return !notFollowingUsers.contains(loginId);
   }
 
   void onPressedAddFollowingUser(String loginId) {

--- a/frontend/lib/ui/profile/my_interests/components/interest_category.dart
+++ b/frontend/lib/ui/profile/my_interests/components/interest_category.dart
@@ -20,6 +20,7 @@ class InterestCategory extends StatelessWidget {
         vertical: 8.0,
       ),
       decoration: BoxDecoration(
+        color: isSelected ? primaryColor : WHITE_COLOR,
         border: Border.all(
           color: isSelected ? primaryColor : circularBorderColor,
         ),
@@ -29,6 +30,7 @@ class InterestCategory extends StatelessWidget {
         name,
         style: isSelected
             ? commonSubRegularStyle.copyWith(
+                color: WHITE_COLOR,
                 fontWeight: FontWeight.w700,
               )
             : commonSubRegularStyle,

--- a/frontend/lib/ui/profile/my_interests/my_interests_screen.dart
+++ b/frontend/lib/ui/profile/my_interests/my_interests_screen.dart
@@ -4,7 +4,6 @@ import 'package:mybrary/data/model/profile/my_interests_response.dart';
 import 'package:mybrary/data/repository/interests_repository.dart';
 import 'package:mybrary/res/constants/style.dart';
 import 'package:mybrary/ui/common/components/circular_loading.dart';
-import 'package:mybrary/ui/common/components/custom_snackbar.dart';
 import 'package:mybrary/ui/common/layout/subpage_layout.dart';
 import 'package:mybrary/ui/profile/my_interests/components/interest_category.dart';
 import 'package:mybrary/ui/profile/my_interests/components/interest_description.dart';
@@ -69,12 +68,11 @@ class _MyInterestsScreenState extends State<MyInterestsScreen> {
               categoriesResponses: selectedInterests,
             );
 
-            const CustomSnackBar(
-              message: '마이 관심사가 저장되었습니다.',
-              duration: Duration(seconds: 1),
-            );
-
             if (!mounted) return;
+            _showMyInterestsSavedMessage(
+              context: context,
+              snackBarText: '마이 관심사가 저장되었습니다.',
+            );
             Navigator.pop(context);
           },
           style: disableAnimationButtonStyle,
@@ -122,6 +120,20 @@ class _MyInterestsScreenState extends State<MyInterestsScreen> {
             ),
           );
         },
+      ),
+    );
+  }
+
+  void _showMyInterestsSavedMessage({
+    required BuildContext context,
+    required String snackBarText,
+  }) {
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text(snackBarText),
+        duration: const Duration(
+          seconds: 1,
+        ),
       ),
     );
   }

--- a/frontend/lib/ui/profile/my_interests/my_interests_screen.dart
+++ b/frontend/lib/ui/profile/my_interests/my_interests_screen.dart
@@ -144,12 +144,12 @@ class _MyInterestsScreenState extends State<MyInterestsScreen> {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: interestCategories.map(
-        (e) {
-          final int startIndex = e.description!.indexOf(e.name!);
-          final int endIndex = startIndex + e.name!.length;
+        (interest) {
+          final int startIndex = interest.description!.indexOf(interest.name!);
+          final int endIndex = startIndex + interest.name!.length;
 
           Widget description = InterestDescription(
-            description: e.description!,
+            description: interest.description!,
             startIndex: startIndex,
             endIndex: endIndex,
           );
@@ -162,20 +162,20 @@ class _MyInterestsScreenState extends State<MyInterestsScreen> {
               Wrap(
                 spacing: 10.0,
                 runSpacing: 10.0,
-                children: e.interestResponses!.map(
-                  (e) {
+                children: interest.interestResponses!.map(
+                  (interestCategory) {
                     final bool isSelected = selectedInterests.any(
-                      (category) => category.id == e.id,
+                      (category) => category.id == interestCategory.id,
                     );
 
                     return InkWell(
                       onTap: () => _onSelectedInterest(
-                        e.id!,
-                        e.name!,
+                        interestCategory.id!,
+                        interestCategory.name!,
                       ),
                       child: InterestCategory(
                         isSelected: isSelected,
-                        name: e.name!,
+                        name: interestCategory.name!,
                       ),
                     );
                   },

--- a/frontend/lib/ui/profile/profile_screen.dart
+++ b/frontend/lib/ui/profile/profile_screen.dart
@@ -1,8 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
+import 'package:mybrary/data/model/profile/follower_response.dart';
+import 'package:mybrary/data/model/profile/following_response.dart';
 import 'package:mybrary/data/model/profile/my_interests_response.dart';
 import 'package:mybrary/data/model/profile/profile_common_response.dart';
 import 'package:mybrary/data/model/profile/profile_response.dart';
+import 'package:mybrary/data/repository/follow_repository.dart';
 import 'package:mybrary/data/repository/interests_repository.dart';
 import 'package:mybrary/data/repository/profile_repository.dart';
 import 'package:mybrary/res/colors/color.dart';
@@ -25,9 +28,12 @@ class ProfileScreen extends StatefulWidget {
 class _ProfileScreenState extends State<ProfileScreen> {
   final _profileRepository = ProfileRepository();
   final _myInterestsRepository = InterestsRepository();
+  final _followRepository = FollowRepository();
 
   late Future<ProfileResponseData> _profileResponseData;
   late Future<MyInterestsResponseData> _myInterestsResponseData;
+  late Future<FollowerResponseData> _followerResponseData;
+  late Future<FollowingResponseData> _followingResponseData;
 
   late List<UserInterests> userInterests;
 
@@ -38,6 +44,12 @@ class _ProfileScreenState extends State<ProfileScreen> {
     _myInterestsResponseData = _myInterestsRepository.getMyInterestsCategories(
       userId: 'testId',
     );
+    _followerResponseData = _followRepository.getFollower(
+      userId: 'testId',
+    );
+    _followingResponseData = _followRepository.getFollowings(
+      userId: 'testId',
+    );
   }
 
   @override
@@ -46,23 +58,34 @@ class _ProfileScreenState extends State<ProfileScreen> {
       appBar: _profileAppBar(),
       child: SingleChildScrollView(
         physics: const BouncingScrollPhysics(),
-        child: FutureBuilder(
-          future: Future.wait([_profileResponseData, _myInterestsResponseData])
-              .then((data) => ProfileCommonData(
-                  profileData: data[0] as ProfileResponseData,
-                  myInterestsData: data[1] as MyInterestsResponseData)),
+        child: FutureBuilder<ProfileCommonData>(
+          future: Future.wait([
+            _profileResponseData,
+            _myInterestsResponseData,
+            _followerResponseData,
+            _followingResponseData,
+          ]).then((data) => ProfileCommonData(
+                profileData: data[0] as ProfileResponseData,
+                myInterestsData: data[1] as MyInterestsResponseData,
+                followerData: data[2] as FollowerResponseData,
+                followingData: data[3] as FollowingResponseData,
+              )),
           builder: (context, snapshot) {
             if (snapshot.hasData) {
               ProfileCommonData data = snapshot.data!;
               final ProfileResponseData profileData = data.profileData;
               final MyInterestsResponseData myInterestsData =
                   data.myInterestsData;
+              final FollowerResponseData followerData = data.followerData;
+              final FollowingResponseData followingData = data.followingData;
 
               return Column(
                 children: [
                   ProfileHeader(
                     nickname: profileData.nickname!,
                     profileImageUrl: profileData.profileImageUrl!,
+                    followerCount: followerData.followers!.length.toString(),
+                    followingCount: followingData.followings!.length.toString(),
                   ),
                   ProfileIntro(
                     introduction: profileData.introduction!,

--- a/frontend/lib/utils/dios/auth_dio.dart
+++ b/frontend/lib/utils/dios/auth_dio.dart
@@ -4,91 +4,74 @@ import 'package:dio/dio.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:mybrary/res/config/config.dart';
+import 'package:mybrary/utils/dios/dio_service.dart';
 import 'package:mybrary/utils/logics/parse_utils.dart';
 
 Future<Dio> authDio(BuildContext context) async {
-  var dio = Dio();
+  Dio dio = DioService().to();
 
   const secureStorage = FlutterSecureStorage();
 
   dio.interceptors.clear();
 
   dio.interceptors.add(InterceptorsWrapper(onRequest: (options, handler) async {
-    // device의 secureStorage에 저장된 AccessToken 불러오기
     final accessToken = await secureStorage.read(key: accessTokenKey);
 
     final jwtPayload = parseJwt(accessToken!);
 
-    // 현재 날짜의 밀리초를 1000으로 나누어 타임스탬프 반환
     final int todayTimeStamp = DateTime.now().millisecondsSinceEpoch ~/ 1000;
     final int expiredTimeStamp = jwtPayload['exp'];
 
-    // 만료 시간이 현재 시간보다 크면 만료되지 않음
     if (expiredTimeStamp >= todayTimeStamp) {
-      // 모든 요청에 대한 loginId 헤더 전달은 논의 필요
       final String loginId = jwtPayload['loginId'];
-      // AccessToken이 만료되지 않았다면, 요청 헤더에 AccessToken 전달
       options.headers[accessTokenHeaderKey] = '$jwtHeaderBearer$accessToken';
       options.headers[loginIdHeaderKey] = loginId;
       return handler.next(options);
     }
 
-    // 만료되었다면, DioException 발생
     options.data = {expiredKey: true};
     return handler.reject(DioException(requestOptions: options), true);
   }, onError: (error, handler) async {
     bool isExpired = error.requestOptions.data[expiredKey];
-    // 1. AccessToken 만료에 대한 인증 오류 발생
-    // AccessToken이 만료되었거나, statusCode가 401 이면 발생
+
     if (isExpired || error.response?.statusCode == 401) {
       log('ERROR: Access 토큰 만료에 대한 클라이언트 및 서버 에러가 발생했습니다.');
 
       final accessToken = await secureStorage.read(key: accessTokenKey);
       final refreshToken = await secureStorage.read(key: refreshTokenKey);
 
-      // 토큰 갱신 요청을 수행할 dio 객체 생성 및 interceptor 설정
-      var refreshDio = Dio();
+      Dio refreshDio = DioService().to();
 
       refreshDio.interceptors.clear();
       refreshDio.interceptors
           .add(InterceptorsWrapper(onError: (error, handler) async {
-        // 2. RefreshToken 만료에 대한 인증 오류 발생 (status == 401)
         if (error.response?.statusCode == 401) {
           log('ERROR: Refresh 토큰 만료에 대한 서버 에러가 발생했습니다.');
-          // 사용자 기기에 저장된 로그인 정보를 삭제 후, 로그인 재 요청
           await secureStorage.deleteAll();
 
-          // 로그인 페이지로 이동
           Navigator.of(context).pushNamedAndRemoveUntil(
               '/signin', (Route<dynamic> route) => false);
         }
         return handler.next(error);
       }));
 
-      // 토큰 갱신을 위한 API 요청 시 만료된 Access/Refresh Token 포함하여 전달
       refreshDio.options.headers[accessTokenHeaderKey] =
           '$jwtHeaderBearer$accessToken';
       refreshDio.options.headers[refreshTokenHeaderKey] =
           '$jwtHeaderBearer$refreshToken';
 
-      // 토큰 갱신을 위한 API 요청 부분
-      // 현재 요청한 API에 새 토큰을 재 요청하기 때문에 requestOptions.path 호출
       final refreshResponse = await refreshDio.get(error.requestOptions.path);
 
-      // 요청한 API의 response에서 갱신된 Access/Refresh Token 파싱
       final newAccessToken = refreshResponse.headers[accessTokenHeaderKey]![0];
       final newRefreshToken =
           refreshResponse.headers[refreshTokenHeaderKey]![0];
 
-      // 기기에 저장된 AccessToken과 RefreshToken 갱신
       await secureStorage.write(key: accessTokenKey, value: newAccessToken);
       await secureStorage.write(key: refreshTokenKey, value: newRefreshToken);
 
-      // 토큰 만료로 수행하지 못했던 API 요청에 담겼던 AccessToken 갱신
       error.requestOptions.headers[accessTokenHeaderKey] =
           '$jwtHeaderBearer$newAccessToken';
 
-      // 수행하지 못했던 API 요청의 복사본 생성
       final clonedRequest = await dio.request(
         error.requestOptions.path,
         options: Options(
@@ -99,7 +82,6 @@ Future<Dio> authDio(BuildContext context) async {
         queryParameters: error.requestOptions.queryParameters,
       );
 
-      // API 복사본으로 재요청
       return handler.resolve(clonedRequest);
     }
 

--- a/frontend/lib/utils/dios/dio_service.dart
+++ b/frontend/lib/utils/dios/dio_service.dart
@@ -1,0 +1,48 @@
+import 'dart:developer';
+
+import 'package:dio/dio.dart';
+import 'package:mybrary/data/network/api.dart';
+
+class DioService {
+  static final DioService _dioService = DioService._internal();
+  factory DioService() => _dioService;
+
+  static Dio _dio = Dio();
+
+  DioService._internal() {
+    BaseOptions options = BaseOptions(
+      baseUrl: baseUrl,
+      connectTimeout: const Duration(seconds: 10),
+      receiveTimeout: const Duration(seconds: 10),
+      sendTimeout: const Duration(seconds: 10),
+      // headers: {},
+    );
+    _dio = Dio(options);
+    _dio.interceptors.add(DioInterceptor());
+  }
+
+  Dio to() {
+    return _dio;
+  }
+}
+
+class DioInterceptor extends Interceptor {
+  @override
+  void onRequest(RequestOptions options, RequestInterceptorHandler handler) {
+    log("API 요청 경로: ${options.path}");
+    super.onRequest(options, handler);
+  }
+
+  @override
+  void onResponse(Response response, ResponseInterceptorHandler handler) {
+    log("${response.requestOptions.path} 의 응답 코드: ${response.statusCode}");
+    super.onResponse(response, handler);
+  }
+
+  @override
+  void onError(DioException err, ErrorInterceptorHandler handler) async {
+    log("ERROR: Server 에러 <${err.error}>");
+    log("ERROR: Server 에러 메세지 <${err.message}>");
+    super.onError(err, handler);
+  }
+}


### PR DESCRIPTION
## 🧑‍💻 작업 사항

### 팔로워 및 팔로잉 페이지 접속 / 팔로워 조회 및 삭제 / 팔로잉 조회 및 삭제 (+ 팔로우(재등록))

<div>
<img src="https://github.com/SWM-IDLE/mybrary/assets/97138841/7ed270fc-0525-46e1-8bc4-7704d46e7d9a" alt="팔로워 및 팔로잉 페이지 접속" width="260" height="580"/>
<img src="https://github.com/SWM-IDLE/mybrary/assets/97138841/e8f8606d-02d9-48a9-b45a-93344363a122" alt="팔로워 조회 및 삭제" width="260" height="580"/>
<img src="https://github.com/SWM-IDLE/mybrary/assets/97138841/a90d39a4-f1d0-4680-971e-4c5828ca20b8" alt="팔로잉 조회 및 삭제 그리고 재등록" width="260" height="580"/>
</div>

<br>

팔로우(팔로워/팔로잉) 페이지
- 프로필 페이지 UI에 팔로우 api 연동 후 팔로워/팔로잉 숫자 표시
- 팔로워/팔로잉 상단 탭바 구현 및 중첩 스크롤 뷰 구현
- 팔로워 조회 및 삭제 버튼 구현
- 팔로잉 조회 및 팔로잉(언팔로우) 버튼 구현 + 목록 유지 및 팔로우 버튼 구현

<br>

### 팔로워 및 팔로잉 시나리오 (언팔 및 팔로워 삭제 및 재등록)

<div>
<img src="https://github.com/SWM-IDLE/mybrary/assets/97138841/630d8ecc-a7e5-417f-b14a-ec2981c03948" alt="팔로워 및 팔로잉 전체 시나리오" width="290" height="640"/>
</div>

<br>

- 가능한 시나리오 테스트를 진행하였습니다.
- 실 기기 테스트 진행 예정입니다.

<br><br>

## 🔗 링크

<br><br>

## 🐰 시급한 정도

🐢 천천히 : 급하지 않습니다.

<br><br>

## 📖 참고 사항

- 테스트 계정(테스트1~30)으로 진행했고, 임의로 생성한 리스트가 아닙니다..!! (모두 서버의 기본 이미지로 되어있어서 착각할수도,,)
- 최대한 리팩터링을 적용하려고 노력 중이여서, 팔로워/팔로잉 페이지가 아닌 페이지에도 일부 코드 수정이 존재합니다 😅
- UI를 구성하면서 피그마 화면에서 조금 더 개선하는 부분이 있어, 기존 피그마 화면과는 일부 다른 점 양해 부탁드립니다!
- 팔로워, 팔로잉이 현재는 리스트에 추가되는 순서로 들어오는 점이 있는데 정렬 부분에 대해 논의하면 좋을 것 같습니다!
- 다음 이슈도 빠르게 진행해보겠습니다..!

<br>