### PR TITLE
[IDLE-224] FeignClient 이슈 해결

### DIFF
--- a/backend/book-service/src/main/java/kr/mybrary/bookservice/client/user/api/UserServiceClient.java
+++ b/backend/book-service/src/main/java/kr/mybrary/bookservice/client/user/api/UserServiceClient.java
@@ -1,15 +1,17 @@
 package kr.mybrary.bookservice.client.user.api;
 
+import feign.Headers;
 import kr.mybrary.bookservice.client.user.dto.request.UserInfoRequest;
 import kr.mybrary.bookservice.client.user.dto.response.UserInfoServiceResponse;
 import org.springframework.cloud.openfeign.FeignClient;
-import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 
 @FeignClient(name = "user-service")
 public interface UserServiceClient {
 
-    @GetMapping("/user-service/api/v1/users/info")
+    @PostMapping("/api/v1/users/info")
+    @Headers("Content-Type: application/json")
     UserInfoServiceResponse getUsersInfo(@RequestBody UserInfoRequest userInfoRequest);
 
 }

--- a/backend/book-service/src/main/java/kr/mybrary/bookservice/client/user/dto/request/UserInfoRequest.java
+++ b/backend/book-service/src/main/java/kr/mybrary/bookservice/client/user/dto/request/UserInfoRequest.java
@@ -8,11 +8,11 @@ import lombok.Getter;
 @Builder
 public class UserInfoRequest {
 
-    List<String> usersIds;
+    List<String> userIds;
 
     public static UserInfoRequest of(List<String> usersIds) {
         return UserInfoRequest.builder()
-            .usersIds(usersIds)
+            .userIds(usersIds)
             .build();
     }
 }

--- a/backend/book-service/src/main/java/kr/mybrary/bookservice/client/user/dto/response/UserInfoServiceResponse.java
+++ b/backend/book-service/src/main/java/kr/mybrary/bookservice/client/user/dto/response/UserInfoServiceResponse.java
@@ -1,18 +1,36 @@
 package kr.mybrary.bookservice.client.user.dto.response;
 
 import java.util.List;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @Builder
