### PR TITLE
[IDLE-200] 오늘 등록한 마이북 갯수 조회 API 개발

### DIFF
--- a/backend/book-service/src/main/java/kr/mybrary/bookservice/mybook/domain/MyBookService.java
+++ b/backend/book-service/src/main/java/kr/mybrary/bookservice/mybook/domain/MyBookService.java
@@ -1,5 +1,6 @@
 package kr.mybrary.bookservice.mybook.domain;
 
+import java.time.LocalDate;
 import java.util.List;
 import kr.mybrary.bookservice.book.domain.BookReadService;
 import kr.mybrary.bookservice.book.persistence.Book;
@@ -111,6 +112,11 @@ public class MyBookService {
     @Transactional(readOnly = true)
     public MyBook findMyBookByIdWithBook(Long myBookId) {
         return myBookRepository.findByIdWithBook(myBookId).orElseThrow(MyBookNotFoundException::new);
+    }
+
+    @Transactional(readOnly = true)
+    public Long getBookRegistrationCountOfToday() {
+        return myBookRepository.getBookRegistrationCountOfDay(LocalDate.now());
     }
 
     private void checkBookAlreadyRegisteredAsMyBook(String userId, Book book) {

--- a/backend/book-service/src/main/java/kr/mybrary/bookservice/mybook/domain/MyBookService.java
+++ b/backend/book-service/src/main/java/kr/mybrary/bookservice/mybook/domain/MyBookService.java
@@ -20,6 +20,7 @@ import kr.mybrary.bookservice.mybook.persistence.repository.MyBookRepository;
 import kr.mybrary.bookservice.mybook.presentation.dto.response.MyBookDetailResponse;
 import kr.mybrary.bookservice.mybook.presentation.dto.response.MyBookElementFromMeaningTagResponse;
 import kr.mybrary.bookservice.mybook.presentation.dto.response.MyBookElementResponse;
+import kr.mybrary.bookservice.mybook.presentation.dto.response.MyBookRegistrationCountResponse;
 import kr.mybrary.bookservice.mybook.presentation.dto.response.MyBookUpdateResponse;
 import kr.mybrary.bookservice.tag.domain.MeaningTagService;
 import lombok.RequiredArgsConstructor;
@@ -115,8 +116,9 @@ public class MyBookService {
     }
 
     @Transactional(readOnly = true)
-    public Long getBookRegistrationCountOfToday() {
-        return myBookRepository.getBookRegistrationCountOfDay(LocalDate.now());
+    public MyBookRegistrationCountResponse getBookRegistrationCountOfToday() {
+
+        return MyBookRegistrationCountResponse.of(myBookRepository.getBookRegistrationCountOfDay(LocalDate.now()));
     }
 
     private void checkBookAlreadyRegisteredAsMyBook(String userId, Book book) {

--- a/backend/book-service/src/main/java/kr/mybrary/bookservice/mybook/persistence/repository/MyBookRepositoryCustom.java
+++ b/backend/book-service/src/main/java/kr/mybrary/bookservice/mybook/persistence/repository/MyBookRepositoryCustom.java
@@ -1,5 +1,6 @@
 package kr.mybrary.bookservice.mybook.persistence.repository;
 
+import java.time.LocalDate;
 import java.util.List;
 import kr.mybrary.bookservice.mybook.persistence.MyBookOrderType;
 import kr.mybrary.bookservice.mybook.persistence.ReadStatus;
@@ -9,4 +10,5 @@ public interface MyBookRepositoryCustom {
 
     List<MyBookListDisplayElementModel> findMyBookListDisplayElementModelsByUserId(String userId, MyBookOrderType myBookOrderType, ReadStatus readStatus);
 
+    Long getBookRegistrationCountOfDay(LocalDate date);
 }

--- a/backend/book-service/src/main/java/kr/mybrary/bookservice/mybook/persistence/repository/MyBookRepositoryCustomImpl.java
+++ b/backend/book-service/src/main/java/kr/mybrary/bookservice/mybook/persistence/repository/MyBookRepositoryCustomImpl.java
@@ -8,6 +8,8 @@ import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.List;
 import kr.mybrary.bookservice.book.persistence.bookInfo.BookAuthor;
@@ -59,6 +61,17 @@ public class MyBookRepositoryCustomImpl implements MyBookRepositoryCustom {
         }
 
         return myBookListDisplayElementModel;
+    }
+
+    @Override
+    public Long getBookRegistrationCountOfDay(LocalDate date) {
+        LocalDateTime start = date.atStartOfDay();
+        LocalDateTime end = date.atTime(23, 59, 59, 999_999_999);
+
+        return queryFactory.select(myBook.count())
+                .from(myBook)
+                .where(myBook.createdAt.between(start, end))
+                .fetchOne();
     }
 
     private BooleanExpression eqReadStatus(ReadStatus readStatus) {

--- a/backend/book-service/src/main/java/kr/mybrary/bookservice/mybook/presentation/MyBookController.java
+++ b/backend/book-service/src/main/java/kr/mybrary/bookservice/mybook/presentation/MyBookController.java
@@ -95,4 +95,11 @@ public class MyBookController {
         return ResponseEntity.ok(SuccessResponse.of(HttpStatus.OK.toString(), "의미 태그를 통해서 마이북을 조회했습니다.",
                         myBookService.findByMeaningTagQuote(request)));
     }
+
+    @GetMapping("/mybooks/today-registration-count")
+    public ResponseEntity getTodayRegistrationCount() {
+
+        return ResponseEntity.ok(SuccessResponse.of(HttpStatus.OK.toString(), "오늘의 마이북 등록 수입니다.",
+                        myBookService.getBookRegistrationCountOfToday()));
+    }
 }

--- a/backend/book-service/src/main/java/kr/mybrary/bookservice/mybook/presentation/dto/response/MyBookRegistrationCountResponse.java
+++ b/backend/book-service/src/main/java/kr/mybrary/bookservice/mybook/presentation/dto/response/MyBookRegistrationCountResponse.java
@@ -1,0 +1,17 @@
+package kr.mybrary.bookservice.mybook.presentation.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class MyBookRegistrationCountResponse {
+
+    private Long count;
+
+    public static MyBookRegistrationCountResponse of(Long count) {
+        return MyBookRegistrationCountResponse.builder()
+                .count(count)
+                .build();
+    }
+}

--- a/backend/book-service/src/test/java/kr/mybrary/bookservice/booksearch/domain/AladinBookSearchApiServiceTest.java
+++ b/backend/book-service/src/test/java/kr/mybrary/bookservice/booksearch/domain/AladinBookSearchApiServiceTest.java
@@ -122,7 +122,7 @@ class AladinBookSearchApiServiceTest {
 
         // then
         assertAll(
-                () -> assertThat(bookSearchResultResponse.getBookSearchResult().size()).isEqualTo(10),
+                () -> assertThat(bookSearchResultResponse.getBookSearchResult().size()).isEqualTo(9),
                 () -> assertThat(bookSearchResultResponse.getNextRequestUrl()).isEqualTo(expectNextRequestUrl)
         );
     }

--- a/backend/book-service/src/test/java/kr/mybrary/bookservice/mybook/MybookDtoTestData.java
+++ b/backend/book-service/src/test/java/kr/mybrary/bookservice/mybook/MybookDtoTestData.java
@@ -18,6 +18,7 @@ import kr.mybrary.bookservice.mybook.presentation.dto.response.MyBookDetailRespo
 import kr.mybrary.bookservice.mybook.presentation.dto.response.MyBookElementFromMeaningTagResponse;
 import kr.mybrary.bookservice.mybook.presentation.dto.response.MyBookElementResponse;
 import kr.mybrary.bookservice.mybook.presentation.dto.response.MyBookElementResponse.BookElementResponse;
+import kr.mybrary.bookservice.mybook.presentation.dto.response.MyBookRegistrationCountResponse;
 import kr.mybrary.bookservice.mybook.presentation.dto.response.MyBookUpdateResponse;
 
 public class MybookDtoTestData {
@@ -174,5 +175,11 @@ public class MybookDtoTestData {
                                 .author(Author.builder().name("저자_2").build())
                                 .build()));
 
+    }
+
+    public static MyBookRegistrationCountResponse createMyBookRegistrationCountResponse() {
+        return MyBookRegistrationCountResponse.builder()
+                .count(10L)
+                .build();
     }
 }

--- a/backend/book-service/src/test/java/kr/mybrary/bookservice/mybook/domain/MyBookReadServiceTest.java
+++ b/backend/book-service/src/test/java/kr/mybrary/bookservice/mybook/domain/MyBookReadServiceTest.java
@@ -35,6 +35,7 @@ import kr.mybrary.bookservice.mybook.persistence.repository.MyBookRepository;
 import kr.mybrary.bookservice.mybook.presentation.dto.response.MyBookDetailResponse;
 import kr.mybrary.bookservice.mybook.presentation.dto.response.MyBookElementFromMeaningTagResponse;
 import kr.mybrary.bookservice.mybook.presentation.dto.response.MyBookElementResponse;
+import kr.mybrary.bookservice.mybook.presentation.dto.response.MyBookRegistrationCountResponse;
 import kr.mybrary.bookservice.mybook.presentation.dto.response.MyBookUpdateResponse;
 import kr.mybrary.bookservice.tag.domain.MeaningTagService;
 import org.junit.jupiter.api.DisplayName;
@@ -393,12 +394,12 @@ class MyBookReadServiceTest {
         given(myBookRepository.getBookRegistrationCountOfDay(LocalDate.now())).willReturn(1L);
 
         // when
-        Long count = myBookService.getBookRegistrationCountOfToday();
+        MyBookRegistrationCountResponse response = myBookService.getBookRegistrationCountOfToday();
 
         // then
         assertAll(
                 () -> verify(myBookRepository, times(1)).getBookRegistrationCountOfDay(any()),
-                () -> assertThat(count).isEqualTo(1L)
+                () -> assertThat(response.getCount()).isEqualTo(1L)
         );
     }
 }

