### PR TITLE
[IDLE-227] 도서 관련 버그 수정

### DIFF
--- a/backend/book-service/src/main/java/kr/mybrary/bookservice/book/domain/dto/BookDtoMapper.java
+++ b/backend/book-service/src/main/java/kr/mybrary/bookservice/book/domain/dto/BookDtoMapper.java
@@ -38,6 +38,7 @@ public interface BookDtoMapper {
     @Mapping(target = "category", source = "bookCategory.name")
     @Mapping(target = "categoryId", source = "bookCategory.cid")
     @Mapping(target = "publicationDate", source = "publicationDate", qualifiedByName = "localDateTimeToString")
+    @Mapping(target = "starRating", expression = "java(getAverageStarRating(book))")
     BookDetailResponse bookToDetailServiceResponse(Book book);
 
     @Mapping(target = "aladinStarRating", source = "starRating")
@@ -89,5 +90,13 @@ public interface BookDtoMapper {
     static String localDateTimeToString(LocalDateTime publicationDate) {
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
         return publicationDate.format(formatter);
+    }
+
+    default double getAverageStarRating(Book book) {
+        if (book.getReviewCount() == 0) {
+            return 0.0;
+        }
+        double averageRating = (double) book.getStarRating() / book.getReviewCount();
+        return Math.round(averageRating * 10.0) / 10.0;
     }
 }

--- a/backend/book-service/src/main/java/kr/mybrary/bookservice/book/persistence/Book.java
+++ b/backend/book-service/src/main/java/kr/mybrary/bookservice/book/persistence/Book.java
@@ -15,6 +15,7 @@ import kr.mybrary.bookservice.book.persistence.bookInfo.BookAuthor;
 import kr.mybrary.bookservice.book.persistence.bookInfo.BookCategory;
 import kr.mybrary.bookservice.book.persistence.bookInfo.BookTranslator;
 import kr.mybrary.bookservice.global.BaseEntity;
+import kr.mybrary.bookservice.mybook.persistence.ReadStatus;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -124,8 +125,20 @@ public class Book extends BaseEntity {
         this.interestCount--;
     }
 
-    public boolean isInterestedByLoginUser(String loginId) {
-        return this.bookInterests.stream()
-                .anyMatch(bookInterest -> bookInterest.getUserId().equals(loginId));
+    private void increaseReadCount() {
+        this.readCount++;
+    }
+
+    private void decreaseReadCount() {
+        this.readCount--;
+    }
+
+    public void adjustReadCount(ReadStatus previousReadStatus, ReadStatus currentReadStatus) {
+
+        if (previousReadStatus == ReadStatus.COMPLETED && currentReadStatus != ReadStatus.COMPLETED) {
+            this.decreaseReadCount();
+        } else if (previousReadStatus != ReadStatus.COMPLETED && currentReadStatus == ReadStatus.COMPLETED) {
+            this.increaseReadCount();
+        }
     }
 }

--- a/backend/book-service/src/main/java/kr/mybrary/bookservice/book/persistence/Book.java
+++ b/backend/book-service/src/main/java/kr/mybrary/bookservice/book/persistence/Book.java
@@ -141,4 +141,9 @@ public class Book extends BaseEntity {
             this.increaseReadCount();
         }
     }
+
+    public void adjustReviewCountAndStarRating(Double starRating) {
+        this.reviewCount++;
+        this.starRating += starRating;
+    }
 }

--- a/backend/book-service/src/main/java/kr/mybrary/bookservice/book/persistence/Book.java
+++ b/backend/book-service/src/main/java/kr/mybrary/bookservice/book/persistence/Book.java
@@ -146,4 +146,8 @@ public class Book extends BaseEntity {
         this.reviewCount++;
         this.starRating += starRating;
     }
+
+    public void recalculateStarRating(Double originStarRating, Double starRating) {
+        this.starRating = (this.starRating - originStarRating) + starRating;
+    }
 }

--- a/backend/book-service/src/main/java/kr/mybrary/bookservice/book/persistence/Book.java
+++ b/backend/book-service/src/main/java/kr/mybrary/bookservice/book/persistence/Book.java
@@ -142,17 +142,17 @@ public class Book extends BaseEntity {
         }
     }
 