+@AllArgsConstructor
+@NoArgsConstructor
 public class UserInfoServiceResponse {
 
-    private List<UserInfoElement> userInfoElements;
+    private String status;
+    private String message;
+    private UserInfoList data;
 
     @Builder
     @Getter
-    public static class UserInfoElement {
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class UserInfoList {
+
+        List<UserInfo> userInfoElements;
+    }
+
+    @Builder
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class UserInfo {
+
         private String userId;
         private String nickname;
         private String profileImageUrl;

--- a/backend/book-service/src/main/java/kr/mybrary/bookservice/review/domain/MyReviewReadService.java
+++ b/backend/book-service/src/main/java/kr/mybrary/bookservice/review/domain/MyReviewReadService.java
@@ -8,7 +8,7 @@ import kr.mybrary.bookservice.book.persistence.Book;
 import kr.mybrary.bookservice.client.user.api.UserServiceClient;
 import kr.mybrary.bookservice.client.user.dto.request.UserInfoRequest;
 import kr.mybrary.bookservice.client.user.dto.response.UserInfoServiceResponse;
-import kr.mybrary.bookservice.client.user.dto.response.UserInfoServiceResponse.UserInfoElement;
+import kr.mybrary.bookservice.client.user.dto.response.UserInfoServiceResponse.UserInfo;
 import kr.mybrary.bookservice.global.util.DateUtils;
 import kr.mybrary.bookservice.mybook.domain.MyBookService;
 import kr.mybrary.bookservice.mybook.persistence.MyBook;
@@ -43,8 +43,8 @@ public class MyReviewReadService {
         UserInfoServiceResponse usersInfo = userServiceClient.getUsersInfo(
                 UserInfoRequest.of(getUserIdFromMyBookReview(reviewElements)));
 
-        Map<String, UserInfoServiceResponse.UserInfoElement> userInfoMap = createUserInfoMapFromResponse(
-                usersInfo.getUserInfoElements());
+        Map<String, UserInfo> userInfoMap = createUserInfoMapFromResponse(
+                usersInfo.getData().getUserInfoElements());
 
         List<ReviewElement> myBookReviewElements = createMyBookReviewElements(reviewElements, userInfoMap);
         double starRatingAverage = getReviewStarRatingAverage(reviewElements);
@@ -70,7 +70,7 @@ public class MyReviewReadService {
     @NotNull
     private static List<ReviewElement> createMyBookReviewElements(
             List<MyReviewElementModel> reviewElements,
-            Map<String, UserInfoElement> userInfoMap) {
+            Map<String, UserInfo> userInfoMap) {
 
         return reviewElements.stream()
                 .map(reviewElement -> ReviewElement.builder()
@@ -86,12 +86,12 @@ public class MyReviewReadService {
     }
 
     @NotNull
-    private static Map<String, UserInfoServiceResponse.UserInfoElement> createUserInfoMapFromResponse(
-            List<UserInfoServiceResponse.UserInfoElement> userInfoServiceResponses) {
+    private static Map<String, UserInfo> createUserInfoMapFromResponse(
+            List<UserInfo> userInfoServiceResponses) {
 
         return userInfoServiceResponses.stream()
-                .collect(Collectors.toMap(
-                        UserInfoElement::getUserId,
+                .collect(Collectors.toConcurrentMap(
+                        UserInfo::getUserId,
                         userInfoServiceResponse -> userInfoServiceResponse)
                 );
     }

--- a/backend/book-service/src/main/java/kr/mybrary/bookservice/review/domain/MyReviewReadService.java
+++ b/backend/book-service/src/main/java/kr/mybrary/bookservice/review/domain/MyReviewReadService.java
@@ -73,14 +73,15 @@ public class MyReviewReadService {
             Map<String, UserInfo> userInfoMap) {
 
         return reviewElements.stream()
-                .map(reviewElement -> ReviewElement.builder()
-                        .id(reviewElement.getId())
-                        .starRating(reviewElement.getStarRating())
-                        .createdAt(DateUtils.toHyphenFormatYYYMMddHHmm(reviewElement.getCreatedAt()))
-                        .content(reviewElement.getContent())
-                        .userId(reviewElement.getUserId())
-                        .userNickname(userInfoMap.get(reviewElement.getUserId()).getNickname())
-                        .userPictureUrl(userInfoMap.get(reviewElement.getUserId()).getProfileImageUrl())
+                .filter(review -> userInfoMap.containsKey(review.getUserId()))
+                .map(review -> ReviewElement.builder()
+                        .id(review.getId())
+                        .starRating(review.getStarRating())
+                        .createdAt(DateUtils.toHyphenFormatYYYMMddHHmm(review.getCreatedAt()))
+                        .content(review.getContent())
+                        .userId(review.getUserId())
+                        .userNickname(userInfoMap.get(review.getUserId()).getNickname())
+                        .userPictureUrl(userInfoMap.get(review.getUserId()).getProfileImageUrl())
                         .build())
                 .toList();
     }

--- a/backend/book-service/src/main/java/kr/mybrary/bookservice/review/persistence/repository/MyReviewRepositoryCustomImpl.java
+++ b/backend/book-service/src/main/java/kr/mybrary/bookservice/review/persistence/repository/MyReviewRepositoryCustomImpl.java
@@ -29,6 +29,7 @@ public class MyReviewRepositoryCustomImpl implements MyReviewRepositoryCustom {
                         myReview.starRating.as("starRating"),
                         myReview.createdAt.as("createdAt")))
                 .from(myReview)
+                .where(myReview.myBook.book.eq(book))
                 .fetch();
     }
 

--- a/backend/book-service/src/test/java/kr/mybrary/bookservice/review/MyReviewDtoTestData.java
+++ b/backend/book-service/src/test/java/kr/mybrary/bookservice/review/MyReviewDtoTestData.java
@@ -4,7 +4,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.IntStream;
 import kr.mybrary.bookservice.client.user.dto.response.UserInfoServiceResponse;
-import kr.mybrary.bookservice.client.user.dto.response.UserInfoServiceResponse.UserInfoElement;
+import kr.mybrary.bookservice.client.user.dto.response.UserInfoServiceResponse.UserInfo;
 import kr.mybrary.bookservice.review.domain.dto.request.MyReviewCreateServiceRequest;
 import kr.mybrary.bookservice.review.domain.dto.request.MyReviewDeleteServiceRequest;
 import kr.mybrary.bookservice.review.domain.dto.request.MyReviewOfMyBookGetServiceRequest;
@@ -58,8 +58,8 @@ public class MyReviewDtoTestData {
 
     public static UserInfoServiceResponse createUserInfoResponseList() {
 
-        List<UserInfoElement> list = IntStream.range(1, 6)
-                .mapToObj(i -> UserInfoElement.builder()
+        List<UserInfo> list = IntStream.range(1, 6)
+                .mapToObj(i -> UserInfo.builder()
                         .userId("USER_ID_" + i)
                         .nickname("USER_NICKNAME_" + i)
                         .profileImageUrl("USER_PICTURE_URL_" + i)
@@ -67,7 +67,11 @@ public class MyReviewDtoTestData {
                 .toList();
 
         return UserInfoServiceResponse.builder()
-                .userInfoElements(list)
+                .status("200 OK")
+                .message("Success")
+                .data(UserInfoServiceResponse.UserInfoList.builder()
+                        .userInfoElements(list)
+                        .build())
                 .build();
     }
 

--- a/backend/user-service/src/main/java/kr/mybrary/userservice/user/presentation/UserController.java
+++ b/backend/user-service/src/main/java/kr/mybrary/userservice/user/presentation/UserController.java
@@ -174,7 +174,7 @@ public class UserController {
         );
     }
 
-    @GetMapping("/info")
+    @PostMapping("/info")
     public ResponseEntity<SuccessResponse> getUserInfo(@RequestBody UserInfoRequest userInfoRequest) {
         return ResponseEntity.ok().body(
                 SuccessResponse.of(HttpStatus.OK.toString(), "사용자 정보를 모두 조회했습니다.",

--- a/backend/user-service/src/test/java/kr/mybrary/userservice/user/presentation/UserControllerTest.java
+++ b/backend/user-service/src/test/java/kr/mybrary/userservice/user/presentation/UserControllerTest.java
@@ -998,7 +998,8 @@ class UserControllerTest {
 
         // when
         ResultActions actions = mockMvc.perform(
-                RestDocumentationRequestBuilders.get(BASE_URL + "/info")
+                RestDocumentationRequestBuilders.post(BASE_URL + "/info")
+                        .with(csrf())
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(userInfoRequest)));
 


### PR DESCRIPTION
## 🧑‍💻 작업 사항

### 한 도서에 대해서 리뷰 조회시, book-service에서 user-service를 호출하여 유저의 닉네임과 프로필 URL을 가져오는 로직
- 기존에 GET을 사용했으나, RequestBody가 있는 경우 GET을 사용하지 못한다. 따라서 GET 대신 POST로 수정
- 실제 user-service에서 응답하는 객체에 맞게 book-service에서도 응답 객체를 준비해야한다.
    - user-service에서 유저의 닉네임과 프로필 URL만 반환하지 않고, status, message, body를 반환하기 때문에 아래와 같이 응답 객체 정의
    ```
    @Builder
    @Getter
    @AllArgsConstructor
    @NoArgsConstructor
    public class UserInfoServiceResponse {

        private String status;
        private String message;
        private UserInfoList data;

        @Builder
        @Getter
        @AllArgsConstructor
        @NoArgsConstructor
        public static class UserInfoList {

            List<UserInfo> userInfoElements;
        }

        @Builder
        @Getter
        @AllArgsConstructor
        @NoArgsConstructor
        public static class UserInfo {
    
            private String userId;
            private String nickname;
            private String profileImageUrl;
        }
    }
    ```
- 도서에 대한 리뷰 조회 QueryDsl에 where절이 빠져있어, 추가.
- 탈퇴한 회원에 있어서 응답 값 생성시, NPE가 발생하여, filter를 통해 예외처리

<br><br>

## 🔗 링크

<!-- 관련된 대화가 이루어진 슬랙 링크 혹은 피그마 링크를 첨부. -->
<!-- - [프레이머](https://framer.com/projects/2--gSDcZoNKqU6dqCUQUYQe-53rEr?node=tQMWSSKqy)  -->

<br><br>

## 🐰 시급한 정도

🐢 천천히 : 급하지 않습니다.

<br><br>

## 📖 참고 사항

<!-- 공유할 내용, 레퍼런스, 추가로 발생할 것으로 예상되는 이슈, 스크린샷 등을 넣어 주세요.  -->
<!-- 변경사항이 큰 경우 집중해야 할 부분, 또는 불안해서 봐주었으면 하는 부분 등 -->
