### PR TITLE
[IDLE-173] feat: 회원 탈퇴 기능 개발 (+사용자 정보 조회 기능 개발)

### DIFF
--- a/backend/user-service/.gitignore
+++ b/backend/user-service/.gitignore
@@ -7,6 +7,7 @@ build/
 
 ### PROPERTIES ###
 /src/main/resources/application-dev.yml
+/src/main/resources/application-local.yml
 
 ### STS ###
 .apt_generated

--- a/backend/user-service/build.gradle
+++ b/backend/user-service/build.gradle
@@ -64,6 +64,12 @@ dependencies {
 
 	// h2
 	runtimeOnly 'com.h2database:h2'
+
+	// querydsl
+	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+	annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
+	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 }
 
 ext {
@@ -106,3 +112,6 @@ openapi3 {
 	outputDirectory = 'build/resources/main/static/docs'
 }
 
+clean {
+	delete file('src/main/generated')
+}

--- a/backend/user-service/http/User.http
+++ b/backend/user-service/http/User.http
@@ -9,11 +9,11 @@ Content-Type: application/json
   "email": "email@email.com"
 }
 
-### 회원 탈퇴
+### 2. 회원 탈퇴
 DELETE http://localhost:8080/api/v1/users/account
 USER-ID: loginId
 
-### 2. 로그인
+### 3. 로그인
 POST http://43.200.200.185:8003/api/v1/auth/login
 Content-Type: application/json
 
@@ -22,39 +22,36 @@ Content-Type: application/json
   "password": "password123!"
 }
 
-### 3. 로그아웃
+### 4. 로그아웃
 POST http://localhost:8080/api/v1/auth/logout
 Authorization: Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJBY2Nlc3NUb2tlbiIsImxvZ2luSWQiOiI3ZWFlM2QwZC0wYzU5LTQxMzctYWU5My1hYjhjOTZmNWZiMGUiLCJleHAiOjE2OTEyMTUyODh9.DkPQdLlegkCVONgElh9UoAr_YpmsX5Ci11TGzsYtVYtK9fHJ7ypjPXpVvMM_fEy1gnDtyjWz0Q9a0TcapedAmA
 
-### 4. 인가 테스트
+### 5. 인가 테스트
 GET http://localhost:8080/auth/v1/test
 Authorization: Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJBY2Nlc3NUb2tlbiIsImxvZ2luSWQiOiI3ZWFlM2QwZC0wYzU5LTQxMzctYWU5My1hYjhjOTZmNWZiMGUiLCJleHAiOjE2OTEyMTUyODh9.DkPQdLlegkCVONgElh9UoAr_YpmsX5Ci11TGzsYtVYtK9fHJ7ypjPXpVvMM_fEy1gnDtyjWz0Q9a0TcapedAmA
 
-### 3. 구글 소셜 로그인
+### 6. 구글 소셜 로그인
 GET http://localhost:8080/oauth2/authorization/google
 
-### 4. 카카오 소셜 로그인
+### 7. 카카오 소셜 로그인
 GET http://localhost:8080/oauth2/authorization/kakao
 
-### 5. 네이버 소셜 로그인
+### 8. 네이버 소셜 로그인
 GET http://localhost:8080/oauth2/authorization/naver
 
-### 6. 인증 오류
+### 9. 인증 오류
 GET http://localhost:8080/user/profile
 
-### 7. 토큰 오류
+### 10. 토큰 오류
 GET http://localhost:8080/api/v1/users/profile
 Authorization: Bearer invalidToken1234
 Authorization-Refresh: Bearer invalidRefreshToken1234
 
-### 8. API 문서 조회
-GET http://localhost:8080/docs/swagger-ui/index.html
-
-### 9. 프로필 조회
+### 11. 프로필 조회
 GET http://localhost:8080/api/v1/users/profile
 USER-ID: loginId
 
-### 10. 프로필 수정
+### 12. 프로필 수정
 PUT http://localhost:8080/api/v1/users/profile
 Content-Type: application/json
 USER-ID: loginId
@@ -65,24 +62,24 @@ USER-ID: loginId
   "introduction": "new-introduction"
 }
 
-### 11. 프로필 이미지 조회
+### 13. 프로필 이미지 조회
 GET http://localhost:8080/api/v1/users/profile/image
 USER-ID: loginId
 
-### 12. 프로필 이미지 삭제
+### 14. 프로필 이미지 삭제
 DELETE http://localhost:8080/api/v1/users/profile/image
 USER-ID: loginId
 
-### 13. 사용자 검색
+### 15. 사용자 검색
 GET http://localhost:8080/api/v1/users/search?nickname=nick
 
