### PR TITLE
[IDLE-145] feat: 설정 페이지 UI 구현

### DIFF
--- a/frontend/lib/data/datasource/profile/profile_datasource.dart
+++ b/frontend/lib/data/datasource/profile/profile_datasource.dart
@@ -1,6 +1,7 @@
 import 'dart:developer';
 
 import 'package:dio/dio.dart';
+import 'package:mybrary/data/model/common/common_response.dart';
 import 'package:mybrary/data/model/profile/profile_image_response.dart';
 import 'package:mybrary/data/model/profile/profile_response.dart';
 import 'package:mybrary/data/network/api.dart';
@@ -127,5 +128,25 @@ class ProfileDataSource {
     );
 
     return result.data!;
+  }
+
+  Future<CommonResponse> deleteAccount(String userId) async {
+    Dio dio = DioService().to();
+    final deleteAccountResponse = await dio.delete(
+      getApi(API.deleteUserAccount),
+      options: Options(headers: {'User-Id': 'testId'}),
+    );
+
+    log('계정 삭제 응답값: $deleteAccountResponse');
+    final CommonResponse result = commonResponseResult(
+      deleteAccountResponse,
+      () => CommonResponse(
+        status: deleteAccountResponse.data['status'],
+        message: deleteAccountResponse.data['message'],
+        data: null,
+      ),
+    );
+
+    return result;
   }
 }

--- a/frontend/lib/data/network/api.dart
+++ b/frontend/lib/data/network/api.dart
@@ -26,6 +26,7 @@ enum API {
   deleteUserProfileImage,
   deleteUserFollower,
   deleteUserFollowing,
+  deleteUserAccount,
   // book-service search
   getBookService,
   getBookSearchKeyword,
@@ -62,6 +63,7 @@ Map<API, String> apiMap = {
   API.deleteUserProfileImage: "/api/v1/users", // /{userId}/profile/image",
   API.deleteUserFollower: "/api/v1/users/follower",
   API.deleteUserFollowing: "/api/v1/users/follow",
+  API.deleteUserAccount: "/api/v1/users/account",
   // book-service
   API.getBookService: "/api/v1",
   API.getBookSearchKeyword: "/api/v1/books/search",

--- a/frontend/lib/data/repository/profile_repository.dart
+++ b/frontend/lib/data/repository/profile_repository.dart
@@ -1,5 +1,6 @@
 import 'package:dio/dio.dart';
 import 'package:mybrary/data/datasource/profile/profile_datasource.dart';
+import 'package:mybrary/data/model/common/common_response.dart';
 import 'package:mybrary/data/model/profile/profile_image_response.dart';
 import 'package:mybrary/data/model/profile/profile_response.dart';
 
@@ -44,5 +45,11 @@ class ProfileRepository {
     required String userId,
   }) {
     return profileDataSource.deleteProfileImage(userId);
+  }
+
+  Future<CommonResponse> deleteAccount({
+    required String userId,
+  }) {
+    return profileDataSource.deleteAccount(userId);
   }
 }

--- a/frontend/lib/res/constants/config.dart
+++ b/frontend/lib/res/constants/config.dart
@@ -6,3 +6,16 @@ const String accessTokenHeaderKey = 'Authorization';
 const String refreshTokenHeaderKey = 'Authorization-Refresh';
 const String loginIdHeaderKey = 'User-Id';
 const String expiredKey = 'isExpired';
+
+// 설정 페이지 내 링크 관련 상수
+const String noticeAndUpdateLink =
+    'https://ribbon-soil-e35.notion.site/dcec4dc01b2b4ab5bbb7ffba3cf24a6a?pvs=4';
+const String mybraryGuideLink =
+    'https://ribbon-soil-e35.notion.site/feaaf88e77474c4b83b7fb2da9f683d8?pvs=4';
+const String inquiryLink = 'https://open.kakao.com/me/mybrary';
+const String mybraryTermsLink =
+    'https://ribbon-soil-e35.notion.site/21ae953b6edd455e8ed77d5bb16fa4c4?pvs=4';
+const String mybraryPrivacyLink =
+    'https://ribbon-soil-e35.notion.site/847e95af04bb4ffb9c08163672cb990a?pvs=4';
+const String openSourceLicenseLink =
+    'https://ribbon-soil-e35.notion.site/f98bad671bcb4e759e194922c3d787bf?pvs=4';

--- a/frontend/lib/res/constants/style.dart
+++ b/frontend/lib/res/constants/style.dart
@@ -297,3 +297,16 @@ const bookShelfTitleStyle = TextStyle(
   fontSize: 13.0,
   fontWeight: FontWeight.w500,
 );
+
+// setting page style
+const settingTitleStyle = TextStyle(
+  color: grey777777,
+  fontSize: 14.0,
+  fontWeight: FontWeight.w500,
+);
+
+const settingSubTitleStyle = TextStyle(
+  color: grey262626,
+  fontSize: 15.0,
+  fontWeight: FontWeight.w400,
+);