--- a/backend/book-service/src/test/java/kr/mybrary/bookservice/mybook/domain/MyBookReadServiceTest.java
+++ b/backend/book-service/src/test/java/kr/mybrary/bookservice/mybook/domain/MyBookReadServiceTest.java
@@ -13,6 +13,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 import kr.mybrary.bookservice.book.BookFixture;
@@ -324,7 +325,8 @@ class MyBookReadServiceTest {
     void findMyBookByMeaningTagQuote() {
 
         // given
-        MyBookFindByMeaningTagQuoteServiceRequest request = MyBookFindByMeaningTagQuoteServiceRequest.of(LOGIN_ID, "quote");
+        MyBookFindByMeaningTagQuoteServiceRequest request = MyBookFindByMeaningTagQuoteServiceRequest.of(LOGIN_ID,
+                "quote");
 
         given(myBookRepository.findByMeaningTagQuote(request.getQuote())).willReturn(
                 List.of(MyBookFixture.COMMON_LOGIN_USER_MYBOOK.getMyBook()));
@@ -380,6 +382,23 @@ class MyBookReadServiceTest {
         assertAll(
                 () -> verify(myBookRepository, times(1)).findByIdWithBook(myBookId),
                 () -> assertThat(foundMyBook).isNotNull()
+        );
+    }
+
+    @DisplayName("오늘 등록된 마이북의 갯수를 조회한다.")
+    @Test
+    void getBookRegistrationCountOfToday() {
+
+        // given
+        given(myBookRepository.getBookRegistrationCountOfDay(LocalDate.now())).willReturn(1L);
+
+        // when
+        Long count = myBookService.getBookRegistrationCountOfToday();
+
+        // then
+        assertAll(
+                () -> verify(myBookRepository, times(1)).getBookRegistrationCountOfDay(any()),
+                () -> assertThat(count).isEqualTo(1L)
         );
     }
 }

--- a/backend/book-service/src/test/java/kr/mybrary/bookservice/mybook/persistence/MyBookRepositoryTest.java
+++ b/backend/book-service/src/test/java/kr/mybrary/bookservice/mybook/persistence/MyBookRepositoryTest.java
@@ -3,6 +3,7 @@ package kr.mybrary.bookservice.mybook.persistence;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 import kr.mybrary.bookservice.PersistenceTest;
@@ -365,6 +366,38 @@ class MyBookRepositoryTest {
                 () -> assertThat(myBookList.size()).isEqualTo(2),
                 () -> assertThat(myBookList).extracting("myBookId")
                         .contains(myBook_1.getId(), myBook_2.getId())
+        );
+    }
+
+    @Test
+    @DisplayName("오늘 등록된 마이북의 갯수를 조회한다.")
+    void getTodayBookRegistrationCount() {
+
+        // when
+        LocalDate today = LocalDate.now();
+
+        Book savedBook_1 = bookRepository.save(BookFixture.COMMON_BOOK_WITHOUT_RELATION.getBookBuilder().isbn10("isbn10_1").isbn13("isbn13_1").build());
+        Book savedBook_2 = bookRepository.save(BookFixture.COMMON_BOOK_WITHOUT_RELATION.getBookBuilder().isbn10("isbn10_2").isbn13("isbn13_2").build());
+        Book savedBook_3 = bookRepository.save(BookFixture.COMMON_BOOK_WITHOUT_RELATION.getBookBuilder().isbn10("isbn10_3").isbn13("isbn13_3").build());
+
+        entityManager.persist(MyBookFixture.MY_BOOK_WITHOUT_RELATION.getMyBookBuilder()
+                .book(savedBook_1).build());
+        entityManager.persist(MyBookFixture.MY_BOOK_WITHOUT_RELATION.getMyBookBuilder()
+                .book(savedBook_2).build());
+        entityManager.persist(MyBookFixture.MY_BOOK_WITHOUT_RELATION.getMyBookBuilder()
+                .book(savedBook_3).build());
+
+        entityManager.flush();
+        entityManager.clear();
+
+        // when
+        Long todayBookRegistrationCount = myBookRepository.getBookRegistrationCountOfDay(today);
+        Long yesterdayBookRegistrationCount = myBookRepository.getBookRegistrationCountOfDay(today.minusDays(1));
+
+        // then
+        assertAll(
+                () -> assertThat(todayBookRegistrationCount).isEqualTo(3L),
+                () -> assertThat(yesterdayBookRegistrationCount).isEqualTo(0L)
         );
     }
 }