-### 14. 카테고리별 관심사 모두 조회
+### 16. 카테고리별 관심사 모두 조회
 GET http://43.200.200.185:8003/api/v1/interest-categories // mybrary.kr
 
-### 15. 사용자 관심사 조회
+### 17. 사용자 관심사 조회
 GET http://43.200.200.185:8003/api/v1/users/testId/interests
 
-### 16. 사용자 관심사 업데이트
+### 18. 사용자 관심사 업데이트
 PUT http://43.200.200.185:8003/api/v1/users/testId/interests
 Content-Type: application/json
 
@@ -97,4 +94,15 @@ Content-Type: application/json
         "name": "외국소설"
       }
     ]
+}
+
+### 19. 사용자 정보 모두 조회
+GET http://localhost:8080/api/v1/users/info
+Content-Type: application/json
+
+{
+  "userIds": [
+    "loginId1",
+    "loginId2"
+  ]
 }

--- a/backend/user-service/http/User.http
+++ b/backend/user-service/http/User.http
@@ -9,22 +9,26 @@ Content-Type: application/json
   "email": "email@email.com"
 }
 
+### 회원 탈퇴
+DELETE http://localhost:8080/api/v1/users/account
+USER-ID: loginId
+
 ### 2. 로그인
-POST http://localhost:8080/api/v1/auth/login
+POST http://43.200.200.185:8003/api/v1/auth/login
 Content-Type: application/json
 
 {
-  "loginId": "loginId",
+  "loginId": "testId",
   "password": "password123!"
 }
 
 ### 3. 로그아웃
 POST http://localhost:8080/api/v1/auth/logout
-Authorization: Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJBY2Nlc3NUb2tlbiIsImxvZ2luSWQiOiJsb2dpbklkIiwiZXhwIjoxNjg5OTUwNjI5fQ.xVTWvIsUbaES_rYcfel-TuGy944Gtlf5XuNhkZO_MioWX2xhKFiMJjmYPcF6f9IogbDebjbiSVxMNJ9PwoIx8w
+Authorization: Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJBY2Nlc3NUb2tlbiIsImxvZ2luSWQiOiI3ZWFlM2QwZC0wYzU5LTQxMzctYWU5My1hYjhjOTZmNWZiMGUiLCJleHAiOjE2OTEyMTUyODh9.DkPQdLlegkCVONgElh9UoAr_YpmsX5Ci11TGzsYtVYtK9fHJ7ypjPXpVvMM_fEy1gnDtyjWz0Q9a0TcapedAmA
 
 ### 4. 인가 테스트
 GET http://localhost:8080/auth/v1/test
-# Authorization: Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJBY2Nlc3NUb2tlbiIsImxvZ2luSWQiOiJsb2dpbklkIiwiZXhwIjoxNjg5OTUwNjI5fQ.xVTWvIsUbaES_rYcfel-TuGy944Gtlf5XuNhkZO_MioWX2xhKFiMJjmYPcF6f9IogbDebjbiSVxMNJ9PwoIx8w
+Authorization: Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJBY2Nlc3NUb2tlbiIsImxvZ2luSWQiOiI3ZWFlM2QwZC0wYzU5LTQxMzctYWU5My1hYjhjOTZmNWZiMGUiLCJleHAiOjE2OTEyMTUyODh9.DkPQdLlegkCVONgElh9UoAr_YpmsX5Ci11TGzsYtVYtK9fHJ7ypjPXpVvMM_fEy1gnDtyjWz0Q9a0TcapedAmA
 
 ### 3. 구글 소셜 로그인
 GET http://localhost:8080/oauth2/authorization/google
@@ -70,10 +74,27 @@ DELETE http://localhost:8080/api/v1/users/profile/image
 USER-ID: loginId
 
 ### 13. 사용자 검색
-GET http://localhost:8080/api/v1/users/search?nickname=
+GET http://localhost:8080/api/v1/users/search?nickname=nick
 
 ### 14. 카테고리별 관심사 모두 조회
-GET http://localhost:8080/api/v1/interest-categories
+GET http://43.200.200.185:8003/api/v1/interest-categories // mybrary.kr
 
 ### 15. 사용자 관심사 조회
-GET http://localhost:8080/api/v1/users/loginId/interests
+GET http://43.200.200.185:8003/api/v1/users/testId/interests
+
+### 16. 사용자 관심사 업데이트
+PUT http://43.200.200.185:8003/api/v1/users/testId/interests
+Content-Type: application/json
+
+{
+    "interestRequests": [
+      {
+        "id": 1,
+        "name": "국내소설"
+      },
+      {
+        "id": 2,
+        "name": "외국소설"
+      }
+    ]
+}