-    public void adjustReviewCountAndStarRating(Double starRating) {
+    public void updateWhenCreateReview(Double newStartRating) {
         this.reviewCount++;
-        this.starRating += starRating;
+        this.starRating += newStartRating;
     }
 
-    public void recalculateStarRating(Double originStarRating, Double starRating) {
-        this.starRating = (this.starRating - originStarRating) + starRating;
+    public void updateWhenUpdateReview(Double originStarRating, Double newStarRating) {
+        this.starRating = (this.starRating - originStarRating) + newStarRating;
     }
 
-    public void removeReview(Double originReviewStarRating) {
+    public void updateWhenDeleteReview(Double originStarRating) {
         this.reviewCount--;
-        this.starRating -= originReviewStarRating;
+        this.starRating -= originStarRating;
     }
 }

--- a/backend/book-service/src/main/java/kr/mybrary/bookservice/book/persistence/Book.java
+++ b/backend/book-service/src/main/java/kr/mybrary/bookservice/book/persistence/Book.java
@@ -150,4 +150,9 @@ public class Book extends BaseEntity {
     public void recalculateStarRating(Double originStarRating, Double starRating) {
         this.starRating = (this.starRating - originStarRating) + starRating;
     }
+
+    public void removeReview(Double originReviewStarRating) {
+        this.reviewCount--;
+        this.starRating -= originReviewStarRating;
+    }
 }

--- a/backend/book-service/src/main/java/kr/mybrary/bookservice/booksearch/domain/AladinBookSearchApiService.java
+++ b/backend/book-service/src/main/java/kr/mybrary/bookservice/booksearch/domain/AladinBookSearchApiService.java
@@ -79,7 +79,9 @@ public class AladinBookSearchApiService implements PlatformBookSearchApiService 
 
         AladinBookSearchResponse response = Objects.requireNonNull(searchResponse.getBody());
 
-        checkIfSearchResultExists(response.getTotalResults());
+        if (response.getTotalResults() == 0) {
+            return BookSearchResultResponse.of(List.of(), "");
+        }
 
         List<BookSearchResultResponseElement> bookSearchResultResponseElement = response.getItem().stream()
                 .filter(book -> hasISBN13(book.getIsbn13()))

--- a/backend/book-service/src/main/java/kr/mybrary/bookservice/mybook/domain/MyBookService.java
+++ b/backend/book-service/src/main/java/kr/mybrary/bookservice/mybook/domain/MyBookService.java
@@ -140,7 +140,7 @@ public class MyBookService {
             MyBookReadCompletedStatusServiceRequest request) {
 
         return bookReadService.findOptionalBookByISBN13(request.getIsbn13())
-                .map(book -> myBookRepository.findByIdWithBook(book.getId())
+                .map(book -> myBookRepository.findByUserIdAndBook(request.getLoginId(), book)
                                 .map(myBook -> MyBookReadCompletedStatusResponse.of(myBook.getReadStatus() == ReadStatus.COMPLETED))
                                 .orElseGet(() -> MyBookReadCompletedStatusResponse.of(false)))
                 .orElseGet(() -> MyBookReadCompletedStatusResponse.of(false));

--- a/backend/book-service/src/main/java/kr/mybrary/bookservice/mybook/persistence/MyBook.java
+++ b/backend/book-service/src/main/java/kr/mybrary/bookservice/mybook/persistence/MyBook.java
@@ -77,10 +77,14 @@ public class MyBook extends BaseEntity {
     }
 
     public void updateFromUpdateRequest(MybookUpdateServiceRequest updateRequest) {
+
+        ReadStatus previousReadStatus = this.readStatus;
         this.readStatus = updateRequest.getReadStatus();
         this.startDateOfPossession = updateRequest.getStartDateOfPossession();
         this.showable = updateRequest.isShowable();
         this.exchangeable = updateRequest.isExchangeable();
         this.shareable = updateRequest.isShareable();
+
+        this.book.adjustReadCount(previousReadStatus, updateRequest.getReadStatus());
     }
 }

--- a/backend/book-service/src/main/java/kr/mybrary/bookservice/mybook/persistence/repository/MyBookRepository.java
+++ b/backend/book-service/src/main/java/kr/mybrary/bookservice/mybook/persistence/repository/MyBookRepository.java
@@ -31,4 +31,6 @@ public interface MyBookRepository extends JpaRepository<MyBook, Long>, MyBookRep
             + "left join fetch m.book "
             + "where m.id = :mybookId")
     Optional<MyBook> findByIdWithBook(Long mybookId);
+
+    Optional<MyBook> findByUserIdAndBook(String userId, Book book);
 }

--- a/backend/book-service/src/main/java/kr/mybrary/bookservice/review/domain/MyReviewWriteService.java
+++ b/backend/book-service/src/main/java/kr/mybrary/bookservice/review/domain/MyReviewWriteService.java
@@ -36,10 +36,12 @@ public class MyReviewWriteService {
     public MyReviewUpdateResponse update(MyReviewUpdateServiceRequest request) {
 
         MyReview myReview = getMyReviewById(request.getMyReviewId());
+        Double originStarRating = myReview.getStarRating();
 
         checkIsOwnerSameAsRequester(myReview.getMyBook().getUserId(), request.getLoginId());
 
         myReview.update(request);
+        myReview.getBook().recalculateStarRating(originStarRating, request.getStarRating());
         return MyReviewUpdateResponse.of(myReview);
     }
 

--- a/backend/book-service/src/main/java/kr/mybrary/bookservice/review/domain/MyReviewWriteService.java
+++ b/backend/book-service/src/main/java/kr/mybrary/bookservice/review/domain/MyReviewWriteService.java
@@ -50,6 +50,7 @@ public class MyReviewWriteService {
         MyReview myReview = getMyReviewById(request.getMyReviewId());
         checkIsOwnerSameAsRequester(myReview.getMyBook().getUserId(), request.getLoginId());
 
+        myReview.getBook().removeReview(myReview.getStarRating());
         myReview.delete();
     }
 

--- a/backend/book-service/src/main/java/kr/mybrary/bookservice/review/domain/MyReviewWriteService.java
+++ b/backend/book-service/src/main/java/kr/mybrary/bookservice/review/domain/MyReviewWriteService.java
@@ -30,6 +30,7 @@ public class MyReviewWriteService {
         checkMyBookReviewAlreadyRegistered(myBook);
 
         myReviewRepository.save(MyReview.of(myBook, request));
+        myBook.getBook().adjustReviewCountAndStarRating(request.getStarRating());
     }
 
     public MyReviewUpdateResponse update(MyReviewUpdateServiceRequest request) {

--- a/backend/book-service/src/test/java/kr/mybrary/bookservice/book/BookFixture.java
+++ b/backend/book-service/src/test/java/kr/mybrary/bookservice/book/BookFixture.java
@@ -17,7 +17,7 @@ import lombok.AllArgsConstructor;
 public enum BookFixture {
 
     COMMON_BOOK(1L, "title", "subTitle", "author","thumbnailUrl", "link", "isbn10", "isbn13", 100, "publisher",
-            LocalDateTime.now(), "description", "toc", 10, 11, 12, 13, 10000, 11000, 1, 1, 1, 4.5, 1, 3.5, 10,
+            LocalDateTime.now(), "description", "toc", 10, 11, 12, 13, 10000, 11000, 1, 1, 1, 4.5, 2, 3.5, 10,
             createBookCategory(), createBookAuthors(), createBookTranslators(), createBookInterest()),
 
     COMMON_BOOK_WITHOUT_RELATION(null, "title", "author","subTitle", "thumbnailUrl", "link", "isbn10", "isbn13", 100, "publisher",

--- a/backend/book-service/src/test/java/kr/mybrary/bookservice/book/domain/dto/BookDtoMapperTest.java
+++ b/backend/book-service/src/test/java/kr/mybrary/bookservice/book/domain/dto/BookDtoMapperTest.java
@@ -120,7 +120,7 @@ class BookDtoMapperTest {
         assertAll(
                 () -> assertThat(bookDetailResponse.getTitle()).isEqualTo(book.getTitle()),
                 () -> assertThat(bookDetailResponse.getThumbnail()).isEqualTo(book.getThumbnailUrl()),
-                () -> assertThat(bookDetailResponse.getStarRating()).isEqualTo(book.getStarRating()),
+                () -> assertThat(bookDetailResponse.getStarRating()).isEqualTo(getAverageStarRating(book)),
                 () -> assertThat(bookDetailResponse.getReviewCount()).isEqualTo(book.getReviewCount()),
                 () -> assertThat(bookDetailResponse.getAladinStarRating()).isEqualTo(book.getAladinStarRating()),
                 () -> assertThat(bookDetailResponse.getAladinReviewCount()).isEqualTo(book.getAladinReviewCount()),
@@ -264,5 +264,13 @@ class BookDtoMapperTest {
                 () -> assertThat(target.getThumbnailUrl()).isEqualTo(source.getBook().getThumbnailUrl()),
                 () -> assertThat(target.getAuthor()).isEqualTo(source.getBook().getAuthor())
         );
+    }
+
+    private double getAverageStarRating(Book book) {
+        if (book.getReviewCount() == 0) {
+            return 0.0;
+        }
+        double averageRating = (double) book.getStarRating() / book.getReviewCount();
+        return Math.round(averageRating * 10.0) / 10.0;
     }
 }

--- a/backend/book-service/src/test/java/kr/mybrary/bookservice/booksearch/domain/AladinBookSearchApiServiceTest.java
+++ b/backend/book-service/src/test/java/kr/mybrary/bookservice/booksearch/domain/AladinBookSearchApiServiceTest.java
@@ -164,7 +164,7 @@ class AladinBookSearchApiServiceTest {
         );
     }
 
-    @DisplayName("도서 검색 결과가 없으면 예외가 발생한다.")
+    @DisplayName("도서 검색 결과가 없으면 빈 응답을 반환한다.")
     @Test
     void searchWithKeywordAndResultEmpty() throws IOException {
 
@@ -178,10 +178,13 @@ class AladinBookSearchApiServiceTest {
                         + API_KEY))
                 .andRespond(withSuccess(expectResult, MediaType.APPLICATION_JSON));
 
-        // when, then
+        // when
+        BookSearchResultResponse response = aladinBookSearchApiService.searchWithKeyword(request);
+
+        // then
         assertAll(
-                () -> assertThatThrownBy(() -> aladinBookSearchApiService.searchWithKeyword(request))
-                .isInstanceOf(BookSearchResultNotFoundException.class),
+                () -> assertThat(response.getBookSearchResult()).isEmpty(),
+                () -> assertThat(response.getNextRequestUrl()).isEqualTo(""),
                 () -> verify(bookSearchRankingService, never()).increaseSearchRankingScore(request.getKeyword())
         );
     }

--- a/backend/book-service/src/test/java/kr/mybrary/bookservice/booksearch/domain/KakaoBookSearchApiServiceTest.java
+++ b/backend/book-service/src/test/java/kr/mybrary/bookservice/booksearch/domain/KakaoBookSearchApiServiceTest.java
@@ -132,7 +132,7 @@ class KakaoBookSearchApiServiceTest {
         );
     }
 
-    @DisplayName("도서 검색 결과가 존재하지 않으면, 예외가 발생한다.")
+    @DisplayName("도서 검색 결과가 존재하지 않으면, 빈 응답을 반환한다.")
     @Test
     void searchFromKakaoApiAndResultNotExist() throws IOException {
 
@@ -140,20 +140,18 @@ class KakaoBookSearchApiServiceTest {
         String expectResult = readJsonFile("resultEmpty.json");
 
         mockServer
-                .expect(requestTo(KAKAO_BOOK_SEARCH_API_URL + "/isbn?isbn=" + NOT_EXIST_ISBN))
+                .expect(requestTo(KAKAO_BOOK_SEARCH_API_URL + "?query=empty keywordr&sort=accuracy&page=1"))
                 .andRespond(withSuccess(expectResult, MediaType.APPLICATION_JSON));
 
-        BookSearchServiceRequest request = BookSearchServiceRequest.of(NOT_EXIST_ISBN);
+        BookSearchServiceRequest request = BookSearchServiceRequest.of("empty keyword", "accuracy", 1);
 
-        // when then
-        BookSearchResultNotFoundException exception = assertThrows(
-                BookSearchResultNotFoundException.class,
-                () -> kakaoBookSearchApiService.searchBookDetailWithISBN(request));
+        // when
+        BookSearchResultResponse response = kakaoBookSearchApiService.searchWithKeyword(request);
 
+        // then
         assertAll(
-                () -> assertThat(exception.getStatus()).isEqualTo(404),
-                () -> assertThat(exception.getErrorMessage()).isEqualTo("도서 검색 결과가 존재하지 않습니다."),
-                () -> assertThat(exception.getErrorCode()).isEqualTo("B-01")
+                () -> assertThat(response.getBookSearchResult()).isEmpty(),
+                () -> assertThat(response.getNextRequestUrl()).isEqualTo("")
         );
     }
 

--- a/backend/book-service/src/test/java/kr/mybrary/bookservice/mybook/MybookDtoTestData.java
+++ b/backend/book-service/src/test/java/kr/mybrary/bookservice/mybook/MybookDtoTestData.java
@@ -9,6 +9,7 @@ import kr.mybrary.bookservice.mybook.domain.dto.request.MyBookFindAllServiceRequ
 import kr.mybrary.bookservice.mybook.domain.dto.request.MyBookReadCompletedStatusServiceRequest;
 import kr.mybrary.bookservice.mybook.domain.dto.request.MyBookRegisteredStatusServiceRequest;
 import kr.mybrary.bookservice.mybook.domain.dto.request.MybookUpdateServiceRequest;
+import kr.mybrary.bookservice.mybook.domain.dto.request.MybookUpdateServiceRequest.MybookUpdateServiceRequestBuilder;
 import kr.mybrary.bookservice.mybook.persistence.MyBookOrderType;
 import kr.mybrary.bookservice.mybook.persistence.ReadStatus;
 import kr.mybrary.bookservice.mybook.persistence.model.MyBookListDisplayElementModel;
@@ -141,7 +142,7 @@ public class MybookDtoTestData {
                 .build();
     }
 
-    public static MybookUpdateServiceRequest createMyBookUpdateServiceRequest(String loginId, Long myBookId) {
+    public static MybookUpdateServiceRequestBuilder createMyBookUpdateServiceRequest(String loginId, Long myBookId) {
         return MybookUpdateServiceRequest.builder()
                 .loginId(loginId)
                 .myBookId(myBookId)
@@ -153,8 +154,7 @@ public class MybookDtoTestData {
                 .meaningTag(MybookUpdateServiceRequest.MeaningTag.builder()
                         .quote("the book that help me dream")
                         .colorCode("#FFFFFF")
-                        .build())
-                .build();
+                        .build());
     }
 
     public static MyBookListDisplayElementModelBuilder createMyBookListDisplayElementModelBuilder() {

--- a/backend/book-service/src/test/java/kr/mybrary/bookservice/mybook/domain/MyBookReadServiceTest.java
+++ b/backend/book-service/src/test/java/kr/mybrary/bookservice/mybook/domain/MyBookReadServiceTest.java
@@ -103,8 +103,7 @@ class MyBookReadServiceTest {
         // given
         MyBookCreateServiceRequest request = MybookDtoTestData.createMyBookCreateServiceRequest();
 
-        given(bookReadService.getRegisteredBookByISBN13(anyString()))
-                .willReturn(Book.builder().id(1L).build());
+        given(bookReadService.getRegisteredBookByISBN13(anyString())).willReturn(Book.builder().id(1L).build());
         given(myBookRepository.existsByUserIdAndBook(any(), any())).willReturn(true);
 
         // when, then
@@ -122,8 +121,7 @@ class MyBookReadServiceTest {
     void findAllMyBooks() {
 
         //given
-        MyBookFindAllServiceRequest request = MybookDtoTestData.createMyBookFindAllServiceRequest(
-                LOGIN_ID, LOGIN_ID);
+        MyBookFindAllServiceRequest request = MybookDtoTestData.createMyBookFindAllServiceRequest(LOGIN_ID, LOGIN_ID);
 
         given(myBookRepository.findMyBookListDisplayElementModelsByUserId(any(), any(), any())).willReturn(
                 List.of(MybookDtoTestData.createMyBookListDisplayElementModelBuilder().build(),
@@ -144,8 +142,7 @@ class MyBookReadServiceTest {
     void findOtherUserAllMyBooks() {
 
         //given
-        MyBookFindAllServiceRequest request = MybookDtoTestData.createMyBookFindAllServiceRequest(
-                OTHER_USER_ID, LOGIN_ID);
+        MyBookFindAllServiceRequest request = MybookDtoTestData.createMyBookFindAllServiceRequest(OTHER_USER_ID, LOGIN_ID);
 
         given(myBookRepository.findMyBookListDisplayElementModelsByUserId(any(), any(), any())).willReturn(
                 List.of(MybookDtoTestData.createMyBookListDisplayElementModelBuilder().build(),
@@ -169,8 +166,7 @@ class MyBookReadServiceTest {
         MyBookDetailServiceRequest request = MyBookDetailServiceRequest.of(LOGIN_ID, 1L);
         MyBook myBook = MyBookFixture.COMMON_LOGIN_USER_MYBOOK.getMyBook();
 
-        given(myBookRepository.findMyBookDetailUsingFetchJoin(any())).willReturn(
-                Optional.ofNullable(myBook));
+        given(myBookRepository.findMyBookDetailUsingFetchJoin(any())).willReturn(Optional.ofNullable(myBook));
 
         // when
         MyBookDetailResponse myBookDetail = myBookService.findMyBookDetail(request);
@@ -211,8 +207,7 @@ class MyBookReadServiceTest {
         MyBookDetailServiceRequest request = MyBookDetailServiceRequest.of(LOGIN_ID, 1L);
         MyBook myBook = MyBookFixture.NOT_SHOWABLE_OTHER_USER_MYBOOK.getMyBook();
 
-        given(myBookRepository.findMyBookDetailUsingFetchJoin(any())).willReturn(
-                Optional.ofNullable(myBook));
+        given(myBookRepository.findMyBookDetailUsingFetchJoin(any())).willReturn(Optional.ofNullable(myBook));
 
         // when, then
         assertAll(
@@ -256,8 +251,7 @@ class MyBookReadServiceTest {
         MyBookDeleteServiceRequest request = MyBookDeleteServiceRequest.of(LOGIN_ID, 1L);
         MyBook myBook = MyBookFixture.COMMON_OTHER_USER_MYBOOK.getMyBook();
 
-        given(myBookRepository.findById(any())).willReturn(
-                Optional.ofNullable(myBook));
+        given(myBookRepository.findById(any())).willReturn(Optional.ofNullable(myBook));
 
         // when, then
         assertAll(
@@ -276,12 +270,10 @@ class MyBookReadServiceTest {
     void updateMyBook() {
 
         //given
-        MybookUpdateServiceRequest request = MybookDtoTestData.createMyBookUpdateServiceRequest(
-                LOGIN_ID, MYBOOK_ID);
+        MybookUpdateServiceRequest request = MybookDtoTestData.createMyBookUpdateServiceRequest(LOGIN_ID, MYBOOK_ID).build();
         MyBook myBook = MyBookFixture.COMMON_LOGIN_USER_MYBOOK.getMyBook();
 
-        given(myBookRepository.findById(any())).willReturn(
-                Optional.ofNullable(myBook));
+        given(myBookRepository.findById(any())).willReturn(Optional.ofNullable(myBook));
         willDoNothing().given(meaningTagService).assignMeaningTag(any());
 
         // when
@@ -292,16 +284,86 @@ class MyBookReadServiceTest {
                 () -> verify(myBookRepository).findById(request.getMyBookId()),
                 () -> {
                     assertThat(myBook).isNotNull();
-                    assertThat(response.getStartDateOfPossession()).isEqualTo(
-                            request.getStartDateOfPossession());
+                    assertThat(response.getStartDateOfPossession()).isEqualTo(request.getStartDateOfPossession());
                     assertThat(response.isExchangeable()).isEqualTo(request.isExchangeable());
                     assertThat(response.isShareable()).isEqualTo(request.isShareable());
                     assertThat(response.isShowable()).isEqualTo(request.isShowable());
                     assertThat(response.getReadStatus()).isEqualTo(request.getReadStatus());
-                    assertThat(response.getMeaningTag().getQuote()).isEqualTo(
-                            request.getMeaningTag().getQuote());
-                    assertThat(response.getMeaningTag().getColorCode()).isEqualTo(
-                            request.getMeaningTag().getColorCode());
+                    assertThat(response.getMeaningTag().getQuote()).isEqualTo(request.getMeaningTag().getQuote());
+                    assertThat(response.getMeaningTag().getColorCode()).isEqualTo(request.getMeaningTag().getColorCode());
+                }
+        );
+    }
+
+    @DisplayName("독서 상태를 완독으로 수정할 때, 도서의 readCount가 1 증가한다.")
+    @Test
+    void updateMyBookReadStatusToCompleted() {
+
+        //given
+        MybookUpdateServiceRequest request = MybookDtoTestData.createMyBookUpdateServiceRequest(LOGIN_ID, MYBOOK_ID)
+                .readStatus(ReadStatus.COMPLETED)
+                .build();
+
+        MyBook myBook = MyBookFixture.COMMON_LOGIN_USER_MYBOOK.getMyBook();
+        Integer originReadCount = myBook.getBook().getReadCount();
+
+        given(myBookRepository.findById(any())).willReturn(Optional.ofNullable(myBook));
+        willDoNothing().given(meaningTagService).assignMeaningTag(any());
+
+        // when
+        MyBookUpdateResponse response = myBookService.updateMyBookProperties(request);
+
+        // then
+        assertAll(
+                () -> verify(myBookRepository).findById(request.getMyBookId()),
+                () -> {
+                    assertThat(myBook).isNotNull();
+                    assertThat(myBook.getBook().getReadCount()).isEqualTo(originReadCount + 1);
+                    assertThat(response.getStartDateOfPossession()).isEqualTo(request.getStartDateOfPossession());
+                    assertThat(response.isExchangeable()).isEqualTo(request.isExchangeable());
+                    assertThat(response.isShareable()).isEqualTo(request.isShareable());
+                    assertThat(response.isShowable()).isEqualTo(request.isShowable());
+                    assertThat(response.getReadStatus()).isEqualTo(request.getReadStatus());
+                    assertThat(response.getMeaningTag().getQuote()).isEqualTo(request.getMeaningTag().getQuote());
+                    assertThat(response.getMeaningTag().getColorCode()).isEqualTo(request.getMeaningTag().getColorCode());
+                }
+        );
+    }
+
+    @DisplayName("독서 상태를 완독에서 읽는 중으로 수정할 때, 도서의 readCount가 1 감소한다")
+    @Test
+    void updateMyBookReadStatusToReadingFromCompleted() {
+
+        //given
+        MybookUpdateServiceRequest request = MybookDtoTestData.createMyBookUpdateServiceRequest(LOGIN_ID, MYBOOK_ID)
+                .readStatus(ReadStatus.READING)
+                .build();
+
+        MyBook myBook = MyBookFixture.COMMON_LOGIN_USER_MYBOOK.getMyBookBuilder()
+                .readStatus(ReadStatus.COMPLETED)
+                .build();
+
+        Integer originReadCount = myBook.getBook().getReadCount();
+
+        given(myBookRepository.findById(any())).willReturn(Optional.ofNullable(myBook));
+        willDoNothing().given(meaningTagService).assignMeaningTag(any());
+
+        // when
+        MyBookUpdateResponse response = myBookService.updateMyBookProperties(request);
+
+        // then
+        assertAll(
+                () -> verify(myBookRepository).findById(request.getMyBookId()),
+                () -> {
+                    assertThat(myBook).isNotNull();
+                    assertThat(myBook.getBook().getReadCount()).isEqualTo(originReadCount - 1);
+                    assertThat(response.getStartDateOfPossession()).isEqualTo(request.getStartDateOfPossession());
+                    assertThat(response.isExchangeable()).isEqualTo(request.isExchangeable());
+                    assertThat(response.isShareable()).isEqualTo(request.isShareable());
+                    assertThat(response.isShowable()).isEqualTo(request.isShowable());
+                    assertThat(response.getReadStatus()).isEqualTo(request.getReadStatus());
+                    assertThat(response.getMeaningTag().getQuote()).isEqualTo(request.getMeaningTag().getQuote());
+                    assertThat(response.getMeaningTag().getColorCode()).isEqualTo(request.getMeaningTag().getColorCode());
                 }
         );
     }
@@ -311,8 +373,7 @@ class MyBookReadServiceTest {
     void occurExceptionWhenUpdateOtherUserMyBook() {
 
         //given
-        MybookUpdateServiceRequest request = MybookDtoTestData.createMyBookUpdateServiceRequest(
-                LOGIN_ID, MYBOOK_ID);
+        MybookUpdateServiceRequest request = MybookDtoTestData.createMyBookUpdateServiceRequest(LOGIN_ID, MYBOOK_ID).build();
         MyBook myBook = MyBookFixture.COMMON_OTHER_USER_MYBOOK.getMyBook();
 
         given(myBookRepository.findById(any())).willReturn(

--- a/backend/book-service/src/test/java/kr/mybrary/bookservice/mybook/domain/MyBookReadServiceTest.java
+++ b/backend/book-service/src/test/java/kr/mybrary/bookservice/mybook/domain/MyBookReadServiceTest.java
@@ -461,7 +461,7 @@ class MyBookReadServiceTest {
                 .readStatus(ReadStatus.COMPLETED).build();
 
         given(bookReadService.findOptionalBookByISBN13(request.getIsbn13())).willReturn(Optional.of(book));
-        given(myBookRepository.findByIdWithBook(book.getId())).willReturn(Optional.of(myBook));
+        given(myBookRepository.findByUserIdAndBook(request.getLoginId(), book)).willReturn(Optional.of(myBook));
 
         // when
         MyBookReadCompletedStatusResponse response = myBookService.getMyBookReadCompletedStatus(request);
@@ -469,7 +469,7 @@ class MyBookReadServiceTest {
         // then
         assertAll(
                 () -> verify(bookReadService, times(1)).findOptionalBookByISBN13(anyString()),
-                () -> verify(myBookRepository, times(1)).findByIdWithBook(any()),
+                () -> verify(myBookRepository, times(1)).findByUserIdAndBook(any(), any()),
                 () -> assertThat(response.isCompleted()).isTrue()
         );
     }
@@ -488,7 +488,7 @@ class MyBookReadServiceTest {
         // then
         assertAll(
                 () -> verify(bookReadService, times(1)).findOptionalBookByISBN13(anyString()),
-                () -> verify(myBookRepository, never()).findByIdWithBook(any()),
+                () -> verify(myBookRepository, never()).findByUserIdAndBook(any(), any()),
                 () -> assertThat(response.isCompleted()).isFalse()
         );
     }
@@ -500,9 +500,10 @@ class MyBookReadServiceTest {
         // given
         MyBookReadCompletedStatusServiceRequest request = MybookDtoTestData.createMyBookReadCompletedStatusServiceRequest();
         Book book = BookFixture.COMMON_BOOK.getBook();
+        String userId = "LOGIN_USER_ID";
 
         given(bookReadService.findOptionalBookByISBN13(request.getIsbn13())).willReturn(Optional.of(book));
-        given(myBookRepository.findByIdWithBook(book.getId())).willReturn(Optional.empty());
+        given(myBookRepository.findByUserIdAndBook(userId, book)).willReturn(Optional.empty());
 
         // when
         MyBookReadCompletedStatusResponse response = myBookService.getMyBookReadCompletedStatus(request);
@@ -510,7 +511,7 @@ class MyBookReadServiceTest {
         // then
         assertAll(
                 () -> verify(bookReadService, times(1)).findOptionalBookByISBN13(anyString()),
-                () -> verify(myBookRepository, times(1)).findByIdWithBook(any()),
+                () -> verify(myBookRepository, times(1)).findByUserIdAndBook(any(), any()),
                 () -> assertThat(response.isCompleted()).isFalse()
         );
     }

--- a/backend/book-service/src/test/java/kr/mybrary/bookservice/mybook/persistence/MyBookRepositoryTest.java
+++ b/backend/book-service/src/test/java/kr/mybrary/bookservice/mybook/persistence/MyBookRepositoryTest.java
@@ -373,7 +373,7 @@ class MyBookRepositoryTest {
     @DisplayName("오늘 등록된 마이북의 갯수를 조회한다.")
     void getTodayBookRegistrationCount() {
 
-        // when
+        // given
         LocalDate today = LocalDate.now();
 
         Book savedBook_1 = bookRepository.save(BookFixture.COMMON_BOOK_WITHOUT_RELATION.getBookBuilder().isbn10("isbn10_1").isbn13("isbn13_1").build());
@@ -398,6 +398,33 @@ class MyBookRepositoryTest {
         assertAll(
                 () -> assertThat(todayBookRegistrationCount).isEqualTo(3L),
                 () -> assertThat(yesterdayBookRegistrationCount).isEqualTo(0L)
+        );
+    }
+
+    @DisplayName("유저 ID와 Book 엔티티를 통해 마이북을 조회한다.")
+    @Test
+    void findByUserIdAndBook() {
+
+        // given
+        Book savedBook = bookRepository.save(BookFixture.COMMON_BOOK_WITHOUT_RELATION.getBook());
+        MyBook myBook = MyBookFixture.COMMON_LOGIN_USER_MYBOOK.getMyBookWithBook(savedBook);
+        String userId = myBook.getUserId();
+
+        MyBook savedMyBook = myBookRepository.save(myBook);
+
+        entityManager.flush();
+        entityManager.clear();
+
+        // when
+        Optional<MyBook> foundMyBook = myBookRepository.findByUserIdAndBook(userId, savedBook);
+
+        // then
+        assertAll(
+                () -> {
+                    assertThat(foundMyBook.isPresent()).isTrue();
+                    assertThat(foundMyBook.get().getId()).isEqualTo(savedMyBook.getId());
+                    assertThat(foundMyBook.get().getUserId()).isEqualTo(savedMyBook.getUserId());
+                }
         );
     }
 }

--- a/backend/book-service/src/test/java/kr/mybrary/bookservice/review/domain/MyReviewWriteServiceTest.java
+++ b/backend/book-service/src/test/java/kr/mybrary/bookservice/review/domain/MyReviewWriteServiceTest.java
@@ -112,15 +112,20 @@ class MyReviewWriteServiceTest {
         );
     }
 
-    @DisplayName("마이 리뷰를 수정한다.")
+    @DisplayName("마이 리뷰를 수정한다. 수정시 기존 Book의 별점도 수정된다.")
     @Test
     void updateMyReview() {
 
         // given
         MyReview myReview = MyReviewFixture.COMMON_MY_BOOK_REVIEW.getMyBookReviewBuilder()
+                .book(MyBookFixture.COMMON_LOGIN_USER_MYBOOK.getMyBook().getBook())
                 .myBook(MyBookFixture.COMMON_LOGIN_USER_MYBOOK.getMyBook()).build();
         MyReviewUpdateServiceRequest request = MyReviewDtoTestData.createMyReviewUpdateServiceRequest(
                 myReview.getMyBook().getUserId(), myReview.getId());
+
+        Double originBookStarRating = myReview.getBook().getStarRating();
+        Double originReviewStarRating = myReview.getStarRating();
+        Double newReviewStarRating = request.getStarRating();
 
         given(myBookReviewRepository.findByIdWithMyBookUsingFetchJoin(any())).willReturn(Optional.of(myReview));
 
@@ -129,10 +134,12 @@ class MyReviewWriteServiceTest {
 
         // then
         assertAll(
-                () -> verify(myBookReviewRepository, times(1)).findByIdWithMyBookUsingFetchJoin(any()),
                 () -> assertThat(response.getId()).isEqualTo(myReview.getId()),
                 () -> assertThat(response.getContent()).isEqualTo(myReview.getContent()),
-                () -> assertThat(response.getStarRating()).isEqualTo(myReview.getStarRating())
+                () -> assertThat(response.getStarRating()).isEqualTo(myReview.getStarRating()),
+                () -> assertThat(myReview.getBook().getStarRating())
+                        .isEqualTo(originBookStarRating - originReviewStarRating + newReviewStarRating),
+                () -> verify(myBookReviewRepository, times(1)).findByIdWithMyBookUsingFetchJoin(any())
         );
     }
 

--- a/backend/book-service/src/test/java/kr/mybrary/bookservice/review/domain/MyReviewWriteServiceTest.java
+++ b/backend/book-service/src/test/java/kr/mybrary/bookservice/review/domain/MyReviewWriteServiceTest.java
@@ -44,13 +44,15 @@ class MyReviewWriteServiceTest {
     @Mock
     private MyBookService myBookService;
 
-    @DisplayName("마이북 리뷰를 등록한다.")
+    @DisplayName("마이북 리뷰를 등록한다. 리뷰 등록시 Book의 리뷰 수와 별점이 변경된다.")
     @Test
     void create() {
 
         // given
         MyReviewCreateServiceRequest request = MyReviewDtoTestData.createMyBookReviewCreateServiceRequest();
         MyBook myBook = MyBookFixture.COMMON_LOGIN_USER_MYBOOK.getMyBook();
+        Integer originReviewCount = myBook.getBook().getReviewCount();
+        Double originStarRating = myBook.getBook().getStarRating();
 
         given(myBookService.findMyBookByIdWithBook(request.getMyBookId())).willReturn(myBook);
         given(myBookReviewRepository.existsByMyBook(myBook)).willReturn(false);
@@ -61,6 +63,8 @@ class MyReviewWriteServiceTest {
 
         // then
         assertAll(
+                () -> assertThat(myBook.getBook().getReviewCount()).isEqualTo(originReviewCount + 1),
+                () -> assertThat(myBook.getBook().getStarRating()).isEqualTo(originStarRating + request.getStarRating()),
                 () -> verify(myBookService, times(1)).findMyBookByIdWithBook(request.getMyBookId()),
                 () -> verify(myBookReviewRepository, times(1)).existsByMyBook(myBook),
                 () -> verify(myBookReviewRepository, times(1)).save(any())

--- a/backend/book-service/src/test/java/kr/mybrary/bookservice/review/domain/MyReviewWriteServiceTest.java
+++ b/backend/book-service/src/test/java/kr/mybrary/bookservice/review/domain/MyReviewWriteServiceTest.java
@@ -164,16 +164,21 @@ class MyReviewWriteServiceTest {
         );
     }
 
-    @DisplayName("마이 리뷰를 삭제한다.")
+    @DisplayName("마이 리뷰를 삭제한다. 삭제시 Book의 별점과 리뷰 수가 감소한다.")
     @Test
     void deleteMyReview() {
 
         // given
         MyReview myReview = MyReviewFixture.COMMON_MY_BOOK_REVIEW.getMyBookReviewBuilder()
+                .book(MyBookFixture.COMMON_LOGIN_USER_MYBOOK.getMyBook().getBook())
                 .myBook(MyBookFixture.COMMON_LOGIN_USER_MYBOOK.getMyBook()).build();
 
         MyReviewDeleteServiceRequest request = MyReviewDtoTestData.createMyReviewDeleteServiceRequest(
                 myReview.getMyBook().getUserId(), myReview.getId());
+
+        Double originBookStarRating = myReview.getBook().getStarRating();
+        Double originReviewStarRating = myReview.getStarRating();
+        Integer originReviewCount = myReview.getBook().getReviewCount();
 
         given(myBookReviewRepository.findByIdWithMyBookUsingFetchJoin(any())).willReturn(Optional.of(myReview));
 
@@ -183,6 +188,8 @@ class MyReviewWriteServiceTest {
         // then
         assertAll(
                 () -> assertThat(myReview.isDeleted()).isTrue(),
+                () -> assertThat(myReview.getBook().getStarRating()).isEqualTo(originBookStarRating - originReviewStarRating),
+                () -> assertThat(myReview.getBook().getReviewCount()).isEqualTo(originReviewCount - 1),
                 () -> verify(myBookReviewRepository, times(1)).findByIdWithMyBookUsingFetchJoin(any())
         );
     }


### PR DESCRIPTION
## 🧑‍💻 작업 사항
요구 사항을 제대로 반영하지 못해서 죄송합니다ㅠ 앞으로 기능 개발시, 요구 사항을 명확하게 정리해서 개발해보도록 하겠습니다!

### 마이북 완독 여부 조회 로직 수정
- 도서 상세 조회시, 사용자가 해당 도서를 완독하였다면, true를 반환하도록 로직 수정

### 도서 읽기 상태 변경시, 도서 엔티티에 변경사항 반영
- 읽기전/읽는중 -> 완독 : 도서 엔티티의 완독수 + 1
- 완독 -> 읽기전.읽는중 : 도서 엔티티의 완독수 - 1

### 리뷰 작성/수정/삭제시, 도서 엔티티의 리뷰 갯수와 리뷰 별점
- 리뷰 작성 : 도서 엔티티의 리뷰 갯수 + 1 and 리뷰 별점 + 사용자가 입력한 리뷰 별점
- 리뷰 수정 : 도서 엔티티의 리뷰 별점 = 도서 엔티티의 리뷰 별점 - 기존 사용자의 리뷰 별점 + 변경한 사용자의 리뷰 별점
- 리뷰 삭제 : 도서 엔티티의 리뷰 갯수 - 1 and 리뷰 별점 - 기존 사용자의 리뷰 별점

### 도서 상세 보기 조회시, 도서 리뷰 별점의 평균을 반환하도록 수정
- 도서 엔티티의 리뷰 별점은 총 사용자의 별점의 합으로 저장
- 따라서 도서 상세 보기 조회시, starRating을 별점 총합 / 리뷰 갯수로 별점의 평균을 반환한다. (소수점 첫째자리까지)

### 도서 키워드 검색시, 결과가 없으면 예외가 아닌 빈 리스트를 반환하도록 수정
- 기존에는 키워드로 도서 검색시, 도서 결과가 없으면 예외를 던졌지만,
- 결과가 없을 시, 빈 리스트를 반환하도록 수정
- isbn13으로 도서 상세 조회시 결과가 없는 경우는 그전과 동일하게 예외를 던진다.

<br><br>

## 🔗 링크

<!-- 관련된 대화가 이루어진 슬랙 링크 혹은 피그마 링크를 첨부. -->
<!-- - [프레이머](https://framer.com/projects/2--gSDcZoNKqU6dqCUQUYQe-53rEr?node=tQMWSSKqy)  -->

<br><br>

## 🐰 시급한 정도

🚨 긴급 : 선 어프루브 후 리뷰를 부탁드립니다. (리뷰는 추후 반영) 

<br><br>

## 📖 참고 사항

<!-- 공유할 내용, 레퍼런스, 추가로 발생할 것으로 예상되는 이슈, 스크린샷 등을 넣어 주세요.  -->
<!-- 변경사항이 큰 경우 집중해야 할 부분, 또는 불안해서 봐주었으면 하는 부분 등 -->