--- a/backend/book-service/src/test/java/kr/mybrary/bookservice/mybook/presentation/MyBookControllerTest.java
+++ b/backend/book-service/src/test/java/kr/mybrary/bookservice/mybook/presentation/MyBookControllerTest.java
@@ -34,6 +34,7 @@ import kr.mybrary.bookservice.mybook.presentation.dto.request.MyBookUpdateReques
 import kr.mybrary.bookservice.mybook.presentation.dto.response.MyBookDetailResponse;
 import kr.mybrary.bookservice.mybook.presentation.dto.response.MyBookElementFromMeaningTagResponse;
 import kr.mybrary.bookservice.mybook.presentation.dto.response.MyBookElementResponse;
+import kr.mybrary.bookservice.mybook.presentation.dto.response.MyBookRegistrationCountResponse;
 import kr.mybrary.bookservice.mybook.presentation.dto.response.MyBookUpdateResponse;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -393,5 +394,39 @@ class MyBookControllerTest {
                                                 fieldWithPath("data[].book.starRating").type(NUMBER).description("도서 별점"),
                                                 fieldWithPath("data[].book.publicationDate").type(STRING).description("도서 출판일"))
                                         .build())));
+    }
+
+    @DisplayName("오늘 마이북 등록수를 조회한다.")
+    @Test
+    void getTodayRegistrationCount() throws Exception {
+
+        // given
+        MyBookRegistrationCountResponse response = MybookDtoTestData.createMyBookRegistrationCountResponse();
+        given(myBookService.getBookRegistrationCountOfToday()).willReturn(response);
+
+        // when
+        ResultActions actions = mockMvc.perform(get("/api/v1/mybooks/today-registration-count"));
+
+        // then
+        actions
+                .andExpect(status().is2xxSuccessful())
+                .andExpect(jsonPath("$.status").value("200 OK"))
+                .andExpect(jsonPath("$.message").value("오늘의 마이북 등록 수입니다."))
+                .andExpect(jsonPath("$.data").isNotEmpty());
+
+        // document
+        actions.andDo(document("get-today-mybook-registration-count",
+                preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()),
+                resource(
+                        ResourceSnippetParameters.builder()
+                                .tag("mybook")
+                                .summary("오늘 마이북 등록수를 조회한다.")
+                                .responseSchema(Schema.schema("get_today_mybook_registration_count_response_body"))
+                                .responseFields(
+                                        fieldWithPath("status").type(STRING).description("응답 상태"),
+                                        fieldWithPath("message").type(STRING).description("응답 메시지"),
+                                        fieldWithPath("data.count").type(NUMBER).description("오늘의 마이북 등록 수"))
+                                .build())));
     }
 }


### PR DESCRIPTION
## 🧑‍💻 작업 사항

## 오늘 등록한 마이북 갯수 조회 API 개발
- GET "/api/v1/mybooks/today-registration-count"
- 응답값

```
{
  "status": "200 OK",
  "message": "서재의 도서 목록입니다.",
  "data": {
     "count" : 10
   }
}
```

<br><br>

## 🔗 링크

<!-- 관련된 대화가 이루어진 슬랙 링크 혹은 피그마 링크를 첨부. -->
<!-- - [프레이머](https://framer.com/projects/2--gSDcZoNKqU6dqCUQUYQe-53rEr?node=tQMWSSKqy)  -->

<br><br>

## 🐰 시급한 정도

🏃‍♂️ 보통 : 최대한 빠르게 리뷰 부탁드립니다.

<br><br>

## 📖 참고 사항

<!-- 공유할 내용, 레퍼런스, 추가로 발생할 것으로 예상되는 이슈, 스크린샷 등을 넣어 주세요.  -->
<!-- 변경사항이 큰 경우 집중해야 할 부분, 또는 불안해서 봐주었으면 하는 부분 등 -->
