### PR TITLE
[IDLE-178] feat: 메인 화면(홈) UI 구현 및 user&book API 연동

### DIFF
--- a/frontend/lib/data/datasource/home/home_datasource.dart
+++ b/frontend/lib/data/datasource/home/home_datasource.dart
@@ -1,6 +1,7 @@
 import 'dart:developer';
 
 import 'package:dio/dio.dart';
+import 'package:mybrary/data/model/home/book_list_by_category_response.dart';
 import 'package:mybrary/data/model/home/today_registered_book_count_response.dart';
 import 'package:mybrary/data/network/api.dart';
 import 'package:mybrary/utils/dios/dio_service.dart';
@@ -21,6 +22,28 @@ class HomeDataSource {
         message: getTodayRegisteredBookCountResponse.data['message'],
         data: TodayRegisteredBookCountResponseData.fromJson(
           getTodayRegisteredBookCountResponse.data['data'],
+        ),
+      ),
+    );
+
+    return result.data!;
+  }
+
+  Future<BookListByCategoryResponseData> getBookListByCategory(
+      String type, int? page, int? categoryId) async {
+    Dio dio = DioService().to();
+    final getBookListByCategoryResponse = await dio.get(
+      '${getBookServiceApi(API.getBookListByCategory)}?type=$type&page=${page ?? 1}&categoryId=${categoryId ?? 0}',
+    );
+
+    log('카테고리 도서 목록 조회 응답값: $getBookListByCategoryResponse');
+    final BookListByCategoryResponse result = commonResponseResult(
+      getBookListByCategoryResponse,
+      () => BookListByCategoryResponse(
+        status: getBookListByCategoryResponse.data['status'],
+        message: getBookListByCategoryResponse.data['message'],
+        data: BookListByCategoryResponseData.fromJson(
+          getBookListByCategoryResponse.data['data'],
         ),
       ),
     );

--- a/frontend/lib/data/datasource/home/home_datasource.dart
+++ b/frontend/lib/data/datasource/home/home_datasource.dart
@@ -1,0 +1,30 @@
+import 'dart:developer';
+
+import 'package:dio/dio.dart';
+import 'package:mybrary/data/model/home/today_registered_book_count_response.dart';
+import 'package:mybrary/data/network/api.dart';
+import 'package:mybrary/utils/dios/dio_service.dart';
+
+class HomeDataSource {
+  Future<TodayRegisteredBookCountResponseData>
+      getTodayRegisteredBookCount() async {
+    Dio dio = DioService().to();
+    final getTodayRegisteredBookCountResponse = await dio.get(
+      getBookServiceApi(API.getTodayRegisteredBookCount),
+    );
+
+    log('오늘의 마이북 등록수 조회 응답값: $getTodayRegisteredBookCountResponse');
+    final TodayRegisteredBookCountResponse result = commonResponseResult(
+      getTodayRegisteredBookCountResponse,
+      () => TodayRegisteredBookCountResponse(
+        status: getTodayRegisteredBookCountResponse.data['status'],
+        message: getTodayRegisteredBookCountResponse.data['message'],
+        data: TodayRegisteredBookCountResponseData.fromJson(
+          getTodayRegisteredBookCountResponse.data['data'],
+        ),
+      ),
+    );
+
+    return result.data!;
+  }
+}

--- a/frontend/lib/data/model/home/book_list_by_category_response.dart
+++ b/frontend/lib/data/model/home/book_list_by_category_response.dart
@@ -1,0 +1,80 @@
+class BookListByCategoryResponse {
+  String status;
+  String message;
+  BookListByCategoryResponseData? data;
+
+  BookListByCategoryResponse({
+    required this.status,
+    required this.message,
+    this.data,
+  });
+
+  factory BookListByCategoryResponse.fromJson(Map<String, dynamic> json) {
+    return BookListByCategoryResponse(
+      status: json['status'],
+      message: json['message'],
+      data: json['data'] != null
+          ? BookListByCategoryResponseData.fromJson(json['data'])
+          : null,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    final Map<String, dynamic> data = <String, dynamic>{};
+    data['status'] = status;
+    data['message'] = message;
+    if (this.data != null) {
+      data['data'] = this.data!.toJson();
+    }
+    return data;
+  }
+}
+
+class BookListByCategoryResponseData {
+  List<Books>? books;
+  String? nextRequestUrl;
+
+  BookListByCategoryResponseData({this.books, this.nextRequestUrl});
+
+  factory BookListByCategoryResponseData.fromJson(Map<String, dynamic> json) {
+    return BookListByCategoryResponseData(
+      books: json['books'] != null
+          ? (json['books'] as List).map((i) => Books.fromJson(i)).toList()
+          : null,
+      nextRequestUrl: json['nextRequestUrl'],
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    final Map<String, dynamic> data = <String, dynamic>{};
+    if (books != null) {
+      data['books'] = books!.map((v) => v.toJson()).toList();
+    }
+    data['nextRequestUrl'] = nextRequestUrl;
+    return data;
+  }
+}
+
+class Books {
+  String? thumbnailUrl;
+  String? isbn13;
+
+  Books({
+    this.thumbnailUrl,
+    this.isbn13,
+  });
+
+  factory Books.fromJson(Map<String, dynamic> json) {
+    return Books(
+      thumbnailUrl: json['thumbnailUrl'],
+      isbn13: json['isbn13'],
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    final Map<String, dynamic> data = <String, dynamic>{};
+    data['thumbnailUrl'] = thumbnailUrl;
+    data['isbn13'] = isbn13;
+    return data;
+  }
+}

--- a/frontend/lib/data/model/home/home_common_response.dart
+++ b/frontend/lib/data/model/home/home_common_response.dart
@@ -4,9 +4,15 @@ import 'package:mybrary/data/model/home/today_registered_book_count_response.dar
 class HomeCommonData {
   TodayRegisteredBookCountResponseData todayRegisteredBookCountResponseData;
   BookListByCategoryResponseData bookListByCategoryResponseData;
+  BookListByCategoryResponseData bookListByGenreNovelData;
+  BookListByCategoryResponseData bookListByPsychologyData;
+  BookListByCategoryResponseData bookListByTravelData;
 
   HomeCommonData({
     required this.todayRegisteredBookCountResponseData,
     required this.bookListByCategoryResponseData,
+    required this.bookListByGenreNovelData,
+    required this.bookListByPsychologyData,
+    required this.bookListByTravelData,
   });
 }

--- a/frontend/lib/data/model/home/home_common_response.dart
+++ b/frontend/lib/data/model/home/home_common_response.dart
@@ -1,0 +1,12 @@
+import 'package:mybrary/data/model/home/book_list_by_category_response.dart';
+import 'package:mybrary/data/model/home/today_registered_book_count_response.dart';
+
+class HomeCommonData {
+  TodayRegisteredBookCountResponseData todayRegisteredBookCountResponseData;
+  BookListByCategoryResponseData bookListByCategoryResponseData;
+
+  HomeCommonData({
+    required this.todayRegisteredBookCountResponseData,
+    required this.bookListByCategoryResponseData,
+  });
+}

--- a/frontend/lib/data/model/home/today_registered_book_count_response.dart
+++ b/frontend/lib/data/model/home/today_registered_book_count_response.dart
@@ -1,0 +1,52 @@
+class TodayRegisteredBookCountResponse {
+  String status;
+  String message;
+  TodayRegisteredBookCountResponseData? data;
+
+  TodayRegisteredBookCountResponse({
+    required this.status,
+    required this.message,
+    required this.data,
+  });
+
+  factory TodayRegisteredBookCountResponse.fromJson(Map<String, dynamic> json) {
+    return TodayRegisteredBookCountResponse(
+      status: json['status'],
+      message: json['message'],
+      data: json['data'] != null
+          ? TodayRegisteredBookCountResponseData.fromJson(json['data'])
+          : null,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    final Map<String, dynamic> data = <String, dynamic>{};
+    data['status'] = status;
+    data['message'] = message;
+    if (this.data != null) {
+      data['data'] = this.data!.toJson();
+    }
+    return data;
+  }
+}
+
+class TodayRegisteredBookCountResponseData {
+  int? count;
+
+  TodayRegisteredBookCountResponseData({
+    this.count,
+  });
+
+  factory TodayRegisteredBookCountResponseData.fromJson(
+      Map<String, dynamic> json) {
+    return TodayRegisteredBookCountResponseData(
+      count: json['count'],
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    final Map<String, dynamic> data = <String, dynamic>{};
+    data['count'] = count;
+    return data;
+  }
+}

--- a/frontend/lib/data/network/api.dart
+++ b/frontend/lib/data/network/api.dart
@@ -36,6 +36,7 @@ enum API {
   getMyBookDetail,
   getMyBookReview,
   getInterestBooks,
+  getTodayRegisteredBookCount,
   createMyBook,
   createMyBookReview,
   createOrDeleteInterestBook,
@@ -73,6 +74,7 @@ Map<API, String> apiMap = {
   API.getMyBookDetail: "/api/v1/mybooks", // '/{mybookId}'
   API.getMyBookReview: "/api/v1/mybooks", // '/{mybookId}/review'
   API.getInterestBooks: "/api/v1/books/users", // '/{userId}/interest'
+  API.getTodayRegisteredBookCount: "/api/v1/mybooks/today-registration-count",
   API.createMyBook: "/api/v1/mybooks",
   API.createMyBookReview: "/api/v1/mybooks", // '/{mybookId}/reviews'
   API.createOrDeleteInterestBook: "/api/v1/books", // '/{isbn13}/interest'

--- a/frontend/lib/data/network/api.dart
+++ b/frontend/lib/data/network/api.dart
@@ -37,6 +37,7 @@ enum API {
   getMyBookReview,
   getInterestBooks,
   getTodayRegisteredBookCount,
+  getBookListByCategory,
   createMyBook,
   createMyBookReview,
   createOrDeleteInterestBook,
@@ -75,6 +76,7 @@ Map<API, String> apiMap = {
   API.getMyBookReview: "/api/v1/mybooks", // '/{mybookId}/review'
   API.getInterestBooks: "/api/v1/books/users", // '/{userId}/interest'
   API.getTodayRegisteredBookCount: "/api/v1/mybooks/today-registration-count",
+  API.getBookListByCategory: "/api/v1/books/search/book-list-by-category",
   API.createMyBook: "/api/v1/mybooks",
   API.createMyBookReview: "/api/v1/mybooks", // '/{mybookId}/reviews'
   API.createOrDeleteInterestBook: "/api/v1/books", // '/{isbn13}/interest'

--- a/frontend/lib/data/repository/home_repository.dart
+++ b/frontend/lib/data/repository/home_repository.dart
@@ -1,11 +1,19 @@
 import 'package:mybrary/data/datasource/home/home_datasource.dart';
+import 'package:mybrary/data/model/home/book_list_by_category_response.dart';
 import 'package:mybrary/data/model/home/today_registered_book_count_response.dart';
 
 class HomeRepository {
   final HomeDataSource _homeDataSource = HomeDataSource();
 
-  Future<TodayRegisteredBookCountResponseData>
-      getTodayRegisteredBookCount() async {
+  Future<TodayRegisteredBookCountResponseData> getTodayRegisteredBookCount() {
     return _homeDataSource.getTodayRegisteredBookCount();
+  }
+
+  Future<BookListByCategoryResponseData> getBookListByCategory({
+    required String type,
+    int? page,
+    int? categoryId,
+  }) async {
+    return _homeDataSource.getBookListByCategory(type, page, categoryId);
   }
 }

--- a/frontend/lib/data/repository/home_repository.dart
+++ b/frontend/lib/data/repository/home_repository.dart
@@ -1,0 +1,11 @@
+import 'package:mybrary/data/datasource/home/home_datasource.dart';
+import 'package:mybrary/data/model/home/today_registered_book_count_response.dart';
+
+class HomeRepository {
+  final HomeDataSource _homeDataSource = HomeDataSource();
+
+  Future<TodayRegisteredBookCountResponseData>
+      getTodayRegisteredBookCount() async {
+    return _homeDataSource.getTodayRegisteredBookCount();
+  }
+}

--- a/frontend/lib/res/constants/color.dart
+++ b/frontend/lib/res/constants/color.dart
@@ -43,8 +43,11 @@ const Color bookStarDisabledColor = Color(0xFFDDDEE3);
 const Color bookDetailColor = Color(0xFF535353);
 const Color myBookScanBackgroundColor = Color(0xFF1C1C1C);
 
-// Main Page Color
-const Color mainPageButtonColor = Color(0xFFEEEEEE);
+// Home Page Color
+const Color homeBarcodeButtonColor = Color(0xFFEEEEEE);
+const Color homeTodayRegisteredBookColorTop = Color(0xFF19C568);
+const Color homeTodayRegisteredBookColorCenter = Color(0xFF6ADE8D);
+const Color homeTodayRegisteredBookColorBottom = Color(0xFFABE8A1);
 
 // My Book Color
 const List<String> meaningTagColors = [

--- a/frontend/lib/res/constants/config.dart
+++ b/frontend/lib/res/constants/config.dart
@@ -19,3 +19,10 @@ const String mybraryPrivacyLink =
     'https://ribbon-soil-e35.notion.site/6ff721bd27824f729b97417d769041ce?pvs=4';
 const String openSourceLicenseLink =
     'https://ribbon-soil-e35.notion.site/de54830fb0fc45c69794373ec8f83ef7?pvs=4';
+
+// 기타 상수
+const List<String> bookListByInterestedCategory = [
+  '장르소설',
+  '심리학',
+  '여행',
+];

--- a/frontend/lib/res/constants/style.dart
+++ b/frontend/lib/res/constants/style.dart
@@ -35,7 +35,7 @@ const commonSubThinStyle = TextStyle(
 
 const commonMainRegularStyle = TextStyle(
   color: grey262626,
-  fontSize: 16.0,
+  fontSize: 18.0,
   fontWeight: FontWeight.w400,
 );
 
@@ -203,6 +203,12 @@ const todayRegisteredBookTextStyle = TextStyle(
   color: grey262626,
   fontSize: 12.0,
   fontWeight: FontWeight.w500,
+);
+
+const categoryCircularTextStyle = TextStyle(
+  color: grey262626,
+  fontSize: 14.0,
+  fontWeight: FontWeight.w400,
 );
 
 // book search page style

--- a/frontend/lib/res/constants/style.dart
+++ b/frontend/lib/res/constants/style.dart
@@ -192,6 +192,13 @@ const bottomButtonTextStyle = TextStyle(
   fontWeight: FontWeight.w700,
 );
 
+// home page style
+const todayRegisteredBookTextStyle = TextStyle(
+  color: grey262626,
+  fontSize: 12.0,
+  fontWeight: FontWeight.w500,
+);
+
 // book search page style
 const searchBookTitleStyle = TextStyle(
   color: grey262626,

--- a/frontend/lib/res/constants/style.dart
+++ b/frontend/lib/res/constants/style.dart
@@ -33,6 +33,12 @@ const commonSubThinStyle = TextStyle(
   fontWeight: FontWeight.w300,
 );
 
+const commonMainRegularStyle = TextStyle(
+  color: grey262626,
+  fontSize: 16.0,
+  fontWeight: FontWeight.w400,
+);
+
 const commonSubRegularStyle = TextStyle(
   color: grey262626,
   fontSize: 14.0,

--- a/frontend/lib/res/constants/style.dart
+++ b/frontend/lib/res/constants/style.dart
@@ -201,7 +201,7 @@ const bottomButtonTextStyle = TextStyle(
 // home page style
 const todayRegisteredBookTextStyle = TextStyle(
   color: grey262626,
-  fontSize: 12.0,
+  fontSize: 13.0,
   fontWeight: FontWeight.w500,
 );
 

--- a/frontend/lib/ui/home/components/home_barcode_button.dart
+++ b/frontend/lib/ui/home/components/home_barcode_button.dart
@@ -19,7 +19,7 @@ class HomeBarcodeButton extends StatelessWidget {
           vertical: 4.0,
         ),
         decoration: BoxDecoration(
-          color: mainPageButtonColor,
+          color: homeBarcodeButtonColor,
           borderRadius: BorderRadius.circular(4.0),
         ),
         child: InkWell(

--- a/frontend/lib/ui/home/components/home_best_seller.dart
+++ b/frontend/lib/ui/home/components/home_best_seller.dart
@@ -1,0 +1,102 @@
+import 'package:flutter/material.dart';
+import 'package:mybrary/data/model/home/book_list_by_category_response.dart';
+import 'package:mybrary/res/constants/style.dart';
+import 'package:mybrary/ui/search/search_detail/search_detail_screen.dart';
+
+class HomeBestSeller extends StatelessWidget {
+  final List<Books> bookListByBestSeller;
+
+  const HomeBestSeller({
+    required this.bookListByBestSeller,
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        const Padding(
+          padding: EdgeInsets.only(
+            left: 16.0,
+            bottom: 16.0,
+          ),
+          child: Row(
+            children: [
+              Text(
+                '이번 주',
+                style: commonMainRegularStyle,
+              ),
+              Text(
+                ' 베스트셀러',
+                style: commonSubBoldStyle,
+              ),
+              Text(
+                '는?',
+                style: commonMainRegularStyle,
+              ),
+            ],
+          ),
+        ),
+        Expanded(
+          child: ListView.builder(
+            scrollDirection: Axis.horizontal,
+            physics: const BouncingScrollPhysics(),
+            itemCount: bookListByBestSeller.length,
+            itemBuilder: (context, index) {
+              return Padding(
+                padding: const EdgeInsets.only(
+                  right: 10.0,
+                  bottom: 10.0,
+                ),
+                child: Row(
+                  children: [
+                    if (index == 0)
+                      const SizedBox(
+                        width: 16.0,
+                      ),
+                    InkWell(
+                      onTap: () {
+                        Navigator.push(
+                          context,
+                          MaterialPageRoute(
+                            builder: (_) => SearchDetailScreen(
+                              isbn13: bookListByBestSeller[index].isbn13!,
+                            ),
+                          ),
+                        );
+                      },
+                      child: Container(
+                        width: 116,
+                        decoration: BoxDecoration(
+                          image: DecorationImage(
+                            image: NetworkImage(
+                              bookListByBestSeller[index].thumbnailUrl!,
+                            ),
+                            fit: BoxFit.fill,
+                          ),
+                          borderRadius: BorderRadius.circular(8),
+                          boxShadow: const [
+                            BoxShadow(
+                              color: Color(0x3F000000),
+                              blurRadius: 2,
+                              offset: Offset(1, 1),
+                              spreadRadius: 1,
+                            )
+                          ],
+                        ),
+                      ),
+                    ),
+                    if (index == bookListByBestSeller.length - 1)
+                      const SizedBox(
+                        width: 8.0,
+                      ),
+                  ],
+                ),
+              );
+            },
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/frontend/lib/ui/home/components/home_best_seller.dart
+++ b/frontend/lib/ui/home/components/home_best_seller.dart
@@ -1,13 +1,14 @@
 import 'package:flutter/material.dart';
 import 'package:mybrary/data/model/home/book_list_by_category_response.dart';
 import 'package:mybrary/res/constants/style.dart';
-import 'package:mybrary/ui/search/search_detail/search_detail_screen.dart';
 
 class HomeBestSeller extends StatelessWidget {
   final List<Books> bookListByBestSeller;
+  final void Function(String) onTapBook;
 
   const HomeBestSeller({
     required this.bookListByBestSeller,
+    required this.onTapBook,
     super.key,
   });
 
@@ -18,7 +19,7 @@ class HomeBestSeller extends StatelessWidget {
         const Padding(
           padding: EdgeInsets.only(
             left: 16.0,
-            bottom: 16.0,
+            bottom: 12.0,
           ),
           child: Row(
             children: [
@@ -45,6 +46,7 @@ class HomeBestSeller extends StatelessWidget {
             itemBuilder: (context, index) {
               return Padding(
                 padding: const EdgeInsets.only(
+                  top: 10.0,
                   right: 10.0,
                   bottom: 10.0,
                 ),
@@ -56,14 +58,7 @@ class HomeBestSeller extends StatelessWidget {
                       ),
                     InkWell(
                       onTap: () {
-                        Navigator.push(
-                          context,
-                          MaterialPageRoute(
-                            builder: (_) => SearchDetailScreen(
-                              isbn13: bookListByBestSeller[index].isbn13!,
-                            ),
-                          ),
-                        );
+                        onTapBook(bookListByBestSeller[index].isbn13!);
                       },
                       child: Container(
                         width: 116,

--- a/frontend/lib/ui/home/components/home_book_count.dart
+++ b/frontend/lib/ui/home/components/home_book_count.dart
@@ -12,63 +12,61 @@ class HomeBookCount extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return SliverToBoxAdapter(
-      child: Container(
-        padding: const EdgeInsets.all(16.0),
-        child: Column(
-          children: [
-            _divider(),
-            Padding(
-              padding: const EdgeInsets.symmetric(vertical: 8.0),
-              child: Row(
-                mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                children: [
-                  const Text(
-                    '오늘 마이브러리에 등록된 책!',
-                    style: todayRegisteredBookTextStyle,
-                  ),
-                  Row(
-                    children: [
-                      Container(
-                        padding: const EdgeInsets.symmetric(
-                          horizontal: 8.0,
-                          vertical: 2.0,
+    return Container(
+      padding: const EdgeInsets.all(16.0),
+      child: Column(
+        children: [
+          _divider(),
+          Padding(
+            padding: const EdgeInsets.symmetric(vertical: 8.0),
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                const Text(
+                  '오늘 마이브러리에 등록된 책!',
+                  style: todayRegisteredBookTextStyle,
+                ),
+                Row(
+                  children: [
+                    Container(
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: 8.0,
+                        vertical: 2.0,
+                      ),
+                      decoration: ShapeDecoration(
+                        gradient: const LinearGradient(
+                          begin: Alignment(0.00, -1.00),
+                          end: Alignment(0, 1),
+                          colors: [
+                            homeTodayRegisteredBookColorTop,
+                            homeTodayRegisteredBookColorCenter,
+                            homeTodayRegisteredBookColorBottom,
+                          ],
                         ),
-                        decoration: ShapeDecoration(
-                          gradient: const LinearGradient(
-                            begin: Alignment(0.00, -1.00),
-                            end: Alignment(0, 1),
-                            colors: [
-                              homeTodayRegisteredBookColorTop,
-                              homeTodayRegisteredBookColorCenter,
-                              homeTodayRegisteredBookColorBottom,
-                            ],
-                          ),
-                          shape: RoundedRectangleBorder(
-                            borderRadius: BorderRadius.circular(30.0),
-                          ),
-                        ),
-                        child: Text(
-                          todayRegisteredBookCount.toString().padLeft(6, '0'),
-                          style: todayRegisteredBookTextStyle.copyWith(
-                            color: commonWhiteColor,
-                            letterSpacing: 2.0,
-                          ),
+                        shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(30.0),
                         ),
                       ),
-                      const SizedBox(width: 4.0),
-                      const Text(
-                        '권',
-                        style: todayRegisteredBookTextStyle,
+                      child: Text(
+                        todayRegisteredBookCount.toString().padLeft(6, '0'),
+                        style: todayRegisteredBookTextStyle.copyWith(
+                          color: commonWhiteColor,
+                          letterSpacing: 2.0,
+                        ),
                       ),
-                    ],
-                  ),
-                ],
-              ),
+                    ),
+                    const SizedBox(width: 4.0),
+                    const Text(
+                      '권',
+                      style: todayRegisteredBookTextStyle,
+                    ),
+                  ],
+                ),
+              ],
             ),
-            _divider(),
-          ],
-        ),
+          ),
+          _divider(),
+        ],
       ),
     );
   }

--- a/frontend/lib/ui/home/components/home_book_count.dart
+++ b/frontend/lib/ui/home/components/home_book_count.dart
@@ -1,0 +1,83 @@
+import 'package:flutter/material.dart';
+import 'package:mybrary/res/constants/color.dart';
+import 'package:mybrary/res/constants/style.dart';
+
+class HomeBookCount extends StatelessWidget {
+  final int todayRegisteredBookCount;
+
+  const HomeBookCount({
+    required this.todayRegisteredBookCount,
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return SliverToBoxAdapter(
+      child: Container(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          children: [
+            _divider(),
+            Padding(
+              padding: const EdgeInsets.symmetric(vertical: 8.0),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: [
+                  const Text(
+                    '오늘 마이브러리에 등록된 책!',
+                    style: todayRegisteredBookTextStyle,
+                  ),
+                  Row(
+                    children: [
+                      Container(
+                        padding: const EdgeInsets.symmetric(
+                          horizontal: 8.0,
+                          vertical: 2.0,
+                        ),
+                        decoration: ShapeDecoration(
+                          gradient: const LinearGradient(
+                            begin: Alignment(0.00, -1.00),
+                            end: Alignment(0, 1),
+                            colors: [
+                              homeTodayRegisteredBookColorTop,
+                              homeTodayRegisteredBookColorCenter,
+                              homeTodayRegisteredBookColorBottom,
+                            ],
+                          ),
+                          shape: RoundedRectangleBorder(
+                            borderRadius: BorderRadius.circular(30.0),
+                          ),
+                        ),
+                        child: Text(
+                          todayRegisteredBookCount.toString().padLeft(6, '0'),
+                          style: todayRegisteredBookTextStyle.copyWith(
+                            color: commonWhiteColor,
+                            letterSpacing: 2.0,
+                          ),
+                        ),
+                      ),
+                      const SizedBox(width: 4.0),
+                      const Text(
+                        '권',
+                        style: todayRegisteredBookTextStyle,
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+            ),
+            _divider(),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Divider _divider() {
+    return const Divider(
+      color: greyDDDDDD,
+      thickness: 1.0,
+      height: 1.0,
+    );
+  }
+}

--- a/frontend/lib/ui/home/components/home_intro.dart
+++ b/frontend/lib/ui/home/components/home_intro.dart
@@ -12,7 +12,7 @@ class HomeIntro extends StatelessWidget {
           horizontal: 16.0,
           vertical: 8.0,
         ),
-        child: Text(
+        child: const Text(
           '안녕하세요, IDLE님\n마이북을 등록하고 나만의 도서관을 만들어보세요 📚',
           style: mainIntroTextStyle,
         ),

--- a/frontend/lib/ui/home/components/home_recommend_books.dart
+++ b/frontend/lib/ui/home/components/home_recommend_books.dart
@@ -3,17 +3,18 @@ import 'package:mybrary/data/model/home/book_list_by_category_response.dart';
 import 'package:mybrary/res/constants/color.dart';
 import 'package:mybrary/res/constants/config.dart';
 import 'package:mybrary/res/constants/style.dart';
-import 'package:mybrary/ui/search/search_detail/search_detail_screen.dart';
 
 class HomeRecommendBooks extends StatelessWidget {
   final String category;
   final List<Books> bookListByCategory;
   final void Function(String) onTapCategory;
+  final void Function(String) onTapBook;
 
   const HomeRecommendBooks({
     required this.category,
     required this.bookListByCategory,
     required this.onTapCategory,
+    required this.onTapBook,
     super.key,
   });
 
@@ -25,7 +26,7 @@ class HomeRecommendBooks extends StatelessWidget {
         const Padding(
           padding: EdgeInsets.only(
             left: 16.0,
-            bottom: 2.0,
+            bottom: 12.0,
           ),
           child: Row(
             children: [
@@ -41,7 +42,10 @@ class HomeRecommendBooks extends StatelessWidget {
           ),
         ),
         Padding(
-          padding: const EdgeInsets.all(16.0),
+          padding: const EdgeInsets.symmetric(
+            horizontal: 16.0,
+            vertical: 8.0,
+          ),
           child: Wrap(
             spacing: 8.0,
             runSpacing: 8.0,
@@ -86,6 +90,7 @@ class HomeRecommendBooks extends StatelessWidget {
             itemBuilder: (context, index) {
               return Padding(
                 padding: const EdgeInsets.only(
+                  top: 10.0,
                   right: 10.0,
                   bottom: 10.0,
                 ),
@@ -97,14 +102,7 @@ class HomeRecommendBooks extends StatelessWidget {
                       ),
                     InkWell(
                       onTap: () {
-                        Navigator.push(
-                          context,
-                          MaterialPageRoute(
-                            builder: (_) => SearchDetailScreen(
-                              isbn13: bookListByCategory[index].isbn13!,
-                            ),
-                          ),
-                        );
+                        onTapBook(bookListByCategory[index].isbn13!);
                       },
                       child: Container(
                         width: 116,

--- a/frontend/lib/ui/home/components/home_recommend_books.dart
+++ b/frontend/lib/ui/home/components/home_recommend_books.dart
@@ -9,12 +9,14 @@ class HomeRecommendBooks extends StatelessWidget {
   final List<Books> bookListByCategory;
   final void Function(String) onTapCategory;
   final void Function(String) onTapBook;
+  final ScrollController categoryScrollController;
 
   const HomeRecommendBooks({
     required this.category,
     required this.bookListByCategory,
     required this.onTapCategory,
     required this.onTapBook,
+    required this.categoryScrollController,
     super.key,
   });
 
@@ -84,6 +86,7 @@ class HomeRecommendBooks extends StatelessWidget {
         ),
         Expanded(
           child: ListView.builder(
+            controller: categoryScrollController,
             scrollDirection: Axis.horizontal,
             physics: const BouncingScrollPhysics(),
             itemCount: bookListByCategory.length,

--- a/frontend/lib/ui/home/components/home_recommend_books.dart
+++ b/frontend/lib/ui/home/components/home_recommend_books.dart
@@ -1,0 +1,143 @@
+import 'package:flutter/material.dart';
+import 'package:mybrary/data/model/home/book_list_by_category_response.dart';
+import 'package:mybrary/res/constants/color.dart';
+import 'package:mybrary/res/constants/config.dart';
+import 'package:mybrary/res/constants/style.dart';
+import 'package:mybrary/ui/search/search_detail/search_detail_screen.dart';
+
+class HomeRecommendBooks extends StatelessWidget {
+  final String category;
+  final List<Books> bookListByCategory;
+  final void Function(String) onTapCategory;
+
+  const HomeRecommendBooks({
+    required this.category,
+    required this.bookListByCategory,
+    required this.onTapCategory,
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const Padding(
+          padding: EdgeInsets.only(
+            left: 16.0,
+            bottom: 2.0,
+          ),
+          child: Row(
+            children: [
+              Text(
+                '추천 도서, ',
+                style: commonSubBoldStyle,
+              ),
+              Text(
+                '이건 어때요?',
+                style: commonMainRegularStyle,
+              ),
+            ],
+          ),
+        ),
+        Padding(
+          padding: const EdgeInsets.all(16.0),
+          child: Wrap(
+            spacing: 8.0,
+            runSpacing: 8.0,
+            children: List.generate(
+              bookListByInterestedCategory.length,
+              (index) => InkWell(
+                onTap: () {
+                  onTapCategory(bookListByInterestedCategory[index]);
+                },
+                child: Container(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 19.0,
+                    vertical: 7.0,
+                  ),
+                  decoration: BoxDecoration(
+                    color: category == bookListByInterestedCategory[index]
+                        ? grey262626
+                        : commonWhiteColor,
+                    border: Border.all(
+                      color: grey777777,
+                    ),
+                    borderRadius: BorderRadius.circular(30.0),
+                  ),
+                  child: Text(
+                    bookListByInterestedCategory[index],
+                    style: categoryCircularTextStyle.copyWith(
+                      color: category == bookListByInterestedCategory[index]
+                          ? commonWhiteColor
+                          : grey262626,
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+        Expanded(
+          child: ListView.builder(
+            scrollDirection: Axis.horizontal,
+            physics: const BouncingScrollPhysics(),
+            itemCount: bookListByCategory.length,
+            itemBuilder: (context, index) {
+              return Padding(
+                padding: const EdgeInsets.only(
+                  right: 10.0,
+                  bottom: 10.0,
+                ),
+                child: Row(
+                  children: [
+                    if (index == 0)
+                      const SizedBox(
+                        width: 16.0,
+                      ),
+                    InkWell(
+                      onTap: () {
+                        Navigator.push(
+                          context,
+                          MaterialPageRoute(
+                            builder: (_) => SearchDetailScreen(
+                              isbn13: bookListByCategory[index].isbn13!,
+                            ),
+                          ),
+                        );
+                      },
+                      child: Container(
+                        width: 116,
+                        decoration: BoxDecoration(
+                          image: DecorationImage(
+                            image: NetworkImage(
+                              bookListByCategory[index].thumbnailUrl!,
+                            ),
+                            fit: BoxFit.fill,
+                          ),
+                          borderRadius: BorderRadius.circular(8),
+                          boxShadow: const [
+                            BoxShadow(
+                              color: Color(0x3F000000),
+                              blurRadius: 2,
+                              offset: Offset(1, 1),
+                              spreadRadius: 1,
+                            )
+                          ],
+                        ),
+                      ),
+                    ),
+                    if (index == bookListByCategory.length - 1)
+                      const SizedBox(
+                        width: 8.0,
+                      ),
+                  ],
+                ),
+              );
+            },
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/frontend/lib/ui/home/home_screen.dart
+++ b/frontend/lib/ui/home/home_screen.dart
@@ -1,9 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
+import 'package:mybrary/data/model/home/today_registered_book_count_response.dart';
+import 'package:mybrary/data/repository/home_repository.dart';
 import 'package:mybrary/res/constants/color.dart';
 import 'package:mybrary/res/constants/style.dart';
 import 'package:mybrary/ui/common/layout/default_layout.dart';
 import 'package:mybrary/ui/home/components/home_barcode_button.dart';
+import 'package:mybrary/ui/home/components/home_book_count.dart';
 import 'package:mybrary/ui/home/components/home_intro.dart';
 
 class HomeScreen extends StatefulWidget {
@@ -14,6 +17,19 @@ class HomeScreen extends StatefulWidget {
 }
 
 class _HomeScreenState extends State<HomeScreen> {
+  final _homeRepository = HomeRepository();
+
+  late Future<TodayRegisteredBookCountResponseData>
+      _getTodayRegisteredBookCount;
+
+  @override
+  void initState() {
+    super.initState();
+
+    _getTodayRegisteredBookCount =
+        _homeRepository.getTodayRegisteredBookCount();
+  }
+
   @override
   Widget build(BuildContext context) {
     return DefaultLayout(
@@ -23,8 +39,28 @@ class _HomeScreenState extends State<HomeScreen> {
         ),
         slivers: [
           _homeAppBar(),
-          HomeIntro(),
+          const HomeIntro(),
           const HomeBarcodeButton(),
+          FutureBuilder<TodayRegisteredBookCountResponseData>(
+            future: _getTodayRegisteredBookCount,
+            builder: (context, snapshot) {
+              if (snapshot.hasError) {
+                return const HomeBookCount(
+                  todayRegisteredBookCount: 0,
+                );
+              }
+
+              if (snapshot.hasData) {
+                final todayRegisteredBookCount = snapshot.data!.count;
+                return HomeBookCount(
+                  todayRegisteredBookCount: todayRegisteredBookCount!,
+                );
+              }
+              return const HomeBookCount(
+                todayRegisteredBookCount: 0,
+              );
+            },
+          ),
         ],
       ),
     );
@@ -40,12 +76,6 @@ class _HomeScreenState extends State<HomeScreen> {
       titleTextStyle: appBarTitleStyle,
       centerTitle: false,
       foregroundColor: commonBlackColor,
-      actions: [
-        IconButton(
-          onPressed: () {},
-          icon: SvgPicture.asset('assets/svg/icon/alarm.svg'),
-        ),
-      ],
     );
   }
 }

--- a/frontend/lib/ui/home/home_screen.dart
+++ b/frontend/lib/ui/home/home_screen.dart
@@ -1,13 +1,18 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
+import 'package:mybrary/data/model/home/book_list_by_category_response.dart';
+import 'package:mybrary/data/model/home/home_common_response.dart';
 import 'package:mybrary/data/model/home/today_registered_book_count_response.dart';
 import 'package:mybrary/data/repository/home_repository.dart';
 import 'package:mybrary/res/constants/color.dart';
 import 'package:mybrary/res/constants/style.dart';
+import 'package:mybrary/ui/common/components/circular_loading.dart';
+import 'package:mybrary/ui/common/components/data_error.dart';
 import 'package:mybrary/ui/common/layout/default_layout.dart';
 import 'package:mybrary/ui/home/components/home_barcode_button.dart';
 import 'package:mybrary/ui/home/components/home_book_count.dart';
 import 'package:mybrary/ui/home/components/home_intro.dart';
+import 'package:mybrary/ui/search/search_detail/search_detail_screen.dart';
 
 class HomeScreen extends StatefulWidget {
   const HomeScreen({Key? key}) : super(key: key);
@@ -20,14 +25,20 @@ class _HomeScreenState extends State<HomeScreen> {
   final _homeRepository = HomeRepository();
 
   late Future<TodayRegisteredBookCountResponseData>
-      _getTodayRegisteredBookCount;
+      _todayRegisteredBookCountData;
+
+  late Future<BookListByCategoryResponseData> _bookListByCategoryData;
 
   @override
   void initState() {
     super.initState();
 
-    _getTodayRegisteredBookCount =
+    _todayRegisteredBookCountData =
         _homeRepository.getTodayRegisteredBookCount();
+
+    _bookListByCategoryData = _homeRepository.getBookListByCategory(
+      type: 'Bestseller',
+    );
   }
 
   @override
@@ -41,29 +52,159 @@ class _HomeScreenState extends State<HomeScreen> {
           _homeAppBar(),
           const HomeIntro(),
           const HomeBarcodeButton(),
-          FutureBuilder<TodayRegisteredBookCountResponseData>(
-            future: _getTodayRegisteredBookCount,
+          FutureBuilder<HomeCommonData>(
+            future: Future.wait(_futureHomeData())
+                .then((data) => _buildHomeData(data)),
             builder: (context, snapshot) {
               if (snapshot.hasError) {
-                return const HomeBookCount(
-                  todayRegisteredBookCount: 0,
+                return const CustomScrollView(
+                  physics: BouncingScrollPhysics(
+                    parent: AlwaysScrollableScrollPhysics(),
+                  ),
+                  slivers: [
+                    SliverToBoxAdapter(
+                      child: SizedBox(
+                        height: 80.0,
+                      ),
+                    ),
+                    SliverToBoxAdapter(
+                      child: DataError(
+                        errorMessage: '메인 화면을 불러오는데 실패했습니다.',
+                      ),
+                    )
+                  ],
                 );
               }
 
               if (snapshot.hasData) {
-                final todayRegisteredBookCount = snapshot.data!.count;
-                return HomeBookCount(
-                  todayRegisteredBookCount: todayRegisteredBookCount!,
+                HomeCommonData homeData = snapshot.data!;
+                final todayRegisteredBookCount =
+                    homeData.todayRegisteredBookCountResponseData.count;
+                final bookListByCategory =
+                    homeData.bookListByCategoryResponseData.books!;
+
+                return SliverToBoxAdapter(
+                  child: Column(
+                    children: [
+                      HomeBookCount(
+                        todayRegisteredBookCount: todayRegisteredBookCount!,
+                      ),
+                      Container(
+                        height: 248,
+                        padding: const EdgeInsets.symmetric(
+                          vertical: 16.0,
+                        ),
+                        child: Column(
+                          children: [
+                            Padding(
+                              padding: const EdgeInsets.only(
+                                  left: 16.0, bottom: 16.0),
+                              child: Row(
+                                children: [
+                                  const Text(
+                                    '이번 주',
+                                    style: commonMainRegularStyle,
+                                  ),
+                                  Text(
+                                    ' 베스트셀러 ',
+                                    style: commonSubBoldStyle.copyWith(
+                                      fontSize: 16.0,
+                                    ),
+                                  ),
+                                  const Text(
+                                    '는?',
+                                    style: commonMainRegularStyle,
+                                  ),
+                                ],
+                              ),
+                            ),
+                            Expanded(
+                              child: ListView.builder(
+                                scrollDirection: Axis.horizontal,
+                                physics: const BouncingScrollPhysics(),
+                                itemCount: bookListByCategory.length,
+                                itemBuilder: (context, index) {
+                                  return Padding(
+                                    padding: const EdgeInsets.only(
+                                      right: 10.0,
+                                      bottom: 10.0,
+                                    ),
+                                    child: Row(
+                                      children: [
+                                        if (index == 0)
+                                          const SizedBox(
+                                            width: 16.0,
+                                          ),
+                                        InkWell(
+                                          onTap: () {
+                                            Navigator.push(
+                                              context,
+                                              MaterialPageRoute(
+                                                builder: (_) =>
+                                                    SearchDetailScreen(
+                                                  isbn13:
+                                                      bookListByCategory[index]
+                                                          .isbn13!,
+                                                ),
+                                              ),
+                                            );
+                                          },
+                                          child: Container(
+                                            width: 116,
+                                            decoration: BoxDecoration(
+                                              image: DecorationImage(
+                                                image: NetworkImage(
+                                                  bookListByCategory[index]
+                                                      .thumbnailUrl!,
+                                                ),
+                                                fit: BoxFit.fill,
+                                              ),
+                                              borderRadius:
+                                                  BorderRadius.circular(8),
+                                              boxShadow: const [
+                                                BoxShadow(
+                                                  color: Color(0x3F000000),
+                                                  blurRadius: 2,
+                                                  offset: Offset(1, 1),
+                                                  spreadRadius: 1,
+                                                )
+                                              ],
+                                            ),
+                                          ),
+                                        ),
+                                        if (index ==
+                                            bookListByCategory.length - 1)
+                                          const SizedBox(
+                                            width: 8.0,
+                                          ),
+                                      ],
+                                    ),
+                                  );
+                                },
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
+                    ],
+                  ),
                 );
               }
-              return const HomeBookCount(
-                todayRegisteredBookCount: 0,
+              return const SliverToBoxAdapter(
+                child: CircularLoading(),
               );
             },
           ),
         ],
       ),
     );
+  }
+
+  List<Future<Object>> _futureHomeData() {
+    return [
+      _todayRegisteredBookCountData,
+      _bookListByCategoryData,
+    ];
   }
 
   SliverAppBar _homeAppBar() {
@@ -76,6 +217,19 @@ class _HomeScreenState extends State<HomeScreen> {
       titleTextStyle: appBarTitleStyle,
       centerTitle: false,
       foregroundColor: commonBlackColor,
+    );
+  }
+
+  HomeCommonData _buildHomeData(List<Object> data) {
+    final [
+      todayRegisteredBookCountResponseData,
+      bookListByCategoryResponseData,
+    ] = data;
+    return HomeCommonData(
+      todayRegisteredBookCountResponseData: todayRegisteredBookCountResponseData
+          as TodayRegisteredBookCountResponseData,
+      bookListByCategoryResponseData:
+          bookListByCategoryResponseData as BookListByCategoryResponseData,
     );
   }
 }

--- a/frontend/lib/ui/home/home_screen.dart
+++ b/frontend/lib/ui/home/home_screen.dart
@@ -14,6 +14,7 @@ import 'package:mybrary/ui/home/components/home_best_seller.dart';
 import 'package:mybrary/ui/home/components/home_book_count.dart';
 import 'package:mybrary/ui/home/components/home_intro.dart';
 import 'package:mybrary/ui/home/components/home_recommend_books.dart';
+import 'package:mybrary/ui/search/search_detail/search_detail_screen.dart';
 
 class HomeScreen extends StatefulWidget {
   const HomeScreen({Key? key}) : super(key: key);
@@ -34,7 +35,7 @@ class _HomeScreenState extends State<HomeScreen> {
   late Future<BookListByCategoryResponseData> _bookListByTravelData;
 
   late String _bookCategory = '장르소설';
-  late List<Books> _bookListByCategory;
+  late List<Books> _bookListByCategory = [];
 
   @override
   void initState() {
@@ -48,7 +49,6 @@ class _HomeScreenState extends State<HomeScreen> {
     );
 
     // 홈 화면 카테고리 별 추천 도서 임시 데이터
-    _fetchData();
     _bookListByGenreNovelData = _homeRepository.getBookListByCategory(
       type: 'Bestseller',
       categoryId: 112011,
@@ -61,14 +61,6 @@ class _HomeScreenState extends State<HomeScreen> {
       type: 'Bestseller',
       categoryId: 1196,
     );
-  }
-
-  void _fetchData() async {
-    final result = await _homeRepository.getBookListByCategory(
-      type: 'Bestseller',
-      categoryId: 112011,
-    );
-    _bookListByCategory = result.books!;
   }
 
   @override
@@ -118,6 +110,10 @@ class _HomeScreenState extends State<HomeScreen> {
                     homeData.bookListByPsychologyData.books!;
                 final bookListByTravel = homeData.bookListByTravelData.books!;
 
+                if (_bookListByCategory.isEmpty) {
+                  _bookListByCategory.addAll([...bookListByGenreNovel]);
+                }
+
                 return SliverToBoxAdapter(
                   child: Column(
                     children: [
@@ -125,22 +121,28 @@ class _HomeScreenState extends State<HomeScreen> {
                         todayRegisteredBookCount: todayRegisteredBookCount!,
                       ),
                       Container(
-                        height: 248,
+                        height: 258,
                         padding: const EdgeInsets.symmetric(
                           vertical: 16.0,
                         ),
                         child: HomeBestSeller(
                           bookListByBestSeller: bookListByBestSeller,
+                          onTapBook: (String isbn13) {
+                            _nextToBookSearchDetailScreen(isbn13);
+                          },
                         ),
                       ),
                       Container(
-                        height: 300,
+                        height: 310,
                         padding: const EdgeInsets.symmetric(
                           vertical: 16.0,
                         ),
                         child: HomeRecommendBooks(
                             category: _bookCategory,
                             bookListByCategory: _bookListByCategory,
+                            onTapBook: (String isbn13) {
+                              _nextToBookSearchDetailScreen(isbn13);
+                            },
                             onTapCategory: (String category) {
                               setState(() {
                                 _bookCategory = category;
@@ -215,5 +217,21 @@ class _HomeScreenState extends State<HomeScreen> {
       bookListByTravelData:
           bookListByTravelData as BookListByCategoryResponseData,
     );
+  }
+
+  void _nextToBookSearchDetailScreen(String isbn13) {
+    Navigator.push(
+      context,
+      MaterialPageRoute(
+        builder: (_) => SearchDetailScreen(
+          isbn13: isbn13,
+        ),
+      ),
+    ).then((value) => {
+          setState(() {
+            _todayRegisteredBookCountData =
+                _homeRepository.getTodayRegisteredBookCount();
+          })
+        });
   }
 }

--- a/frontend/lib/ui/home/home_screen.dart
+++ b/frontend/lib/ui/home/home_screen.dart
@@ -10,9 +10,10 @@ import 'package:mybrary/ui/common/components/circular_loading.dart';
 import 'package:mybrary/ui/common/components/data_error.dart';
 import 'package:mybrary/ui/common/layout/default_layout.dart';
 import 'package:mybrary/ui/home/components/home_barcode_button.dart';
+import 'package:mybrary/ui/home/components/home_best_seller.dart';
 import 'package:mybrary/ui/home/components/home_book_count.dart';
 import 'package:mybrary/ui/home/components/home_intro.dart';
-import 'package:mybrary/ui/search/search_detail/search_detail_screen.dart';
+import 'package:mybrary/ui/home/components/home_recommend_books.dart';
 
 class HomeScreen extends StatefulWidget {
   const HomeScreen({Key? key}) : super(key: key);
@@ -28,6 +29,12 @@ class _HomeScreenState extends State<HomeScreen> {
       _todayRegisteredBookCountData;
 
   late Future<BookListByCategoryResponseData> _bookListByCategoryData;
+  late Future<BookListByCategoryResponseData> _bookListByGenreNovelData;
+  late Future<BookListByCategoryResponseData> _bookListByPsychologyData;
+  late Future<BookListByCategoryResponseData> _bookListByTravelData;
+
+  late String _bookCategory = '장르소설';
+  late List<Books> _bookListByCategory;
 
   @override
   void initState() {
@@ -39,6 +46,29 @@ class _HomeScreenState extends State<HomeScreen> {
     _bookListByCategoryData = _homeRepository.getBookListByCategory(
       type: 'Bestseller',
     );
+
+    // 홈 화면 카테고리 별 추천 도서 임시 데이터
+    _fetchData();
+    _bookListByGenreNovelData = _homeRepository.getBookListByCategory(
+      type: 'Bestseller',
+      categoryId: 112011,
+    );
+    _bookListByPsychologyData = _homeRepository.getBookListByCategory(
+      type: 'Bestseller',
+      categoryId: 51395,
+    );
+    _bookListByTravelData = _homeRepository.getBookListByCategory(
+      type: 'Bestseller',
+      categoryId: 1196,
+    );
+  }
+
+  void _fetchData() async {
+    final result = await _homeRepository.getBookListByCategory(
+      type: 'Bestseller',
+      categoryId: 112011,
+    );
+    _bookListByCategory = result.books!;
   }
 
   @override
@@ -80,8 +110,13 @@ class _HomeScreenState extends State<HomeScreen> {
                 HomeCommonData homeData = snapshot.data!;
                 final todayRegisteredBookCount =
                     homeData.todayRegisteredBookCountResponseData.count;
-                final bookListByCategory =
+                final bookListByBestSeller =
                     homeData.bookListByCategoryResponseData.books!;
+                final bookListByGenreNovel =
+                    homeData.bookListByGenreNovelData.books!;
+                final bookListByPsychology =
+                    homeData.bookListByPsychologyData.books!;
+                final bookListByTravel = homeData.bookListByTravelData.books!;
 
                 return SliverToBoxAdapter(
                   child: Column(
@@ -94,98 +129,35 @@ class _HomeScreenState extends State<HomeScreen> {
                         padding: const EdgeInsets.symmetric(
                           vertical: 16.0,
                         ),
-                        child: Column(
-                          children: [
-                            Padding(
-                              padding: const EdgeInsets.only(
-                                  left: 16.0, bottom: 16.0),
-                              child: Row(
-                                children: [
-                                  const Text(
-                                    '이번 주',
-                                    style: commonMainRegularStyle,
-                                  ),
-                                  Text(
-                                    ' 베스트셀러 ',
-                                    style: commonSubBoldStyle.copyWith(
-                                      fontSize: 16.0,
-                                    ),
-                                  ),
-                                  const Text(
-                                    '는?',
-                                    style: commonMainRegularStyle,
-                                  ),
-                                ],
-                              ),
-                            ),
-                            Expanded(
-                              child: ListView.builder(
-                                scrollDirection: Axis.horizontal,
-                                physics: const BouncingScrollPhysics(),
-                                itemCount: bookListByCategory.length,
-                                itemBuilder: (context, index) {
-                                  return Padding(
-                                    padding: const EdgeInsets.only(
-                                      right: 10.0,
-                                      bottom: 10.0,
-                                    ),
-                                    child: Row(
-                                      children: [
-                                        if (index == 0)
-                                          const SizedBox(
-                                            width: 16.0,
-                                          ),
-                                        InkWell(
-                                          onTap: () {
-                                            Navigator.push(
-                                              context,
-                                              MaterialPageRoute(
-                                                builder: (_) =>
-                                                    SearchDetailScreen(
-                                                  isbn13:
-                                                      bookListByCategory[index]
-                                                          .isbn13!,
-                                                ),
-                                              ),
-                                            );
-                                          },
-                                          child: Container(
-                                            width: 116,
-                                            decoration: BoxDecoration(
-                                              image: DecorationImage(
-                                                image: NetworkImage(
-                                                  bookListByCategory[index]
-                                                      .thumbnailUrl!,
-                                                ),
-                                                fit: BoxFit.fill,
-                                              ),
-                                              borderRadius:
-                                                  BorderRadius.circular(8),
-                                              boxShadow: const [
-                                                BoxShadow(
-                                                  color: Color(0x3F000000),
-                                                  blurRadius: 2,
-                                                  offset: Offset(1, 1),
-                                                  spreadRadius: 1,
-                                                )
-                                              ],
-                                            ),
-                                          ),
-                                        ),
-                                        if (index ==
-                                            bookListByCategory.length - 1)
-                                          const SizedBox(
-                                            width: 8.0,
-                                          ),
-                                      ],
-                                    ),
-                                  );
-                                },
-                              ),
-                            ),
-                          ],
+                        child: HomeBestSeller(
+                          bookListByBestSeller: bookListByBestSeller,
                         ),
                       ),
+                      Container(
+                        height: 300,
+                        padding: const EdgeInsets.symmetric(
+                          vertical: 16.0,
+                        ),
+                        child: HomeRecommendBooks(
+                            category: _bookCategory,
+                            bookListByCategory: _bookListByCategory,
+                            onTapCategory: (String category) {
+                              setState(() {
+                                _bookCategory = category;
+                                switch (category) {
+                                  case '심리학':
+                                    _bookListByCategory = bookListByPsychology;
+                                    break;
+                                  case '여행':
+                                    _bookListByCategory = bookListByTravel;
+                                    break;
+                                  default:
+                                    _bookListByCategory = bookListByGenreNovel;
+                                }
+                              });
+                            }),
+                      ),
+                      const SizedBox(height: 30.0),
                     ],
                   ),
                 );
@@ -198,13 +170,6 @@ class _HomeScreenState extends State<HomeScreen> {
         ],
       ),
     );
-  }
-
-  List<Future<Object>> _futureHomeData() {
-    return [
-      _todayRegisteredBookCountData,
-      _bookListByCategoryData,
-    ];
   }
 
   SliverAppBar _homeAppBar() {
@@ -220,16 +185,35 @@ class _HomeScreenState extends State<HomeScreen> {
     );
   }
 
+  List<Future<Object>> _futureHomeData() {
+    return [
+      _todayRegisteredBookCountData,
+      _bookListByCategoryData,
+      _bookListByGenreNovelData,
+      _bookListByPsychologyData,
+      _bookListByTravelData
+    ];
+  }
+
   HomeCommonData _buildHomeData(List<Object> data) {
     final [
       todayRegisteredBookCountResponseData,
       bookListByCategoryResponseData,
+      bookListByGenreNovelData,
+      bookListByPsychologyData,
+      bookListByTravelData,
     ] = data;
     return HomeCommonData(
       todayRegisteredBookCountResponseData: todayRegisteredBookCountResponseData
           as TodayRegisteredBookCountResponseData,
       bookListByCategoryResponseData:
           bookListByCategoryResponseData as BookListByCategoryResponseData,
+      bookListByGenreNovelData:
+          bookListByGenreNovelData as BookListByCategoryResponseData,
+      bookListByPsychologyData:
+          bookListByPsychologyData as BookListByCategoryResponseData,
+      bookListByTravelData:
+          bookListByTravelData as BookListByCategoryResponseData,
     );
   }
 }

--- a/frontend/lib/ui/home/home_screen.dart
+++ b/frontend/lib/ui/home/home_screen.dart
@@ -37,6 +37,8 @@ class _HomeScreenState extends State<HomeScreen> {
   late String _bookCategory = '장르소설';
   late List<Books> _bookListByCategory = [];
 
+  final ScrollController _categoryScrollController = ScrollController();
+
   @override
   void initState() {
     super.initState();
@@ -60,6 +62,14 @@ class _HomeScreenState extends State<HomeScreen> {
     _bookListByTravelData = _homeRepository.getBookListByCategory(
       type: 'Bestseller',
       categoryId: 1196,
+    );
+  }
+
+  void _scrollToTop() {
+    _categoryScrollController.animateTo(
+      0,
+      duration: const Duration(microseconds: 500),
+      curve: Curves.easeInOut,
     );
   }
 
@@ -140,6 +150,7 @@ class _HomeScreenState extends State<HomeScreen> {
                         child: HomeRecommendBooks(
                             category: _bookCategory,
                             bookListByCategory: _bookListByCategory,
+                            categoryScrollController: _categoryScrollController,
                             onTapBook: (String isbn13) {
                               _nextToBookSearchDetailScreen(isbn13);
                             },
@@ -149,12 +160,15 @@ class _HomeScreenState extends State<HomeScreen> {
                                 switch (category) {
                                   case '심리학':
                                     _bookListByCategory = bookListByPsychology;
+                                    _scrollToTop();
                                     break;
                                   case '여행':
                                     _bookListByCategory = bookListByTravel;
+                                    _scrollToTop();
                                     break;
                                   default:
                                     _bookListByCategory = bookListByGenreNovel;
+                                    _scrollToTop();
                                 }
                               });
                             }),

--- a/frontend/lib/ui/mybook/mybook_screen.dart
+++ b/frontend/lib/ui/mybook/mybook_screen.dart
@@ -145,9 +145,7 @@ class _MyBookScreenState extends State<MyBookScreen> {
               ],
             );
           }
-          return const SliverToBoxAdapter(
-            child: CircularLoading(),
-          );
+          return const CircularLoading();
         },
       ),
     );

--- a/frontend/lib/ui/mybook/mybook_screen.dart
+++ b/frontend/lib/ui/mybook/mybook_screen.dart
@@ -145,7 +145,9 @@ class _MyBookScreenState extends State<MyBookScreen> {
               ],
             );
           }
-          return const CircularLoading();
+          return const SliverToBoxAdapter(
+            child: CircularLoading(),
+          );
         },
       ),
     );

--- a/frontend/lib/utils/logics/common_utils.dart
+++ b/frontend/lib/utils/logics/common_utils.dart
@@ -2,12 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:mybrary/res/constants/color.dart';
 
 Widget loadingIndicator() {
-  return SizedBox(
-    width: 30,
-    height: 30,
-    child: CircularProgressIndicator(
-      backgroundColor: primaryColor.withOpacity(0.2),
-      valueColor: const AlwaysStoppedAnimation<Color>(primaryColor),
-    ),
+  return CircularProgressIndicator(
+    backgroundColor: primaryColor.withOpacity(0.2),
+    valueColor: const AlwaysStoppedAnimation<Color>(primaryColor),
   );
 }

--- a/frontend/lib/utils/logics/common_utils.dart
+++ b/frontend/lib/utils/logics/common_utils.dart
@@ -1,0 +1,13 @@
+import 'package:flutter/material.dart';
+import 'package:mybrary/res/constants/color.dart';
+
+Widget loadingIndicator() {
+  return SizedBox(
+    width: 30,
+    height: 30,
+    child: CircularProgressIndicator(
+      backgroundColor: primaryColor.withOpacity(0.2),
+      valueColor: const AlwaysStoppedAnimation<Color>(primaryColor),
+    ),
+  );
+}


### PR DESCRIPTION
## 🧑‍💻 작업 사항

### 홈 메인 페이지 - 오늘 등록된 책 수 카운팅 및 이번 주 베스트 셀러 조회 / 카테고리 별 추천 도서 조회

<div>
<img src="https://github.com/SWM-IDLE/mybrary/assets/97138841/b1eaf238-3449-42d8-89bb-84ee5b30300e" alt="책 카운팅 및 베스트셀러 조회" width="290" height="630"/>
<img src="https://github.com/SWM-IDLE/mybrary/assets/97138841/21ee5a37-1aa3-4787-99b3-2d2745dc5b61" alt="카테고리 별 추천도서 조회" width="290" height="630"/>
</div>

<br>

홈 메인 페이지
- 오늘 마이브러리에 등록된 책 수 표시 UI 구현 및 api 연동
- 이번 주 베스트 셀러 UI 구현 및 api 연동
  - 마이북 등록 후 뒤로가기 시 등록된 책 수 재 카운팅
- 카테고리 별 추천 도서 UI 구현 및 api 임시 연동
  - 카테고리 도서 목록 스크롤 후 다른 카테고리 선택 시 스크롤 초기화 (UX)

<br><br>

## 🔗 링크

<br><br>

## 🐰 시급한 정도

🏃‍♂️ 보통 : 최대한 빠르게 리뷰 부탁드립니다.

<br><br>

## 📖 참고 사항

- 피그마와 조금 다르게 오늘 등록된 책의 자릿수를 6자리로 설정하였습니다.
- 카테고리 (관심사) 별 추천 도서 UI 구현 및 조회가 잘 되는지 여부를 확인하기 위해 3개의 임시 카테고리로 조회합니다.
  - 추후 api 개발되면 수정하도록 하겠습니다!

<br>