--- a/frontend/lib/res/constants/style.dart
+++ b/frontend/lib/res/constants/style.dart
@@ -310,3 +310,9 @@ const settingSubTitleStyle = TextStyle(
   fontSize: 15.0,
   fontWeight: FontWeight.w400,
 );
+
+const settingInfoStyle = TextStyle(
+  color: commonWhiteColor,
+  fontSize: 14.0,
+  fontWeight: FontWeight.w400,
+);

--- a/frontend/lib/ui/setting/components/account_withdrawal.dart
+++ b/frontend/lib/ui/setting/components/account_withdrawal.dart
@@ -1,0 +1,214 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_svg/svg.dart';
+import 'package:mybrary/data/repository/profile_repository.dart';
+import 'package:mybrary/res/constants/color.dart';
+import 'package:mybrary/res/constants/style.dart';
+import 'package:mybrary/ui/common/layout/subpage_layout.dart';
+
+class AccountWithdrawal extends StatefulWidget {
+  const AccountWithdrawal({
+    super.key,
+  });
+
+  @override
+  State<AccountWithdrawal> createState() => _AccountWithdrawalState();
+}
+
+class _AccountWithdrawalState extends State<AccountWithdrawal> {
+  final _profileRepository = ProfileRepository();
+
+  bool _isChecked = false;
+
+  @override
+  Widget build(BuildContext context) {
+    return SubPageLayout(
+      appBarTitle: '',
+      child: Center(
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.center,
+          children: [
+            Text(
+              '마이브러리 회원 탈퇴',
+              style: commonSubMediumStyle.copyWith(
+                fontSize: 18.0,
+              ),
+            ),
+            const SizedBox(height: 8.0),
+            Text(
+              '회원 탈퇴 전 반드시 아래 내용을 확인해주세요.',
+              style: commonSubRegularStyle.copyWith(
+                color: commonRedColor,
+              ),
+            ),
+            const SizedBox(height: 16.0),
+            Container(
+              color: grey262626,
+              padding: const EdgeInsets.symmetric(
+                horizontal: 24.0,
+                vertical: 42.0,
+              ),
+              child: const Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    '1. 회원 탈퇴 시, 계정 정보는 복구가 불가능합니다.',
+                    style: settingInfoStyle,
+                  ),
+                  SizedBox(height: 12.0),
+                  Text(
+                    '2. 사용자 신고 등 부정 이용에 대한 조치를 위해 해당 정보는 6개월 간 보존됩니다.',
+                    style: settingInfoStyle,
+                  ),
+                  SizedBox(height: 12.0),
+                  Text(
+                    '3. 등록된 리뷰 혹은 도서는 자동으로 삭제되지 않습니다. 탈퇴 전 개별적으로 삭제하시기 바랍니다.',
+                    style: settingInfoStyle,
+                  ),
+                ],
+              ),
+            ),
+            const SizedBox(height: 24.0),
+            InkWell(
+              onTap: () {
+                setState(() {
+                  _isChecked = !_isChecked;
+                });
+              },
+              child: Padding(
+                padding: const EdgeInsets.all(16.0),
+                child: Container(
+                  padding: const EdgeInsets.all(16.0),
+                  decoration: BoxDecoration(
+                    color: greyF1F2F5,
+                    borderRadius: BorderRadius.circular(8.0),
+                  ),
+                  child: Row(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      SvgPicture.asset(
+                          'assets/svg/icon/small/heart${_isChecked ? '_green' : ''}.svg'),
+                      const SizedBox(width: 8.0),
+                      Text(
+                        '위 내용을 확인하였으며, 회원 탈퇴에 동의합니다.',
+                        style: commonSubMediumStyle.copyWith(
+                          height: 1.2,
+                          fontSize: 14.0,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ),
+            const SizedBox(height: 12.0),
+            InkWell(
+              onTap: () async {
+                await showDialog(
+                  context: context,
+                  builder: (BuildContext context) {
+                    return AlertDialog(
+                      title: const Text(
+                        '회원탈퇴',
+                        style: commonSubBoldStyle,
+                        textAlign: TextAlign.center,
+                      ),
+                      content: const Text(
+                        '정말 회원을 탈퇴하시겠습니까?',
+                        style: confirmButtonTextStyle,
+                        textAlign: TextAlign.center,
+                      ),
+                      contentPadding: const EdgeInsets.only(
+                        top: 24.0,
+                        bottom: 16.0,
+                      ),
+                      actionsAlignment: MainAxisAlignment.center,
+                      buttonPadding:
+                          const EdgeInsets.symmetric(horizontal: 8.0),
+                      actions: [
+                        Row(
+                          children: [
+                            _confirmButton(
+                              onTap: () {
+                                Navigator.of(context).pop();
+                              },
+                              buttonText: '취소',
+                              isCancel: true,
+                            ),
+                            _confirmButton(
+                              onTap: () async {
+                                await _profileRepository.deleteAccount(
+                                  userId: 'testId',
+                                );
+
+                                Future.delayed(
+                                    const Duration(milliseconds: 500), () {
+                                  Navigator.of(context).pushNamedAndRemoveUntil(
+                                    '/signin',
+                                    (Route<dynamic> route) => false,
+                                  );
+                                });
+                              },
+                              buttonText: '탈퇴하기',
+                              isCancel: false,
+                            ),
+                          ],
+                        ),
+                      ],
+                    );
+                  },
+                );
+              },
+              child: Container(
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 16.0,
+                  vertical: 8.0,
+                ),
+                decoration: BoxDecoration(
+                  color: commonRedColor,
+                  borderRadius: BorderRadius.circular(4.0),
+                ),
+                child: Text(
+                  '회원 탈퇴',
+                  style: commonSubRegularStyle.copyWith(
+                    color: commonWhiteColor,
+                  ),
+                ),
+              ),
+            )
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _confirmButton({
+    required GestureTapCallback? onTap,
+    required String buttonText,
+    required bool isCancel,
+  }) {
+    return Expanded(
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 4.0),
+        child: InkWell(
+          onTap: onTap,
+          child: Container(
+            height: 46.0,
+            decoration: BoxDecoration(
+              color: isCancel ? greyF1F2F5 : commonRedColor,
+              borderRadius: BorderRadius.circular(4.0),
+            ),
+            child: Center(
+              child: Text(
+                buttonText,
+                style: commonSubBoldStyle.copyWith(
+                  color: isCancel ? commonBlackColor : commonWhiteColor,
+                  fontSize: 14.0,
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/frontend/lib/ui/setting/components/account_withdrawal.dart
+++ b/frontend/lib/ui/setting/components/account_withdrawal.dart
@@ -86,7 +86,7 @@ class _AccountWithdrawalState extends State<AccountWithdrawal> {
                     mainAxisAlignment: MainAxisAlignment.center,
                     children: [
                       SvgPicture.asset(
-                          'assets/svg/icon/small/heart${_isChecked ? '_green' : ''}.svg'),
+                          'assets/svg/icon/small/checkbox_${_isChecked ? 'green' : 'grey'}.svg'),
                       const SizedBox(width: 8.0),
                       Text(
                         '위 내용을 확인하였으며, 회원 탈퇴에 동의합니다.',

--- a/frontend/lib/ui/setting/components/account_withdrawal.dart
+++ b/frontend/lib/ui/setting/components/account_withdrawal.dart
@@ -103,60 +103,63 @@ class _AccountWithdrawalState extends State<AccountWithdrawal> {
             const SizedBox(height: 12.0),
             InkWell(
               onTap: () async {
-                await showDialog(
-                  context: context,
-                  builder: (BuildContext context) {
-                    return AlertDialog(
-                      title: const Text(
-                        '회원탈퇴',
-                        style: commonSubBoldStyle,
-                        textAlign: TextAlign.center,
-                      ),
-                      content: const Text(
-                        '정말 회원을 탈퇴하시겠습니까?',
-                        style: confirmButtonTextStyle,
-                        textAlign: TextAlign.center,
-                      ),
-                      contentPadding: const EdgeInsets.only(
-                        top: 24.0,
-                        bottom: 16.0,
-                      ),
-                      actionsAlignment: MainAxisAlignment.center,
-                      buttonPadding:
-                          const EdgeInsets.symmetric(horizontal: 8.0),
-                      actions: [
-                        Row(
-                          children: [
-                            _confirmButton(
-                              onTap: () {
-                                Navigator.of(context).pop();
-                              },
-                              buttonText: '취소',
-                              isCancel: true,
-                            ),
-                            _confirmButton(
-                              onTap: () async {
-                                await _profileRepository.deleteAccount(
-                                  userId: 'testId',
-                                );
-
-                                Future.delayed(
-                                    const Duration(milliseconds: 500), () {
-                                  Navigator.of(context).pushNamedAndRemoveUntil(
-                                    '/signin',
-                                    (Route<dynamic> route) => false,
-                                  );
-                                });
-                              },
-                              buttonText: '탈퇴하기',
-                              isCancel: false,
-                            ),
-                          ],
+                if (_isChecked) {
+                  await showDialog(
+                    context: context,
+                    builder: (BuildContext context) {
+                      return AlertDialog(
+                        title: const Text(
+                          '회원탈퇴',
+                          style: commonSubBoldStyle,
+                          textAlign: TextAlign.center,
                         ),
-                      ],
-                    );
-                  },
-                );
+                        content: const Text(
+                          '정말 회원을 탈퇴하시겠습니까?',
+                          style: confirmButtonTextStyle,
+                          textAlign: TextAlign.center,
+                        ),
+                        contentPadding: const EdgeInsets.only(
+                          top: 24.0,
+                          bottom: 16.0,
+                        ),
+                        actionsAlignment: MainAxisAlignment.center,
+                        buttonPadding:
+                            const EdgeInsets.symmetric(horizontal: 8.0),
+                        actions: [
+                          Row(
+                            children: [
+                              _confirmButton(
+                                onTap: () {
+                                  Navigator.of(context).pop();
+                                },
+                                buttonText: '취소',
+                                isCancel: true,
+                              ),
+                              _confirmButton(
+                                onTap: () async {
+                                  await _profileRepository.deleteAccount(
+                                    userId: 'testId',
+                                  );
+
+                                  Future.delayed(
+                                      const Duration(milliseconds: 500), () {
+                                    Navigator.of(context)
+                                        .pushNamedAndRemoveUntil(
+                                      '/signin',
+                                      (Route<dynamic> route) => false,
+                                    );
+                                  });
+                                },
+                                buttonText: '탈퇴하기',
+                                isCancel: false,
+                              ),
+                            ],
+                          ),
+                        ],
+                      );
+                    },
+                  );
+                }
               },
               child: Container(
                 padding: const EdgeInsets.symmetric(
@@ -164,7 +167,7 @@ class _AccountWithdrawalState extends State<AccountWithdrawal> {
                   vertical: 8.0,
                 ),
                 decoration: BoxDecoration(
-                  color: commonRedColor,
+                  color: _isChecked ? commonRedColor : greyACACAC,
                   borderRadius: BorderRadius.circular(4.0),
                 ),
                 child: Text(

--- a/frontend/lib/ui/setting/setting_screen.dart
+++ b/frontend/lib/ui/setting/setting_screen.dart
@@ -54,7 +54,7 @@ class SettingScreen extends StatelessWidget {
                         );
                       },
                     ),
-                    const SizedBox(height: 30.0),
+                    const SizedBox(height: 24.0),
                     const Text(
                       '서비스 안내',
                       style: settingTitleStyle,
@@ -89,7 +89,7 @@ class SettingScreen extends StatelessWidget {
                         }
                       },
                     ),
-                    const SizedBox(height: 30.0),
+                    const SizedBox(height: 24.0),
                     const Text(
                       '법적 고지 및 정책',
                       style: settingTitleStyle,
@@ -119,7 +119,7 @@ class SettingScreen extends StatelessWidget {
                         );
                       },
                     ),
-                    const SizedBox(height: 30.0),
+                    const SizedBox(height: 24.0),
                     const Text(
                       '기타',
                       style: settingTitleStyle,
@@ -156,13 +156,15 @@ class SettingScreen extends StatelessWidget {
                       child: Container(
                         width: double.infinity,
                         alignment: Alignment.centerRight,
-                        padding: const EdgeInsets.only(right: 4.0),
+                        padding: const EdgeInsets.symmetric(
+                            horizontal: 12.0, vertical: 6.0),
                         child: const Text(
                           '탈퇴하기',
                           style: settingTitleStyle,
                         ),
                       ),
                     ),
+                    const SizedBox(height: 24.0),
                   ],
                 ),
               ),
@@ -248,7 +250,10 @@ class SettingScreen extends StatelessWidget {
     required GestureTapCallback onTap,
   }) {
     return Container(
-      padding: const EdgeInsets.all(14.0),
+      padding: const EdgeInsets.symmetric(
+        horizontal: 12.0,
+        vertical: 16.0,
+      ),
       child: InkWell(
         onTap: onTap,
         child: Row(

--- a/frontend/lib/ui/setting/setting_screen.dart
+++ b/frontend/lib/ui/setting/setting_screen.dart
@@ -2,9 +2,13 @@ import 'package:flutter/material.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:mybrary/res/constants/color.dart';
+import 'package:mybrary/res/constants/config.dart';
 import 'package:mybrary/res/constants/style.dart';
+import 'package:mybrary/ui/common/components/error_page.dart';
 import 'package:mybrary/ui/common/layout/default_layout.dart';
+import 'package:mybrary/ui/common/layout/subpage_layout.dart';
 import 'package:mybrary/ui/profile/profile_edit/profile_edit_screen.dart';
+import 'package:mybrary/ui/setting/components/account_withdrawal.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 class SettingScreen extends StatelessWidget {
@@ -50,11 +54,7 @@ class SettingScreen extends StatelessWidget {
                         );
                       },
                     ),
-                    _settingTab(
-                      tabTitle: '로그인 정보',
-                      onTap: () {},
-                    ),
-                    const SizedBox(height: 26.0),
+                    const SizedBox(height: 30.0),
                     const Text(
                       '서비스 안내',
                       style: settingTitleStyle,
@@ -64,8 +64,7 @@ class SettingScreen extends StatelessWidget {
                       tabTitle: '공지사항 / 업데이트 소식',
                       onTap: () async {
                         await launchUrl(
-                          Uri.parse(
-                              'https://ribbon-soil-e35.notion.site/dcec4dc01b2b4ab5bbb7ffba3cf24a6a?pvs=4'),
+                          Uri.parse(noticeAndUpdateLink),
                         );
                       },
                     ),
@@ -73,15 +72,14 @@ class SettingScreen extends StatelessWidget {
                       tabTitle: '마이브러리 가이드',
                       onTap: () async {
                         await launchUrl(
-                          Uri.parse(
-                              'https://ribbon-soil-e35.notion.site/feaaf88e77474c4b83b7fb2da9f683d8?pvs=4'),
+                          Uri.parse(mybraryGuideLink),
                         );
                       },
                     ),
                     _settingTab(
-                      tabTitle: '1:1 문의 및 요청',
+                      tabTitle: '1:1 문의하기',
                       onTap: () async {
-                        String url = 'https://open.kakao.com/me/mybrary';
+                        String url = inquiryLink;
                         if (await canLaunchUrl(Uri.parse(url))) {
                           await launchUrl(
                             Uri.parse(url),
@@ -91,7 +89,7 @@ class SettingScreen extends StatelessWidget {
                         }
                       },
                     ),
-                    const SizedBox(height: 26.0),
+                    const SizedBox(height: 30.0),
                     const Text(
                       '법적 고지 및 정책',
                       style: settingTitleStyle,
@@ -101,8 +99,7 @@ class SettingScreen extends StatelessWidget {
                       tabTitle: '마이브러리 이용약관',
                       onTap: () async {
                         await launchUrl(
-                          Uri.parse(
-                              'https://ribbon-soil-e35.notion.site/21ae953b6edd455e8ed77d5bb16fa4c4?pvs=4'),
+                          Uri.parse(mybraryTermsLink),
                         );
                       },
                     ),
@@ -110,8 +107,7 @@ class SettingScreen extends StatelessWidget {
                       tabTitle: '개인정보 처리방침',
                       onTap: () async {
                         await launchUrl(
-                          Uri.parse(
-                              'https://ribbon-soil-e35.notion.site/847e95af04bb4ffb9c08163672cb990a?pvs=4'),
+                          Uri.parse(mybraryPrivacyLink),
                         );
                       },
                     ),
@@ -119,12 +115,11 @@ class SettingScreen extends StatelessWidget {
                       tabTitle: '오픈소스 라이선스',
                       onTap: () async {
                         await launchUrl(
-                          Uri.parse(
-                              'https://ribbon-soil-e35.notion.site/f98bad671bcb4e759e194922c3d787bf?pvs=4'),
+                          Uri.parse(openSourceLicenseLink),
                         );
                       },
                     ),
-                    const SizedBox(height: 26.0),
+                    const SizedBox(height: 30.0),
                     const Text(
                       '기타',
                       style: settingTitleStyle,
@@ -132,87 +127,40 @@ class SettingScreen extends StatelessWidget {
                     const SizedBox(height: 12.0),
                     _settingTab(
                       tabTitle: '리뷰로 응원하기',
-                      onTap: () {},
+                      onTap: () {
+                        Navigator.of(context).push(
+                          MaterialPageRoute(
+                            builder: (context) => _settingTempPage(),
+                          ),
+                        );
+                      },
                     ),
                     _settingTab(
                       tabTitle: '로그아웃',
                       onTap: () async {
-                        await showDialog(
-                          context: context,
-                          builder: (BuildContext context) {
-                            return AlertDialog(
-                              title: const Text(
-                                '로그아웃',
-                                style: commonSubBoldStyle,
-                                textAlign: TextAlign.center,
-                              ),
-                              content: Wrap(
-                                alignment: WrapAlignment.center,
-                                children: [
-                                  const Text(
-                                    '정말',
-                                    style: confirmButtonTextStyle,
-                                  ),
-                                  Text(
-                                    ' 로그아웃 ',
-                                    style: confirmButtonTextStyle.copyWith(
-                                      color: commonRedColor,
-                                    ),
-                                  ),
-                                  const Text(
-                                    '하시겠습니까?',
-                                    style: confirmButtonTextStyle,
-                                  ),
-                                ],
-                              ),
-                              contentPadding: const EdgeInsets.only(
-                                top: 24.0,
-                                bottom: 16.0,
-                              ),
-                              actionsAlignment: MainAxisAlignment.center,
-                              buttonPadding:
-                                  const EdgeInsets.symmetric(horizontal: 8.0),
-                              actions: [
-                                Row(
-                                  children: [
-                                    _confirmButton(
-                                      onTap: () {
-                                        Navigator.of(context).pop();
-                                      },
-                                      buttonText: '취소',
-                                      isCancel: true,
-                                    ),
-                                    _confirmButton(
-                                      onTap: () async {
-                                        await secureStorage.deleteAll();
-
-                                        if (context.mounted) {
-                                          Navigator.of(context)
-                                              .pushNamedAndRemoveUntil(
-                                            '/signin',
-                                            (Route<dynamic> route) => false,
-                                          );
-                                        }
-                                      },
-                                      buttonText: '삭제',
-                                      isCancel: false,
-                                    ),
-                                  ],
-                                ),
-                              ],
-                            );
-                          },
+                        await _showLogoutAlert(
+                          context,
+                          secureStorage,
                         );
                       },
                     ),
-                    const SizedBox(height: 6.0),
-                    Container(
-                      width: double.infinity,
-                      alignment: Alignment.centerRight,
-                      padding: const EdgeInsets.only(right: 4.0),
-                      child: const Text(
-                        '탈퇴하기',
-                        style: settingTitleStyle,
+                    const SizedBox(height: 12.0),
+                    InkWell(
+                      onTap: () {
+                        Navigator.of(context).push(
+                          MaterialPageRoute(
+                            builder: (context) => const AccountWithdrawal(),
+                          ),
+                        );
+                      },
+                      child: Container(
+                        width: double.infinity,
+                        alignment: Alignment.centerRight,
+                        padding: const EdgeInsets.only(right: 4.0),
+                        child: const Text(
+                          '탈퇴하기',
+                          style: settingTitleStyle,
+                        ),
                       ),
                     ),
                   ],
@@ -225,12 +173,82 @@ class SettingScreen extends StatelessWidget {
     );
   }
 
+  SubPageLayout _settingTempPage() {
+    return const SubPageLayout(
+      appBarTitle: '리뷰로 응원하기',
+      child: Align(
+        alignment: Alignment.center,
+        child: Column(
+          children: [
+            ErrorPage(
+              errorMessage: '곧 서비스 링크가 열릴 예정이에요!',
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Future<dynamic> _showLogoutAlert(
+      BuildContext context, FlutterSecureStorage secureStorage) async {
+    return await showDialog(
+      context: context,
+      builder: (BuildContext context) {
+        return AlertDialog(
+          title: const Text(
+            '로그아웃',
+            style: commonSubBoldStyle,
+            textAlign: TextAlign.center,
+          ),
+          content: const Text(
+            '정말 로그아웃 하시겠습니까?',
+            style: confirmButtonTextStyle,
+            textAlign: TextAlign.center,
+          ),
+          contentPadding: const EdgeInsets.only(
+            top: 24.0,
+            bottom: 16.0,
+          ),
+          actionsAlignment: MainAxisAlignment.center,
+          buttonPadding: const EdgeInsets.symmetric(horizontal: 8.0),
+          actions: [
+            Row(
+              children: [
+                _confirmButton(
+                  onTap: () {
+                    Navigator.of(context).pop();
+                  },
+                  buttonText: '취소',
+                  isCancel: true,
+                ),
+                _confirmButton(
+                  onTap: () async {
+                    await secureStorage.deleteAll();
+
+                    if (context.mounted) {
+                      Navigator.of(context).pushNamedAndRemoveUntil(
+                        '/signin',
+                        (Route<dynamic> route) => false,
+                      );
+                    }
+                  },
+                  buttonText: '로그아웃',
+                  isCancel: false,
+                ),
+              ],
+            ),
+          ],
+        );
+      },
+    );
+  }
+
   Container _settingTab({
     required String tabTitle,
     required GestureTapCallback onTap,
   }) {
     return Container(
-      padding: const EdgeInsets.all(12.0),
+      padding: const EdgeInsets.all(14.0),
       child: InkWell(
         onTap: onTap,
         child: Row(
@@ -263,7 +281,7 @@ class SettingScreen extends StatelessWidget {
           child: Container(
             height: 46.0,
             decoration: BoxDecoration(
-              color: isCancel ? greyF1F2F5 : primaryColor,
+              color: isCancel ? greyF1F2F5 : commonRedColor,
               borderRadius: BorderRadius.circular(4.0),
             ),
             child: Center(

--- a/frontend/lib/ui/setting/setting_screen.dart
+++ b/frontend/lib/ui/setting/setting_screen.dart
@@ -1,13 +1,19 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:flutter_svg/flutter_svg.dart';
 import 'package:mybrary/res/constants/color.dart';
 import 'package:mybrary/res/constants/style.dart';
 import 'package:mybrary/ui/common/layout/default_layout.dart';
+import 'package:mybrary/ui/profile/profile_edit/profile_edit_screen.dart';
+import 'package:url_launcher/url_launcher.dart';
 
 class SettingScreen extends StatelessWidget {
   const SettingScreen({super.key});
 
   @override
   Widget build(BuildContext context) {
+    const secureStorage = FlutterSecureStorage();
+
     return DefaultLayout(
       appBar: AppBar(
         backgroundColor: commonWhiteColor,
@@ -19,8 +25,258 @@ class SettingScreen extends StatelessWidget {
         centerTitle: true,
         foregroundColor: commonBlackColor,
       ),
-      child: Center(
-        child: Text('설정'),
+      child: Column(
+        children: [
+          Expanded(
+            child: SingleChildScrollView(
+              physics: const BouncingScrollPhysics(),
+              child: Padding(
+                padding: const EdgeInsets.all(16.0),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    const Text(
+                      '설정',
+                      style: settingTitleStyle,
+                    ),
+                    const SizedBox(height: 12.0),
+                    _settingTab(
+                      tabTitle: '프로필 편집',
+                      onTap: () {
+                        Navigator.of(context).push(
+                          MaterialPageRoute(
+                            builder: (context) => const ProfileEditScreen(),
+                          ),
+                        );
+                      },
+                    ),
+                    _settingTab(
+                      tabTitle: '로그인 정보',
+                      onTap: () {},
+                    ),
+                    const SizedBox(height: 26.0),
+                    const Text(
+                      '서비스 안내',
+                      style: settingTitleStyle,
+                    ),
+                    const SizedBox(height: 12.0),
+                    _settingTab(
+                      tabTitle: '공지사항 / 업데이트 소식',
+                      onTap: () async {
+                        await launchUrl(
+                          Uri.parse(
+                              'https://ribbon-soil-e35.notion.site/dcec4dc01b2b4ab5bbb7ffba3cf24a6a?pvs=4'),
+                        );
+                      },
+                    ),
+                    _settingTab(
+                      tabTitle: '마이브러리 가이드',
+                      onTap: () async {
+                        await launchUrl(
+                          Uri.parse(
+                              'https://ribbon-soil-e35.notion.site/feaaf88e77474c4b83b7fb2da9f683d8?pvs=4'),
+                        );
+                      },
+                    ),
+                    _settingTab(
+                      tabTitle: '1:1 문의 및 요청',
+                      onTap: () async {
+                        String url = 'https://open.kakao.com/me/mybrary';
+                        if (await canLaunchUrl(Uri.parse(url))) {
+                          await launchUrl(
+                            Uri.parse(url),
+                            mode: LaunchMode.externalApplication,
+                            webOnlyWindowName: '_self',
+                          );
+                        }
+                      },
+                    ),
+                    const SizedBox(height: 26.0),
+                    const Text(
+                      '법적 고지 및 정책',
+                      style: settingTitleStyle,
+                    ),
+                    const SizedBox(height: 12.0),
+                    _settingTab(
+                      tabTitle: '마이브러리 이용약관',
+                      onTap: () async {
+                        await launchUrl(
+                          Uri.parse(
+                              'https://ribbon-soil-e35.notion.site/21ae953b6edd455e8ed77d5bb16fa4c4?pvs=4'),
+                        );
+                      },
+                    ),
+                    _settingTab(
+                      tabTitle: '개인정보 처리방침',
+                      onTap: () async {
+                        await launchUrl(
+                          Uri.parse(
+                              'https://ribbon-soil-e35.notion.site/847e95af04bb4ffb9c08163672cb990a?pvs=4'),
+                        );
+                      },
+                    ),
+                    _settingTab(
+                      tabTitle: '오픈소스 라이선스',
+                      onTap: () async {
+                        await launchUrl(
+                          Uri.parse(
+                              'https://ribbon-soil-e35.notion.site/f98bad671bcb4e759e194922c3d787bf?pvs=4'),
+                        );
+                      },
+                    ),
+                    const SizedBox(height: 26.0),
+                    const Text(
+                      '기타',
+                      style: settingTitleStyle,
+                    ),
+                    const SizedBox(height: 12.0),
+                    _settingTab(
+                      tabTitle: '리뷰로 응원하기',
+                      onTap: () {},
+                    ),
+                    _settingTab(
+                      tabTitle: '로그아웃',
+                      onTap: () async {
+                        await showDialog(
+                          context: context,
+                          builder: (BuildContext context) {
+                            return AlertDialog(
+                              title: const Text(
+                                '로그아웃',
+                                style: commonSubBoldStyle,
+                                textAlign: TextAlign.center,
+                              ),
+                              content: Wrap(
+                                alignment: WrapAlignment.center,
+                                children: [
+                                  const Text(
+                                    '정말',
+                                    style: confirmButtonTextStyle,
+                                  ),
+                                  Text(
+                                    ' 로그아웃 ',
+                                    style: confirmButtonTextStyle.copyWith(
+                                      color: commonRedColor,
+                                    ),
+                                  ),
+                                  const Text(
+                                    '하시겠습니까?',
+                                    style: confirmButtonTextStyle,
+                                  ),
+                                ],
+                              ),
+                              contentPadding: const EdgeInsets.only(
+                                top: 24.0,
+                                bottom: 16.0,
+                              ),
+                              actionsAlignment: MainAxisAlignment.center,
+                              buttonPadding:
+                                  const EdgeInsets.symmetric(horizontal: 8.0),
+                              actions: [
+                                Row(
+                                  children: [
+                                    _confirmButton(
+                                      onTap: () {
+                                        Navigator.of(context).pop();
+                                      },
+                                      buttonText: '취소',
+                                      isCancel: true,
+                                    ),
+                                    _confirmButton(
+                                      onTap: () async {
+                                        await secureStorage.deleteAll();
+
+                                        if (context.mounted) {
+                                          Navigator.of(context)
+                                              .pushNamedAndRemoveUntil(
+                                            '/signin',
+                                            (Route<dynamic> route) => false,
+                                          );
+                                        }
+                                      },
+                                      buttonText: '삭제',
+                                      isCancel: false,
+                                    ),
+                                  ],
+                                ),
+                              ],
+                            );
+                          },
+                        );
+                      },
+                    ),
+                    const SizedBox(height: 6.0),
+                    Container(
+                      width: double.infinity,
+                      alignment: Alignment.centerRight,
+                      padding: const EdgeInsets.only(right: 4.0),
+                      child: const Text(
+                        '탈퇴하기',
+                        style: settingTitleStyle,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Container _settingTab({
+    required String tabTitle,
+    required GestureTapCallback onTap,
+  }) {
+    return Container(
+      padding: const EdgeInsets.all(12.0),
+      child: InkWell(
+        onTap: onTap,
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          crossAxisAlignment: CrossAxisAlignment.center,
+          children: [
+            Text(
+              tabTitle,
+              style: settingSubTitleStyle,
+            ),
+            SvgPicture.asset(
+              'assets/svg/icon/profile_menu_arrow.svg',
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _confirmButton({
+    required GestureTapCallback? onTap,
+    required String buttonText,
+    required bool isCancel,
+  }) {
+    return Expanded(
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 4.0),
+        child: InkWell(
+          onTap: onTap,
+          child: Container(
+            height: 46.0,
+            decoration: BoxDecoration(
+              color: isCancel ? greyF1F2F5 : primaryColor,
+              borderRadius: BorderRadius.circular(4.0),
+            ),
+            child: Center(
+              child: Text(
+                buttonText,
+                style: commonSubBoldStyle.copyWith(
+                  color: isCancel ? commonBlackColor : commonWhiteColor,
+                  fontSize: 14.0,
+                ),
+              ),
+            ),
+          ),
+        ),
       ),
     );
   }


### PR DESCRIPTION
## 🧑‍💻 작업 사항

### 설정 페이지 - 프로필 편집 및 기타 페이지, 로그아웃 / 정책 관련 노션 이동 / 탈퇴하기

<div>
<img src="https://github.com/SWM-IDLE/mybrary/assets/97138841/b53a090f-d002-42db-951d-ef79e460a2e6" alt="설정 프로필편집 및 기타페이지" width="260" height="580"/>
<img src="https://github.com/SWM-IDLE/mybrary/assets/97138841/0ca4fd2e-5ad8-41eb-acf3-e67fadbd6665" alt="설정 노션 이동" width="260" height="580"/>
<img src="https://github.com/SWM-IDLE/mybrary/assets/97138841/865f7f30-5c5b-4e4d-bb08-112cbf23802b" alt="설정 탈퇴하기" width="260" height="580"/>
</div>

<br>

설정 페이지
- 프로필에서 설정 페이지 이동 및 프로필 편집, 기타 페이지, 로그아웃 UI 구현
  - 로그아웃 시 기기 내 토큰 제거 및 로그인 화면 이동
- 마이브러리 정책 및 공지사항 노션 페이지 링크 이동
- 설정 탈퇴하기 UI 구현 및 탈퇴 api 연동
  - 체크 박스로 동의해야 탈퇴하기 버튼 활성화

<br>

### 1:1 문의하기 - 마이브러리 카카오톡 채널로 이동

<div>
<img src="https://github.com/SWM-IDLE/mybrary/assets/97138841/f6761895-a0ee-4c4f-908c-532ff9fd3fa6" alt="설정카카오채널이동" width="260" height="580"/>
</div>

<br>

- 설정 페이지에서 1:1 문의하기 누르면 마이브러리 카카오톡 채널로 이동
  - 카카오톡이 설치되지 않은 사용자는 플레이 스토어로 이동
  - 추후 링크로 띄우는 방향도 생각

<br><br>

## 🔗 링크

<br><br>

## 🐰 시급한 정도

🏃‍♂️ 보통 : 최대한 빠르게 리뷰 부탁드립니다.

<br><br>

## 📖 참고 사항

- 공지사항 및 업데이트 소식, 마이브러리 가이드 관련해서 노션에 내용을 작성해야 합니다..!
- 오픈소스 라이선스는 정리해서 노션에 올릴 예정입니다.
- 로그아웃과 탈퇴하기는 소셜 로그인 연동 후 재 테스트 해보겠습니다!

<br>