--- a/backend/user-service/src/main/java/kr/mybrary/userservice/UserServiceApplication.java
+++ b/backend/user-service/src/main/java/kr/mybrary/userservice/UserServiceApplication.java
@@ -5,12 +5,10 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.EnableAspectJAutoProxy;
-import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
 @SpringBootApplication
-@EnableJpaAuditing
 @EnableDiscoveryClient
 @EnableAspectJAutoProxy
 public class UserServiceApplication {

--- a/backend/user-service/src/main/java/kr/mybrary/userservice/global/config/QueryDslConfig.java
+++ b/backend/user-service/src/main/java/kr/mybrary/userservice/global/config/QueryDslConfig.java
@@ -1,0 +1,21 @@
+package kr.mybrary.userservice.global.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@EnableJpaAuditing
+@Configuration
+public class QueryDslConfig {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/backend/user-service/src/main/java/kr/mybrary/userservice/user/domain/UserService.java
+++ b/backend/user-service/src/main/java/kr/mybrary/userservice/user/domain/UserService.java
@@ -1,10 +1,6 @@
 package kr.mybrary.userservice.user.domain;
 
-import kr.mybrary.userservice.user.domain.dto.request.FollowServiceRequest;
-import kr.mybrary.userservice.user.domain.dto.request.FollowerServiceRequest;
-import kr.mybrary.userservice.user.domain.dto.request.ProfileImageUpdateServiceRequest;
-import kr.mybrary.userservice.user.domain.dto.request.ProfileUpdateServiceRequest;
-import kr.mybrary.userservice.user.domain.dto.request.SignUpServiceRequest;
+import kr.mybrary.userservice.user.domain.dto.request.*;
 import kr.mybrary.userservice.user.domain.dto.response.*;
 
 public interface UserService {
@@ -36,5 +32,7 @@ public interface UserService {
     SearchServiceResponse searchByNickname(String nickname);
 
     void deleteAccount(String loginId);
+
+    UserInfoServiceResponse getUserInfo(UserInfoServiceRequest serviceRequest);
 
 }

--- a/backend/user-service/src/main/java/kr/mybrary/userservice/user/domain/UserService.java
+++ b/backend/user-service/src/main/java/kr/mybrary/userservice/user/domain/UserService.java
@@ -35,4 +35,6 @@ public interface UserService {
 
     SearchServiceResponse searchByNickname(String nickname);
 
+    void deleteAccount(String loginId);
+
 }

--- a/backend/user-service/src/main/java/kr/mybrary/userservice/user/domain/UserServiceImpl.java
+++ b/backend/user-service/src/main/java/kr/mybrary/userservice/user/domain/UserServiceImpl.java
@@ -1,12 +1,9 @@
 package kr.mybrary.userservice.user.domain;
 
+import jakarta.validation.constraints.NotNull;
 import kr.mybrary.userservice.global.util.MultipartFileUtil;
 import kr.mybrary.userservice.user.domain.dto.UserMapper;
-import kr.mybrary.userservice.user.domain.dto.request.FollowServiceRequest;
-import kr.mybrary.userservice.user.domain.dto.request.FollowerServiceRequest;
-import kr.mybrary.userservice.user.domain.dto.request.ProfileImageUpdateServiceRequest;
-import kr.mybrary.userservice.user.domain.dto.request.ProfileUpdateServiceRequest;
-import kr.mybrary.userservice.user.domain.dto.request.SignUpServiceRequest;
+import kr.mybrary.userservice.user.domain.dto.request.*;
 import kr.mybrary.userservice.user.domain.dto.response.*;
 import kr.mybrary.userservice.user.domain.exception.follow.DuplicateFollowException;
 import kr.mybrary.userservice.user.domain.exception.follow.SameSourceTargetUserException;
@@ -294,5 +291,19 @@ public class UserServiceImpl implements UserService {
         userRepository.delete(user);
     }
 
+    @Override
+    @Transactional(readOnly = true)
+    public UserInfoServiceResponse getUserInfo(UserInfoServiceRequest serviceRequest) {
+        return UserInfoServiceResponse.builder()
+                .userInfoElements(getUserInfoElements(serviceRequest))
+                .build();
+    }
+
+    @NotNull
+    private List<UserInfoServiceResponse.UserInfoElement> getUserInfoElements(UserInfoServiceRequest serviceRequest) {
+        return userRepository.findAllUserInfoByLoginIds(serviceRequest.getUserIds()).stream()
+                .map(userInfoModel -> UserInfoServiceResponse.UserInfoElement.of(userInfoModel))
+                .collect(Collectors.toList());
+    }
 
 }

--- a/backend/user-service/src/main/java/kr/mybrary/userservice/user/domain/UserServiceImpl.java
+++ b/backend/user-service/src/main/java/kr/mybrary/userservice/user/domain/UserServiceImpl.java
@@ -288,5 +288,11 @@ public class UserServiceImpl implements UserService {
         }
     }
 
+    @Override
+    public void deleteAccount(String loginId) {
+        User user = getUser(loginId);
+        userRepository.delete(user);
+    }
+
 
 }

