### PR TITLE
[IDLE-223] fix: 마이북 테스트 중 버그 해결

### DIFF
--- a/frontend/ios/Runner/Info.plist
+++ b/frontend/ios/Runner/Info.plist
@@ -37,6 +37,11 @@
 	</array>
 	<key>CFBundleVersion</key>
 	<string>$(FLUTTER_BUILD_NUMBER)</string>
+	<key>LSApplicationQueriesSchemes</key>
+    <array>
+        <string>http</string>
+        <string>https</string>
+    </array>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSCameraUsageDescription</key>

--- a/frontend/lib/res/constants/style.dart
+++ b/frontend/lib/res/constants/style.dart
@@ -221,7 +221,7 @@ const bookDetailSubStyle = TextStyle(
 
 const bookDetailInfoStyle = TextStyle(
   height: 1.5,
-  color: grey777777,
+  color: commonBlackColor,
   fontSize: 16.0,
   fontWeight: FontWeight.w300,
 );

--- a/frontend/lib/ui/mybook/components/mybook_header.dart
+++ b/frontend/lib/ui/mybook/components/mybook_header.dart
@@ -47,7 +47,8 @@ class MyBookHeader extends StatelessWidget {
               _headerButton(
                 context: context,
                 status: '완독북',
-                iconUrl: 'read.svg',
+                iconUrl:
+                    completedBooksData.isEmpty ? 'read.svg' : 'read_green.svg',
                 count: '${completedBooksData.length}',
                 onTap: () => onTapMyBook!(
                   status: '완독북',

--- a/frontend/lib/ui/mybook/mybook_detail/components/mybook_detail_record.dart
+++ b/frontend/lib/ui/mybook/mybook_detail/components/mybook_detail_record.dart
@@ -58,7 +58,7 @@ class MyBookDetailRecord extends StatelessWidget {
               itemDescription:
                   meaningTagQuote == '' ? '어떤 의미인가요?' : meaningTagQuote,
               colorCode: meaningTagColorCode == ''
-                  ? grey777777
+                  ? commonBlackColor
                   : Color(
                       int.parse('0xFF$meaningTagColorCode'),
                     ),

--- a/frontend/lib/ui/mybook/mybook_detail/components/mybook_edit_review.dart
+++ b/frontend/lib/ui/mybook/mybook_detail/components/mybook_edit_review.dart
@@ -38,31 +38,83 @@ class _MyBookEditReviewState extends State<MyBookEditReview> {
   final _bookRepository = BookRepository();
 
   double? newStarRating;
+  String? newContent;
 
   @override
   Widget build(BuildContext context) {
-    return DefaultLayout(
-      child: CustomScrollView(
-        keyboardDismissBehavior: ScrollViewKeyboardDismissBehavior.onDrag,
-        physics: const BouncingScrollPhysics(
-          parent: AlwaysScrollableScrollPhysics(),
-        ),
-        slivers: [
-          _myBookEditAppBar(context),
-          SliverToBoxAdapter(
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                _reviewHeader(),
-                const SizedBox(height: 20.0),
-                _reviewBody(context),
-                const SizedBox(height: 20.0),
-              ],
-            ),
+    return WillPopScope(
+      onWillPop: () {
+        return _onBackKey(context);
+      },
+      child: DefaultLayout(
+        child: CustomScrollView(
+          keyboardDismissBehavior: ScrollViewKeyboardDismissBehavior.onDrag,
+          physics: const BouncingScrollPhysics(
+            parent: AlwaysScrollableScrollPhysics(),
           ),
-        ],
+          slivers: [
+            _myBookEditAppBar(context),
+            SliverToBoxAdapter(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  _reviewHeader(),
+                  const SizedBox(height: 20.0),
+                  _reviewBody(context),
+                  const SizedBox(height: 20.0),
+                ],
+              ),
+            ),
+          ],
+        ),
       ),
     );
+  }
+
+  Future<bool> _onBackKey(BuildContext context) async {
+    if (newStarRating != null || newContent != null) {
+      return await showDialog(
+        context: context,
+        builder: (BuildContext context) {
+          return AlertDialog(
+            title: const Text(
+              '저장 여부',
+              style: commonSubBoldStyle,
+              textAlign: TextAlign.center,
+            ),
+            content: const Text(
+              '작성 중인 리뷰가 존재합니다. 저장하지 않고 뒤로 가시겠습니까?',
+              style: confirmButtonTextStyle,
+            ),
+            contentPadding: const EdgeInsets.all(16.0),
+            actionsAlignment: MainAxisAlignment.center,
+            buttonPadding: const EdgeInsets.symmetric(horizontal: 8.0),
+            actions: [
+              Row(
+                children: [
+                  _confirmButton(
+                    onTap: () {
+                      Navigator.of(context).pop(false);
+                    },
+                    buttonText: '취소',
+                    isCancel: true,
+                  ),
+                  _confirmButton(
+                    onTap: () {
+                      Navigator.of(context).pop(true);
+                    },
+                    buttonText: '저장없이 뒤로가기',
+                    isCancel: false,
+                  ),
+                ],
+              ),
+            ],
+          );
+        },
+      );
+    } else {
+      return true;
+    }
   }
 
   Padding _reviewBody(BuildContext context) {
@@ -103,6 +155,11 @@ class _MyBookEditReviewState extends State<MyBookEditReview> {
       scrollPadding: EdgeInsets.only(
         bottom: MediaQuery.of(context).viewInsets.bottom,
       ),
+      onChanged: (String value) {
+        setState(() {
+          newContent = value;
+        });
+      },
       onEditingComplete: () {
         FocusScope.of(context).unfocus();
       },
@@ -248,5 +305,36 @@ class _MyBookEditReviewState extends State<MyBookEditReview> {
       ),
     );
     Navigator.pop(context);
+  }
+
+  Widget _confirmButton({
+    required GestureTapCallback? onTap,
+    required String buttonText,
+    required bool isCancel,
+  }) {
+    return Expanded(
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 4.0),
+        child: InkWell(
+          onTap: onTap,
+          child: Container(
+            height: 46.0,
+            decoration: BoxDecoration(
+              color: isCancel ? greyF1F2F5 : primaryColor,
+              borderRadius: BorderRadius.circular(4.0),
+            ),
+            child: Center(
+              child: Text(
+                buttonText,
+                style: commonSubBoldStyle.copyWith(
+                  color: isCancel ? commonBlackColor : commonWhiteColor,
+                  fontSize: 14.0,
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
   }
 }

--- a/frontend/lib/ui/mybook/mybook_detail/mybook_detail_screen.dart
+++ b/frontend/lib/ui/mybook/mybook_detail/mybook_detail_screen.dart
@@ -41,6 +41,7 @@ class _MyBookDetailScreenState extends State<MyBookDetailScreen> {
   late Future<MyBookReviewResponseData?> _myBookReview;
 
   final GlobalKey _myBookDetailHeaderKey = GlobalKey();
+
   final ScrollController _myBookDetailScrollController = ScrollController();
   final TextEditingController _meaningTagQuoteController =
       TextEditingController();
@@ -280,186 +281,194 @@ class _MyBookDetailScreenState extends State<MyBookDetailScreen> {
       context,
       StatefulBuilder(
         builder: (BuildContext context, StateSetter bottomState) {
-          return SingleChildScrollView(
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Padding(
-                  padding: const EdgeInsets.only(
-                    left: 16.0,
-                    right: 16.0,
-                    top: 24.0,
+          final bottomInset = MediaQuery.of(context).viewInsets.bottom;
+
+          return Padding(
+            padding: EdgeInsets.only(bottom: bottomInset),
+            child: SingleChildScrollView(
+              physics: const BouncingScrollPhysics(),
+              keyboardDismissBehavior: ScrollViewKeyboardDismissBehavior.onDrag,
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Padding(
+                    padding: const EdgeInsets.only(
+                      left: 16.0,
+                      right: 16.0,
+                      top: 24.0,
+                    ),
+                    child: Container(
+                      padding: const EdgeInsets.symmetric(
+                        vertical: 8.0,
+                      ),
+                      decoration: BoxDecoration(
+                        color: greyF1F2F5,
+                        borderRadius: BorderRadius.circular(50.0),
+                      ),
+                      alignment: Alignment.center,
+                      child: Row(
+                        mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                        children: [
+                          _readStatusButtonItem(
+                            buttonText: '읽기전',
+                            currentReadStatus: _originalReadStatus == 'TO_READ',
+                            onTapReadStatus: () {
+                              bottomState(
+                                () => _originalReadStatus = 'TO_READ',
+                              );
+                            },
+                          ),
+                          _readStatusButtonItem(
+                            buttonText: '읽는중',
+                            currentReadStatus: _originalReadStatus == 'READING',
+                            onTapReadStatus: () {
+                              bottomState(
+                                () => _originalReadStatus = 'READING',
+                              );
+                            },
+                          ),
+                          _readStatusButtonItem(
+                            buttonText: '완독함',
+                            currentReadStatus:
+                                _originalReadStatus == 'COMPLETED',
+                            onTapReadStatus: () {
+                              bottomState(
+                                () => _originalReadStatus = 'COMPLETED',
+                              );
+                            },
+                          ),
+                        ],
+                      ),
+                    ),
                   ),
-                  child: Container(
-                    padding: const EdgeInsets.symmetric(
-                      vertical: 8.0,
-                    ),
-                    decoration: BoxDecoration(
-                      color: greyF1F2F5,
-                      borderRadius: BorderRadius.circular(50.0),
-                    ),
-                    alignment: Alignment.center,
-                    child: Row(
-                      mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                  const SizedBox(
+                    height: 8.0,
+                  ),
+                  Padding(
+                    padding: const EdgeInsets.all(24.0),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
-                        _readStatusButtonItem(
-                          buttonText: '읽기전',
-                          currentReadStatus: _originalReadStatus == 'TO_READ',
-                          onTapReadStatus: () {
-                            bottomState(
-                              () => _originalReadStatus = 'TO_READ',
-                            );
-                          },
+                        const Text(
+                          '나에게 이 책은',
+                          style: myBookSortTextStyle,
                         ),
-                        _readStatusButtonItem(
-                          buttonText: '읽는중',
-                          currentReadStatus: _originalReadStatus == 'READING',
-                          onTapReadStatus: () {
-                            bottomState(
-                              () => _originalReadStatus = 'READING',
-                            );
-                          },
+                        const SizedBox(height: 16.0),
+                        Wrap(
+                          spacing: 8.0,
+                          runSpacing: 10.0,
+                          children: meaningTagColors
+                              .map(
+                                (color) => InkWell(
+                                  onTap: () {
+                                    bottomState(() {
+                                      colorCode = color;
+                                    });
+                                  },
+                                  child: renderColor(
+                                    color,
+                                    colorCode == color,
+                                  ),
+                                ),
+                              )
+                              .toList(),
                         ),
-                        _readStatusButtonItem(
-                          buttonText: '완독함',
-                          currentReadStatus: _originalReadStatus == 'COMPLETED',
-                          onTapReadStatus: () {
-                            bottomState(
-                              () => _originalReadStatus = 'COMPLETED',
-                            );
-                          },
+                        const SizedBox(height: 10.0),
+                        _myBookRecordInput(
+                          context: context,
+                          controller: _meaningTagQuoteController,
+                          hintText: '내 삶을 돌아보게 만든 책',
+                        ),
+                        const SizedBox(height: 16.0),
+                        const Text(
+                          '소장일',
+                          style: myBookSortTextStyle,
+                        ),
+                        const SizedBox(height: 8.0),
+                        CupertinoButton(
+                          padding: const EdgeInsets.all(0.0),
+                          onPressed: () => showCupertinoPicker(
+                            context,
+                            CupertinoDatePicker(
+                              initialDateTime: dateTime,
+                              mode: CupertinoDatePickerMode.date,
+                              use24hFormat: true,
+                              maximumDate: DateTime.now(),
+                              onDateTimeChanged: (DateTime newDateTime) {
+                                bottomState(
+                                  () => dateTime = newDateTime,
+                                );
+                              },
+                            ),
+                          ),
+                          child: Container(
+                            width: double.infinity,
+                            padding: const EdgeInsets.symmetric(
+                              vertical: 12.0,
+                            ),
+                            decoration: const BoxDecoration(
+                              border: Border(
+                                bottom: BorderSide(
+                                  color: inputBorderColor,
+                                  width: 1.0,
+                                ),
+                              ),
+                            ),
+                            child: Text(
+                              '${dateTime.year}.${dateTime.month}.${dateTime.day}',
+                              style: commonSubMediumStyle,
+                            ),
+                          ),
+                        ),
+                        const SizedBox(height: 24.0),
+                        Row(
+                          children: [
+                            Expanded(
+                              child: Column(
+                                crossAxisAlignment: CrossAxisAlignment.start,
+                                children: [
+                                  const Text(
+                                    '교환/나눔',
+                                    style: myBookSortTextStyle,
+                                  ),
+                                  const SizedBox(height: 18.0),
+                                  _checkRecordItemRow(bottomState),
+                                  const SizedBox(height: 10.0),
+                                ],
+                              ),
+                            ),
+                            Expanded(
+                              child: Column(
+                                children: [
+                                  const Text(
+                                    '비공개',
+                                    style: myBookSortTextStyle,
+                                  ),
+                                  const SizedBox(height: 10.0),
+                                  CupertinoSwitch(
+                                    value: !_originalShowable,
+                                    onChanged: (value) {
+                                      bottomState(() {
+                                        _originalShowable = !value;
+                                      });
+                                    },
+                                    activeColor: primaryColor,
+                                  ),
+                                ],
+                              ),
+                            ),
+                          ],
                         ),
                       ],
                     ),
                   ),
-                ),
-                const SizedBox(
-                  height: 8.0,
-                ),
-                Padding(
-                  padding: const EdgeInsets.all(24.0),
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      const Text(
-                        '나에게 이 책은',
-                        style: myBookSortTextStyle,
-                      ),
-                      const SizedBox(height: 16.0),
-                      Wrap(
-                        spacing: 8.0,
-                        runSpacing: 10.0,
-                        children: meaningTagColors
-                            .map(
-                              (color) => InkWell(
-                                onTap: () {
-                                  bottomState(() {
-                                    colorCode = color;
-                                  });
-                                },
-                                child: renderColor(
-                                  color,
-                                  colorCode == color,
-                                ),
-                              ),
-                            )
-                            .toList(),
-                      ),
-                      const SizedBox(height: 10.0),
-                      _myBookRecordInput(
-                        context: context,
-                        controller: _meaningTagQuoteController,
-                        hintText: '내 삶을 돌아보게 만든 책',
-                      ),
-                      const SizedBox(height: 16.0),
-                      const Text(
-                        '소장일',
-                        style: myBookSortTextStyle,
-                      ),
-                      const SizedBox(height: 8.0),
-                      CupertinoButton(
-                        padding: const EdgeInsets.all(0.0),
-                        onPressed: () => showCupertinoPicker(
-                          context,
-                          CupertinoDatePicker(
-                            initialDateTime: dateTime,
-                            mode: CupertinoDatePickerMode.date,
-                            use24hFormat: true,
-                            maximumDate: DateTime.now(),
-                            onDateTimeChanged: (DateTime newDateTime) {
-                              bottomState(
-                                () => dateTime = newDateTime,
-                              );
-                            },
-                          ),
-                        ),
-                        child: Container(
-                          width: double.infinity,
-                          padding: const EdgeInsets.symmetric(
-                            vertical: 12.0,
-                          ),
-                          decoration: const BoxDecoration(
-                            border: Border(
-                              bottom: BorderSide(
-                                color: inputBorderColor,
-                                width: 1.0,
-                              ),
-                            ),
-                          ),
-                          child: Text(
-                            '${dateTime.year}.${dateTime.month}.${dateTime.day}',
-                            style: commonSubMediumStyle,
-                          ),
-                        ),
-                      ),
-                      const SizedBox(height: 24.0),
-                      Row(
-                        children: [
-                          Expanded(
-                            child: Column(
-                              crossAxisAlignment: CrossAxisAlignment.start,
-                              children: [
-                                const Text(
-                                  '교환/나눔',
-                                  style: myBookSortTextStyle,
-                                ),
-                                const SizedBox(height: 18.0),
-                                _checkRecordItemRow(bottomState),
-                                const SizedBox(height: 10.0),
-                              ],
-                            ),
-                          ),
-                          Expanded(
-                            child: Column(
-                              children: [
-                                const Text(
-                                  '비공개',
-                                  style: myBookSortTextStyle,
-                                ),
-                                const SizedBox(height: 10.0),
-                                CupertinoSwitch(
-                                  value: !_originalShowable,
-                                  onChanged: (value) {
-                                    bottomState(() {
-                                      _originalShowable = !value;
-                                    });
-                                  },
-                                  activeColor: primaryColor,
-                                ),
-                              ],
-                            ),
-                          ),
-                        ],
-                      ),
-                    ],
+                  _myBookRecordButton(
+                    context: context,
+                    dateTime: dateTime,
+                    colorCode: colorCode,
                   ),
-                ),
-                _myBookRecordButton(
-                  context: context,
-                  dateTime: dateTime,
-                  colorCode: colorCode,
-                ),
-              ],
+                ],
+              ),
             ),
           );
         },

--- a/frontend/lib/ui/mybook/mybook_screen.dart
+++ b/frontend/lib/ui/mybook/mybook_screen.dart
@@ -92,6 +92,8 @@ class _MyBookScreenState extends State<MyBookScreen> {
                 data.interestBooksResponseData;
 
             final myBooksBookShelfData = _limitedBookShelfData(myBooksData);
+            final completedBooksBookShelfData =
+                _limitedBookShelfData(completedBooksData);
             final interestBooksBookShelfData =
                 _limitedBookShelfData(interestBooksData);
 
@@ -131,7 +133,7 @@ class _MyBookScreenState extends State<MyBookScreen> {
                           readStatus: '',
                         ),
                         _myBookShelfItem(
-                          myBooksBookShelfData: completedBooksData,
+                          myBooksBookShelfData: completedBooksBookShelfData,
                           status: '완독북',
                           order: '',
                           readStatus: 'COMPLETED',
@@ -374,12 +376,28 @@ class _MyBookScreenState extends State<MyBookScreen> {
             order: order,
             readStatus: readStatus,
           );
+          _myBooksResponseData = _bookRepository.getMyBooks(
+            userId: 'testId',
+            order: '',
+            readStatus: '',
+          );
+          _interestBooksResponseData = _bookRepository.getInterestBooks(
+            userId: 'testId',
+          );
         }
         if (readStatus == '') {
           _myBooksResponseData = _bookRepository.getMyBooks(
             userId: 'testId',
             order: order,
             readStatus: readStatus,
+          );
+          _completedBooksResponseData = _bookRepository.getMyBooks(
+            userId: 'testId',
+            order: '',
+            readStatus: 'COMPLETED',
+          );
+          _interestBooksResponseData = _bookRepository.getInterestBooks(
+            userId: 'testId',
           );
         }
       }),


### PR DESCRIPTION
## 🧑‍💻 작업 사항

### 마이북 서재 사진 정렬 및 데이터 패칭 / 마이리뷰 없을 때 뒤로가기 팝업 / 마이리뷰 있을 때 뒤로가기 팝업

<div>
<img src="https://github.com/SWM-IDLE/mybrary/assets/97138841/f84668be-7734-4a3f-b5ea-160294122dab" alt="마이북 정렬 및 데이터패칭 해결" width="260" height="580"/>
<img src="https://github.com/SWM-IDLE/mybrary/assets/97138841/41123b5f-2489-455c-b163-22af9fcd580d" alt="마이리뷰 없을 때 뒤로가기 팝업" width="260" height="580"/>
<img src="https://github.com/SWM-IDLE/mybrary/assets/97138841/d7224e73-a1a5-4641-8548-2db1a93863c0" alt="마이리뷰 있을 때 뒤로가기 팝업" width="260" height="580"/>
</div>

<br>

- 완독 설정 후 데이터 패칭 해결
- 서재 사진 겹치는 순서 해결
- 저장되지 않은 리뷰 팝업창 해결

<br><br>

## 🔗 링크

<br><br>

## 🐰 시급한 정도

🏃‍♂️ 보통 : 최대한 빠르게 리뷰 부탁드립니다.

<br><br>

## 📖 참고 사항

- 마이북 테스트 중 발생한 버그에 대해서 해결하였습니다.
- 기록한 내용이 있을 때, 뒤로가기를 막고 팝업을 띄우는 기능을 추가하였습니다.

<br>