--- a/backend/user-service/src/main/java/kr/mybrary/userservice/user/domain/dto/request/UserInfoServiceRequest.java
+++ b/backend/user-service/src/main/java/kr/mybrary/userservice/user/domain/dto/request/UserInfoServiceRequest.java
@@ -1,0 +1,21 @@
+package kr.mybrary.userservice.user.domain.dto.request;
+
+import kr.mybrary.userservice.user.presentation.dto.request.UserInfoRequest;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class UserInfoServiceRequest {
+
+    List<String> userIds;
+
+    public static UserInfoServiceRequest of(UserInfoRequest userInfoRequest) {
+        return UserInfoServiceRequest.builder()
+                .userIds(userInfoRequest.getUserIds())
+                .build();
+    }
+
+}

--- a/backend/user-service/src/main/java/kr/mybrary/userservice/user/domain/dto/response/UserInfoServiceResponse.java
+++ b/backend/user-service/src/main/java/kr/mybrary/userservice/user/domain/dto/response/UserInfoServiceResponse.java
@@ -1,0 +1,33 @@
+package kr.mybrary.userservice.user.domain.dto.response;
+
+import kr.mybrary.userservice.user.persistence.model.UserInfoModel;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class UserInfoServiceResponse {
+
+    List<UserInfoElement> userInfoElements;
+
+    @Getter
+    @Builder
+    public static class UserInfoElement {
+
+        private String userId;
+        private String nickname;
+        private String profileImageUrl;
+
+        public static UserInfoElement of(UserInfoModel userInfoModel) {
+            return UserInfoElement.builder()
+                    .userId(userInfoModel.getLoginId())
+                    .nickname(userInfoModel.getNickname())
+                    .profileImageUrl(userInfoModel.getProfileImageUrl())
+                    .build();
+        }
+
+    }
+
+}

--- a/backend/user-service/src/main/java/kr/mybrary/userservice/user/persistence/User.java
+++ b/backend/user-service/src/main/java/kr/mybrary/userservice/user/persistence/User.java
@@ -6,16 +6,32 @@ import kr.mybrary.userservice.global.BaseEntity;
 import kr.mybrary.userservice.interest.persistence.Interest;
 import kr.mybrary.userservice.interest.persistence.UserInterest;
 import lombok.*;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 @Builder
-@Table(name = "users")
+@Table(name = "users",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uk_users_login_id_deleted",
+                        columnNames = {"loginId", "deleted"}
+                ),
+                @UniqueConstraint(
+                        name = "uk_users_nickname_deleted",
+                        columnNames = {"nickname", "deleted"}
+                ),
+                @UniqueConstraint(
+                        name = "uk_users_login_id_nickname_deleted",
+                        columnNames = {"loginId", "nickname", "deleted"}
+                ),
+        }
+)
 @AllArgsConstructor
-// TODO: soft delete 적용 시 unique 제약 조건 이슈
-// @SQLDelete(sql = "UPDATE users SET deleted = true WHERE user_id = ?")
-// @Where(clause = "deleted = false")
+@SQLDelete(sql = "UPDATE users SET deleted = true WHERE user_id = ?")
+@Where(clause = "deleted = false")
 public class User extends BaseEntity {
 
     @Id
@@ -23,10 +39,10 @@ public class User extends BaseEntity {
     @Column(name = "user_id")
     private Long id;
 
-    @Column(unique = true)
+    @Column(nullable = false)
     private String loginId;
 
-    @Column(nullable = false, unique = true)
+    @Column(nullable = false)
     private String nickname;
 
     @Column(nullable = false)

--- a/backend/user-service/src/main/java/kr/mybrary/userservice/user/persistence/model/UserInfoModel.java
+++ b/backend/user-service/src/main/java/kr/mybrary/userservice/user/persistence/model/UserInfoModel.java
@@ -1,0 +1,18 @@
+package kr.mybrary.userservice.user.persistence.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserInfoModel {
+
+    private String loginId;
+    private String nickname;
+    private String profileImageUrl;
+
+}

--- a/backend/user-service/src/main/java/kr/mybrary/userservice/user/persistence/repository/UserRepository.java
+++ b/backend/user-service/src/main/java/kr/mybrary/userservice/user/persistence/repository/UserRepository.java
@@ -7,7 +7,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 import java.util.Optional;
 
-public interface UserRepository extends JpaRepository<User, Long> {
+public interface UserRepository extends JpaRepository<User, Long>, UserRepositoryCustom {
 
     Optional<User> findByLoginId(String loginId);
 

--- a/backend/user-service/src/main/java/kr/mybrary/userservice/user/persistence/repository/UserRepositoryCustom.java
+++ b/backend/user-service/src/main/java/kr/mybrary/userservice/user/persistence/repository/UserRepositoryCustom.java
@@ -1,0 +1,11 @@
+package kr.mybrary.userservice.user.persistence.repository;
+
+import kr.mybrary.userservice.user.persistence.model.UserInfoModel;
+
+import java.util.List;
+
+public interface UserRepositoryCustom {
+
+    List<UserInfoModel> findAllUserInfoByLoginIds(List<String> loginIds);
+
+}

--- a/backend/user-service/src/main/java/kr/mybrary/userservice/user/persistence/repository/UserRepositoryCustomImpl.java
+++ b/backend/user-service/src/main/java/kr/mybrary/userservice/user/persistence/repository/UserRepositoryCustomImpl.java
@@ -1,0 +1,30 @@
+package kr.mybrary.userservice.user.persistence.repository;
+
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import kr.mybrary.userservice.user.persistence.model.UserInfoModel;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+import static kr.mybrary.userservice.user.persistence.QUser.user;
+
+@Repository
+@RequiredArgsConstructor
+public class UserRepositoryCustomImpl implements UserRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<UserInfoModel> findAllUserInfoByLoginIds(List<String> loginIds) {
+        return queryFactory
+                .select(Projections.fields(UserInfoModel.class,
+                        user.loginId,
+                        user.nickname,
+                        user.profileImageUrl))
+                .from(user)
+                .where(user.loginId.in(loginIds))
+                .fetch();
+    }
+}

--- a/backend/user-service/src/main/java/kr/mybrary/userservice/user/presentation/UserController.java
+++ b/backend/user-service/src/main/java/kr/mybrary/userservice/user/presentation/UserController.java
@@ -3,16 +3,9 @@ package kr.mybrary.userservice.user.presentation;
 import jakarta.validation.Valid;
 import kr.mybrary.userservice.global.dto.response.SuccessResponse;
 import kr.mybrary.userservice.user.domain.UserService;
-import kr.mybrary.userservice.user.domain.dto.request.FollowServiceRequest;
-import kr.mybrary.userservice.user.domain.dto.request.FollowerServiceRequest;
-import kr.mybrary.userservice.user.domain.dto.request.ProfileImageUpdateServiceRequest;
-import kr.mybrary.userservice.user.domain.dto.request.ProfileUpdateServiceRequest;
-import kr.mybrary.userservice.user.domain.dto.request.SignUpServiceRequest;
+import kr.mybrary.userservice.user.domain.dto.request.*;
 import kr.mybrary.userservice.user.domain.dto.response.*;
-import kr.mybrary.userservice.user.presentation.dto.request.FollowRequest;
-import kr.mybrary.userservice.user.presentation.dto.request.FollowerRequest;
-import kr.mybrary.userservice.user.presentation.dto.request.ProfileUpdateRequest;
-import kr.mybrary.userservice.user.presentation.dto.request.SignUpRequest;
+import kr.mybrary.userservice.user.presentation.dto.request.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -175,6 +168,14 @@ public class UserController {
 
         return ResponseEntity.ok().body(
                 SuccessResponse.of(HttpStatus.OK.toString(), "회원 탈퇴에 성공했습니다.", null)
+        );
+    }
+
+    @GetMapping("/info")
+    public ResponseEntity<SuccessResponse> getUserInfo(@RequestBody UserInfoRequest userInfoRequest) {
+        return ResponseEntity.ok().body(
+                SuccessResponse.of(HttpStatus.OK.toString(), "사용자 정보를 모두 조회했습니다.",
+                        userService.getUserInfo(UserInfoServiceRequest.of(userInfoRequest)))
         );
     }
 

--- a/backend/user-service/src/main/java/kr/mybrary/userservice/user/presentation/UserController.java
+++ b/backend/user-service/src/main/java/kr/mybrary/userservice/user/presentation/UserController.java
@@ -169,4 +169,13 @@ public class UserController {
         );
     }
 
+    @DeleteMapping("/account")
+    public ResponseEntity<SuccessResponse> withdrawal(@RequestHeader("USER-ID") String loginId) {
+        userService.deleteAccount(loginId);
+
+        return ResponseEntity.ok().body(
+                SuccessResponse.of(HttpStatus.OK.toString(), "회원 탈퇴에 성공했습니다.", null)
+        );
+    }
+
 }

--- a/backend/user-service/src/main/java/kr/mybrary/userservice/user/presentation/dto/request/UserInfoRequest.java
+++ b/backend/user-service/src/main/java/kr/mybrary/userservice/user/presentation/dto/request/UserInfoRequest.java
@@ -1,0 +1,18 @@
+package kr.mybrary.userservice.user.presentation.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class UserInfoRequest {
+
+    List<String> userIds;
+
+}

--- a/backend/user-service/src/main/resources/application-test.yml
+++ b/backend/user-service/src/main/resources/application-test.yml
@@ -24,3 +24,6 @@ spring:
 logging:
   level:
     root: info
+
+jwt:
+  secretKey: testSecretKey

--- a/backend/user-service/src/test/java/kr/mybrary/userservice/PersistenceTest.java
+++ b/backend/user-service/src/test/java/kr/mybrary/userservice/PersistenceTest.java
@@ -1,0 +1,20 @@
+package kr.mybrary.userservice;
+
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Import(TestConfig.class)
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@ActiveProfiles("test")
+public @interface PersistenceTest {
+}

--- a/backend/user-service/src/test/java/kr/mybrary/userservice/TestConfig.java
+++ b/backend/user-service/src/test/java/kr/mybrary/userservice/TestConfig.java
@@ -1,0 +1,21 @@
+package kr.mybrary.userservice;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@TestConfiguration
+@EnableJpaAuditing
+public class TestConfig {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/backend/user-service/src/test/java/kr/mybrary/userservice/global/jwt/service/JwtServiceTest.java
+++ b/backend/user-service/src/test/java/kr/mybrary/userservice/global/jwt/service/JwtServiceTest.java
@@ -77,15 +77,15 @@ class JwtServiceTest {
         LocalDateTime date = LocalDateTime.of(2023, 1, 1, 0, 0, 0);
 
         // when
-        String createdAccessToken = jwtService.createRefreshToken(date);
+        String createdRefreshToken = jwtService.createRefreshToken(date);
 
         // then
-        assertAll( // TODO: 수정 필요~~
-                () -> assertThat(createdAccessToken).isNotNull(),
-                () -> assertThat(JWT.decode(createdAccessToken).getSubject()).isEqualTo(REFRESH_TOKEN_SUBJECT),
-                () -> assertThat(JWT.decode(createdAccessToken).getExpiresAt()).isEqualTo(new Date(
+        assertAll(
+                () -> assertThat(createdRefreshToken).isNotNull(),
+                () -> assertThat(JWT.decode(createdRefreshToken).getSubject()).isEqualTo(REFRESH_TOKEN_SUBJECT),
+                () -> assertThat(JWT.decode(createdRefreshToken).getExpiresAt()).isEqualTo(new Date(
                         Date.from(date.atZone(ZoneId.systemDefault()).toInstant()).getTime() + refreshTokenExpirationPeriod)),
-                () -> assertThat(JWT.decode(createdAccessToken).getSignature()).isNotNull()
+                () -> assertThat(JWT.decode(createdRefreshToken).getSignature()).isNotNull()
         );
     }
 

--- a/backend/user-service/src/test/java/kr/mybrary/userservice/interest/persistence/repository/InterestCategoryRepositoryTest.java
+++ b/backend/user-service/src/test/java/kr/mybrary/userservice/interest/persistence/repository/InterestCategoryRepositoryTest.java
@@ -1,15 +1,13 @@
 package kr.mybrary.userservice.interest.persistence.repository;
 
+import kr.mybrary.userservice.PersistenceTest;
 import kr.mybrary.userservice.interest.persistence.Interest;
 import kr.mybrary.userservice.interest.persistence.InterestCategory;
 import org.hibernate.proxy.HibernateProxy;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
-import org.springframework.test.context.ActiveProfiles;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -17,9 +15,7 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
-@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
-@ActiveProfiles("test")
-@DataJpaTest
+@PersistenceTest
 class InterestCategoryRepositoryTest {
 
     @Autowired

--- a/backend/user-service/src/test/java/kr/mybrary/userservice/interest/persistence/repository/InterestRepositoryTest.java
+++ b/backend/user-service/src/test/java/kr/mybrary/userservice/interest/persistence/repository/InterestRepositoryTest.java
@@ -1,22 +1,18 @@
 package kr.mybrary.userservice.interest.persistence.repository;
 
+import kr.mybrary.userservice.PersistenceTest;
 import kr.mybrary.userservice.interest.persistence.Interest;
 import kr.mybrary.userservice.interest.persistence.InterestCategory;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.test.context.ActiveProfiles;
 
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
-@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
-@ActiveProfiles("test")
-@DataJpaTest
+@PersistenceTest
 class InterestRepositoryTest {
 
     @Autowired

--- a/backend/user-service/src/test/java/kr/mybrary/userservice/interest/persistence/repository/UserInterestRepositoryTest.java
+++ b/backend/user-service/src/test/java/kr/mybrary/userservice/interest/persistence/repository/UserInterestRepositoryTest.java
@@ -1,5 +1,6 @@
 package kr.mybrary.userservice.interest.persistence.repository;
 
+import kr.mybrary.userservice.PersistenceTest;
 import kr.mybrary.userservice.interest.InterestFixture;
 import kr.mybrary.userservice.interest.persistence.Interest;
 import kr.mybrary.userservice.interest.persistence.UserInterest;
@@ -10,19 +11,14 @@ import org.hibernate.proxy.HibernateProxy;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
-import org.springframework.test.context.ActiveProfiles;
 
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
-@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
-@ActiveProfiles("test")
-@DataJpaTest
+@PersistenceTest
 class UserInterestRepositoryTest {
 
     @Autowired

--- a/backend/user-service/src/test/java/kr/mybrary/userservice/user/domain/UserServiceImplTest.java
+++ b/backend/user-service/src/test/java/kr/mybrary/userservice/user/domain/UserServiceImplTest.java
@@ -507,5 +507,20 @@ class UserServiceImplTest {
         verify(userRepository).findByNicknameContaining("nickname");
     }
 
+    @Test
+    @DisplayName("로그인 아이디로 사용자 계정을 삭제한다")
+    void deleteAccount() {
+        // Given
+        User user = UserFixture.COMMON_USER.getUser();
+        given(userRepository.findByLoginId(LOGIN_ID)).willReturn(Optional.of(user));
+
+        // When
+        userService.deleteAccount(LOGIN_ID);
+
+        // Then
+        verify(userRepository).findByLoginId(LOGIN_ID);
+        verify(userRepository).delete(user);
+    }
+
 
 }

--- a/backend/user-service/src/test/java/kr/mybrary/userservice/user/persistence/repository/UserRepositoryTest.java
+++ b/backend/user-service/src/test/java/kr/mybrary/userservice/user/persistence/repository/UserRepositoryTest.java
@@ -3,6 +3,7 @@ package kr.mybrary.userservice.user.persistence.repository;
 import kr.mybrary.userservice.PersistenceTest;
 import kr.mybrary.userservice.user.UserFixture;
 import kr.mybrary.userservice.user.persistence.User;
+import kr.mybrary.userservice.user.persistence.model.UserInfoModel;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -147,4 +148,24 @@ class UserRepositoryTest {
             () -> assertThat(foundUser.get(1).getNickname()).contains(savedUser.getNickname())
         );
     }
+
+    @Test
+    @DisplayName("로그인 아이디 목록으로 사용자 정보를 가져온다.")
+    void findAllUserInfoByLoginIds() {
+        // given
+        User savedUser = userRepository.save(UserFixture.COMMON_USER.getUser());
+        User savedUser2 = userRepository.save(UserFixture.USER_WITH_SIMILAR_NICKNAME.getUser());
+
+        // when
+        List<UserInfoModel> userInfos = userRepository.findAllUserInfoByLoginIds(List.of(savedUser.getLoginId(), savedUser2.getLoginId()));
+
+        // then
+        assertAll(
+            () -> assertThat(userInfos).hasSize(2),
+            () -> assertThat(userInfos).extracting("loginId").containsExactly(savedUser.getLoginId(), savedUser2.getLoginId()),
+            () -> assertThat(userInfos).extracting("nickname").containsExactly(savedUser.getNickname(), savedUser2.getNickname()),
+            () -> assertThat(userInfos).extracting("profileImageUrl").containsExactly(savedUser.getProfileImageUrl(), savedUser2.getProfileImageUrl())
+        );
+    }
+
 }

--- a/backend/user-service/src/test/java/kr/mybrary/userservice/user/persistence/repository/UserRepositoryTest.java
+++ b/backend/user-service/src/test/java/kr/mybrary/userservice/user/persistence/repository/UserRepositoryTest.java
@@ -1,22 +1,19 @@
 package kr.mybrary.userservice.user.persistence.repository;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
-
-import java.util.List;
-import java.util.Optional;
+import kr.mybrary.userservice.PersistenceTest;
 import kr.mybrary.userservice.user.UserFixture;
 import kr.mybrary.userservice.user.persistence.User;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.test.context.ActiveProfiles;
 
-@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
-@ActiveProfiles("test")
-@DataJpaTest
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+@PersistenceTest
 class UserRepositoryTest {
 
     @Autowired

--- a/backend/user-service/src/test/java/kr/mybrary/userservice/user/presentation/UserControllerTest.java
+++ b/backend/user-service/src/test/java/kr/mybrary/userservice/user/presentation/UserControllerTest.java
@@ -876,4 +876,50 @@ class UserControllerTest {
         );
     }
 
+    @DisplayName("사용자를 탈퇴 처리한다.")
+    @Test
+    void deleteAccount() throws Exception {
+        // given
+        doNothing().when(userService).deleteAccount(any());
+
+        // when
+        ResultActions actions = mockMvc.perform(
+                RestDocumentationRequestBuilders.delete(BASE_URL + "/account")
+                        .with(csrf())
+                        .header("USER-ID", LOGIN_ID));
+
+        // then
+        actions
+                .andExpect(status().is2xxSuccessful())
+                .andExpect(jsonPath("$.status").value(HttpStatus.OK.toString()))
+                .andExpect(jsonPath("$.message").value("회원 탈퇴에 성공했습니다."))
+                .andExpect(jsonPath("$.data").isEmpty());
+
+        verify(userService).deleteAccount(any());
+
+        // docs
+        actions.andDo(document("delete-user",
+                preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()),
+                resource(
+                        ResourceSnippetParameters.builder()
+                                .tag("user")
+                                .summary("사용자를 탈퇴 처리한다.")
+                                .requestHeaders(
+                                        headerWithName("USER-ID").description("로그인 된 사용자의 아이디")
+                                )
+                                .responseSchema(Schema.schema("delete_user_response_body"))
+                                .responseFields(
+                                        fieldWithPath("status").type(JsonFieldType.STRING)
+                                                .description(STATUS_FIELD_DESCRIPTION),
+                                        fieldWithPath("message").type(JsonFieldType.STRING)
+                                                .description(MESSAGE_FIELD_DESCRIPTION),
+                                        fieldWithPath("data").type(JsonFieldType.OBJECT)
+                                                .description("응답 데이터").optional()
+                                )
+                                .build()
+                ))
+        );
+    }
+
 }


### PR DESCRIPTION
## 🧑‍💻 작업 사항

### 회원 탈퇴 API
- 요청
  - DELETE api/v1/users/account
  - header: USER-ID

- 응답
```
{
  "status": "200 OK",
  "message": "회원 탈퇴에 성공했습니다.",
  "data": null
}
```
- 현재 회원 탈퇴 시 단순히 사용자 정보를 soft-delete 처리하고 있습니다. 추후 사용자 탈퇴 시 해당 사용자의 마이북, 마이북리뷰, 획득 뱃지 등을 삭제 처리하기 위한 이벤트 발행을 추가하겠습니다.

### 사용자 정보 조회 API
- 요청
  - GET api/v1/users/info
  - request body
  ```
  {
    "userIds": [
      "loginId1",
      "loginId2",
      "loginId3"
    ]
  }
  ```

- 응답
```
{
  "status": "200 OK",
  "message": "사용자 정보를 모두 조회했습니다.",
  "data": {
    "userInfoElements": [
      {
        "userId": "loginId1",
        "nickname": "nickname1",
        "profileImageUrl": "https://mybrary-user-service.s3.ap-northeast-2.amazonaws.com/profile/profileImage/default.jpg"
      },
      {
        "userId": "loginId2",
        "nickname": "nickname2",
        "profileImageUrl": "https://mybrary-user-service.s3.ap-northeast-2.amazonaws.com/profile/profileImage/default.jpg"
      },
      {
        "userId": "loginId3",
        "nickname": "nickname3",
        "profileImageUrl": "https://mybrary-user-service.s3.ap-northeast-2.amazonaws.com/profile/profileImage/default.jpg"
      }
    ]
  }
}
```

- 요청된 userId로 사용자가 발견되지 않는 경우, 응답에서 제외됩니다.

<br><br>

## 🔗 링크

<!-- 관련된 대화가 이루어진 슬랙 링크 혹은 피그마 링크를 첨부. -->
<!-- - [프레이머](https://framer.com/projects/2--gSDcZoNKqU6dqCUQUYQe-53rEr?node=tQMWSSKqy)  -->

<br><br>

## 🐰 시급한 정도
🐢 천천히 : 급하지 않습니다.

<br><br>

## 📖 참고 사항
### 사용자 식별 값 관련
사용자 식별 값이 loginId와 userId로 혼재되어 불리고 있는 것 같습니다.
서비스 운영 시 소셜 로그인만 서비스할 예정이기 때문에 users 테이블의 login_id 칼럼엔 uuid만 들어가게 됩니다.
따라서 loginId의 의미가 없어지는 것 같기도 하고, uuid 대신 pk로 사용자를 식별해야 되나 싶기도 합니다.
클라이언트-서버 통신 시에는 loginId로 요청을 보내고
서버-서버 통신 시에는 pk로 요청을 보내도록 나누는 것은 또 어떨까 고민됩니다.
관련해서 의견 남겨주시면 감사하겠습니다 😊