### PR TITLE
[IDLE-209] feat: 사용자 검색 UI 구현 및 API 연동

### DIFF
--- a/frontend/lib/data/datasource/search/search_datasource.dart
+++ b/frontend/lib/data/datasource/search/search_datasource.dart
@@ -7,6 +7,7 @@ import 'package:mybrary/data/model/search/book_interest_status_response.dart';
 import 'package:mybrary/data/model/search/book_registered_status_response.dart';
 import 'package:mybrary/data/model/search/book_search_detail_response.dart';
 import 'package:mybrary/data/model/search/book_search_response.dart';
+import 'package:mybrary/data/model/search/user_search_response.dart';
 import 'package:mybrary/data/network/api.dart';
 import 'package:mybrary/utils/dios/auth_dio.dart';
 
@@ -145,6 +146,29 @@ class SearchDataSource {
         message: bookCompletedStatusResponse.data['message'],
         data: BookCompletedStatusResponseData.fromJson(
           bookCompletedStatusResponse.data['data'],
+        ),
+      ),
+    );
+
+    return result.data!;
+  }
+
+  Future<UserSearchResponseData> getUserSearchResponse(
+    BuildContext context,
+    String nickname,
+  ) async {
+    final dio = await authDio(context);
+    final userSearchResponse =
+        await dio.get('${getApi(API.getUserSearch)}?nickname=$nickname');
+
+    log('사용자 검색 응답값: $userSearchResponse');
+    final UserSearchResponse result = commonResponseResult(
+      userSearchResponse,
+      () => UserSearchResponse(
+        status: userSearchResponse.data['status'],
+        message: userSearchResponse.data['message'],
+        data: UserSearchResponseData.fromJson(
+          userSearchResponse.data['data'],
         ),
       ),
     );

--- a/frontend/lib/data/model/search/search_common_data.dart
+++ b/frontend/lib/data/model/search/search_common_data.dart
@@ -1,0 +1,12 @@
+import 'package:mybrary/data/model/search/book_search_response.dart';
+import 'package:mybrary/data/model/search/user_search_response.dart';
+
+class SearchCommonData {
+  BookSearchResponseData bookSearchResponseData;
+  UserSearchResponseData userSearchResponseData;
+
+  SearchCommonData({
+    required this.bookSearchResponseData,
+    required this.userSearchResponseData,
+  });
+}

--- a/frontend/lib/data/model/search/user_search_response.dart
+++ b/frontend/lib/data/model/search/user_search_response.dart
@@ -1,0 +1,79 @@
+class UserSearchResponse {
+  String status;
+  String message;
+  UserSearchResponseData? data;
+
+  UserSearchResponse({
+    required this.status,
+    required this.message,
+    required this.data,
+  });
+
+  factory UserSearchResponse.fromJson(Map<String, dynamic> json) {
+    return UserSearchResponse(
+      status: json['status'],
+      message: json['message'],
+      data: json['data'] != null
+          ? UserSearchResponseData.fromJson(json['data'])
+          : null,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    final Map<String, dynamic> data = <String, dynamic>{};
+    data['status'] = status;
+    data['message'] = message;
+    if (this.data != null) {
+      data['data'] = this.data!.toJson();
+    }
+    return data;
+  }
+}
+
+class UserSearchResponseData {
+  List<SearchedUsers>? searchedUsers;
+
+  UserSearchResponseData({this.searchedUsers});
+
+  factory UserSearchResponseData.fromJson(Map<String, dynamic> json) {
+    return UserSearchResponseData(
+      searchedUsers: json['searchedUsers'] != null
+          ? (json['searchedUsers'] as List)
+              .map((i) => SearchedUsers.fromJson(i))
+              .toList()
+          : null,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    final Map<String, dynamic> data = <String, dynamic>{};
+    if (searchedUsers != null) {
+      data['searchedUsers'] = searchedUsers!.map((v) => v.toJson()).toList();
+    }
+    return data;
+  }
+}
+
+class SearchedUsers {
+  String? userId;
+  String? nickname;
+  String? profileImageUrl;
+
+  SearchedUsers({this.userId, this.nickname, this.profileImageUrl});
+
+  factory SearchedUsers.fromJson(Map<String, dynamic> json) {
+    return SearchedUsers(
+      userId: json['userId'],
+      nickname: json['nickname'],
+      profileImageUrl: json['profileImageUrl'],
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    final Map<String, dynamic> data = <String, dynamic>{};
+    data['userId'] = userId;
+    data['nickname'] = nickname;
+    data['profileImageUrl'] = profileImageUrl;
+    return data;
+  }
+}

--- a/frontend/lib/data/network/api.dart
+++ b/frontend/lib/data/network/api.dart
@@ -20,6 +20,7 @@ enum API {
   getUserFollowings,
   getUserInterests,
   getInterestCategories,
+  getUserSearch,
   updateUserProfile,
   updateUserProfileImage,
   updateUserFollowing,
@@ -64,6 +65,8 @@ Map<API, String> apiMap = {
   API.getUserFollowings: "/user-service/api/v1/users", // /{userId}/followings",
   API.getUserInterests: "/user-service/api/v1/users", // '/{userId}/interests'
   API.getInterestCategories: "/user-service/api/v1/interest-categories",
+  API.getUserSearch:
+      "/user-service/api/v1/users/search", // ?nickname={nickname}
   API.updateUserProfile: "/user-service/api/v1/users", // /{userId}/profile",
   API.updateUserProfileImage:
       "/user-service/api/v1/users", // /{userId}/profile/image",

--- a/frontend/lib/data/repository/search_repository.dart
+++ b/frontend/lib/data/repository/search_repository.dart
@@ -5,6 +5,7 @@ import 'package:mybrary/data/model/search/book_interest_status_response.dart';
 import 'package:mybrary/data/model/search/book_registered_status_response.dart';
 import 'package:mybrary/data/model/search/book_search_detail_response.dart';
 import 'package:mybrary/data/model/search/book_search_response.dart';
+import 'package:mybrary/data/model/search/user_search_response.dart';
 
 class SearchRepository {
   final SearchDataSource _searchDataSource = SearchDataSource();
@@ -56,5 +57,12 @@ class SearchRepository {
     required String isbn13,
   }) {
     return _searchDataSource.getBookCompletedStatusResponse(context, isbn13);
+  }
+
+  Future<UserSearchResponseData> getUserSearchResponse({
+    required BuildContext context,
+    required String nickname,
+  }) {
+    return _searchDataSource.getUserSearchResponse(context, nickname);
   }
 }

--- a/frontend/lib/res/constants/style.dart
+++ b/frontend/lib/res/constants/style.dart
@@ -351,4 +351,4 @@ const settingInfoStyle = TextStyle(
 
 // padding
 final double paddingTopHeight =
-    Size.fromHeight(const SliverAppBar().toolbarHeight).height * 1.9;
+    Size.fromHeight(const SliverAppBar().toolbarHeight).height * 2;

--- a/frontend/lib/res/constants/style.dart
+++ b/frontend/lib/res/constants/style.dart
@@ -348,3 +348,7 @@ const settingInfoStyle = TextStyle(
   fontSize: 14.0,
   fontWeight: FontWeight.w400,
 );
+
+// padding
+final double paddingTopHeight =
+    Size.fromHeight(const SliverAppBar().toolbarHeight).height * 1.9;

--- a/frontend/lib/ui/search/components/search_popular_keyword.dart
+++ b/frontend/lib/ui/search/components/search_popular_keyword.dart
@@ -48,7 +48,7 @@ class SearchPopularKeyword extends StatelessWidget {
                     context,
                     MaterialPageRoute(
                       builder: (_) => SearchBookList(
-                        bookSearchKeyword: popularSearchKeyword[index],
+                        searchKeyword: popularSearchKeyword[index],
                       ),
                     ),
                   ).then(

--- a/frontend/lib/ui/search/search_book_list/components/search_book_list_info.dart
+++ b/frontend/lib/ui/search/search_book_list/components/search_book_list_info.dart
@@ -9,133 +9,144 @@ import 'package:mybrary/utils/logics/book_utils.dart';
 class SearchBookListInfo extends StatelessWidget {
   final List<BookSearchResult> bookSearchDataList;
   final ScrollController scrollController;
+  final double paddingTopHeight;
 
   const SearchBookListInfo({
     required this.bookSearchDataList,
     required this.scrollController,
+    required this.paddingTopHeight,
     super.key,
   });
 
   @override
   Widget build(BuildContext context) {
     return Expanded(
-      child: Scrollbar(
-        controller: scrollController,
-        child: ListView.separated(
-          physics: const BouncingScrollPhysics(),
-          keyboardDismissBehavior: ScrollViewKeyboardDismissBehavior.onDrag,
+      child: Padding(
+        padding: EdgeInsets.only(top: paddingTopHeight),
+        child: Scrollbar(
           controller: scrollController,
-          itemCount: bookSearchDataList.length,
-          itemBuilder: (context, index) {
-            final searchBookData = bookSearchDataList[index];
-            final DateTime publishDate =
-                getPublishDate(searchBookData.publicationDate!);
+          child: ListView.separated(
+            physics: const BouncingScrollPhysics(
+              parent: AlwaysScrollableScrollPhysics(),
+            ),
+            keyboardDismissBehavior: ScrollViewKeyboardDismissBehavior.onDrag,
+            controller: scrollController,
+            itemCount: bookSearchDataList.length,
+            itemBuilder: (context, index) {
+              final searchBookData = bookSearchDataList[index];
+              final DateTime publishDate =
+                  getPublishDate(searchBookData.publicationDate!);
 
-            return GestureDetector(
-              onTap: () {
-                Navigator.push(
-                  context,
-                  MaterialPageRoute(
-                    builder: (_) => SearchDetailScreen(
-                      isbn13: searchBookData.isbn13!,
-                    ),
-                  ),
-                );
-              },
-              behavior: HitTestBehavior.opaque,
-              child: Column(
-                children: [
-                  Padding(
-                    padding: const EdgeInsets.all(16.0),
-                    child: SizedBox(
-                      height: 126,
-                      child: Row(
-                        children: [
-                          Container(
-                            width: 86,
-                            height: 126,
-                            decoration: BoxDecoration(
-                              border: Border.all(
-                                color: greyF1F2F5,
-                                width: 1,
-                              ),
-                              borderRadius: BorderRadius.circular(8.0),
-                              image: DecorationImage(
-                                image: NetworkImage(
-                                  searchBookData.thumbnailUrl!,
-                                ),
-                                onError: (exception, stackTrace) => Image.asset(
-                                  'assets/img/logo/mybrary.png',
-                                  fit: BoxFit.fill,
-                                ),
-                                fit: BoxFit.fill,
-                              ),
-                            ),
-                          ),
-                          const SizedBox(width: 12.0),
-                          Expanded(
-                            child: Column(
-                              mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                              crossAxisAlignment: CrossAxisAlignment.start,
-                              children: [
-                                Column(
-                                  crossAxisAlignment: CrossAxisAlignment.start,
-                                  children: [
-                                    Text(
-                                      parse(searchBookData.title!)
-                                          .documentElement!
-                                          .text,
-                                      maxLines: 2,
-                                      overflow: TextOverflow.ellipsis,
-                                      textWidthBasis: TextWidthBasis.parent,
-                                      style: searchBookTitleStyle,
-                                    ),
-                                    const SizedBox(height: 4.0),
-                                    bookInfo(
-                                      infoText:
-                                          parse(searchBookData.description!)
-                                              .documentElement!
-                                              .text,
-                                      fontSize: 13.0,
-                                      fontColor: bookDescriptionColor,
-                                    ),
-                                  ],
-                                ),
-                                Column(
-                                  crossAxisAlignment: CrossAxisAlignment.start,
-                                  children: [
-                                    bookInfo(
-                                      infoText: searchBookData.author!,
-                                      fontSize: 13.0,
-                                      fontColor: bookDescriptionColor,
-                                    ),
-                                    const SizedBox(height: 1.0),
-                                    bookInfo(
-                                      infoText:
-                                          '${publishDate.year}.${publishDate.month}',
-                                      fontSize: 13.0,
-                                      fontColor: bookDescriptionColor,
-                                    ),
-                                  ],
-                                ),
-                              ],
-                            ),
-                          ),
-                        ],
+              return GestureDetector(
+                onTap: () {
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                      builder: (_) => SearchDetailScreen(
+                        isbn13: searchBookData.isbn13!,
                       ),
                     ),
-                  ),
-                ],
-              ),
-            );
-          },
-          separatorBuilder: (BuildContext context, int index) {
-            return const Divider(
-              thickness: 1,
-              height: 1,
-              color: greyF1F2F5,
-            );
-          },
+                  );
+                },
+                behavior: HitTestBehavior.opaque,
+                child: Column(
+                  children: [
+                    Padding(
+                      padding: const EdgeInsets.all(16.0),
+                      child: SizedBox(
+                        height: 126,
+                        child: Row(
+                          children: [
+                            Container(
+                              width: 86,
+                              height: 126,
+                              decoration: BoxDecoration(
+                                border: Border.all(
+                                  color: greyF1F2F5,
+                                  width: 1,
+                                ),
+                                borderRadius: BorderRadius.circular(8.0),
+                                image: DecorationImage(
+                                  image: NetworkImage(
+                                    searchBookData.thumbnailUrl!,
+                                  ),
+                                  onError: (exception, stackTrace) =>
+                                      Image.asset(
+                                    'assets/img/logo/mybrary.png',
+                                    fit: BoxFit.fill,
+                                  ),
+                                  fit: BoxFit.fill,
+                                ),
+                              ),
+                            ),
+                            const SizedBox(width: 12.0),
+                            Expanded(
+                              child: Column(
+                                mainAxisAlignment:
+                                    MainAxisAlignment.spaceBetween,
+                                crossAxisAlignment: CrossAxisAlignment.start,
+                                children: [
+                                  Column(
+                                    crossAxisAlignment:
+                                        CrossAxisAlignment.start,
+                                    children: [
+                                      Text(
+                                        parse(searchBookData.title!)
+                                            .documentElement!
+                                            .text,
+                                        maxLines: 2,
+                                        overflow: TextOverflow.ellipsis,
+                                        textWidthBasis: TextWidthBasis.parent,
+                                        style: searchBookTitleStyle,
+                                      ),
+                                      const SizedBox(height: 4.0),
+                                      bookInfo(
+                                        infoText:
+                                            parse(searchBookData.description!)
+                                                .documentElement!
+                                                .text,
+                                        fontSize: 13.0,
+                                        fontColor: bookDescriptionColor,
+                                      ),
+                                    ],
+                                  ),
+                                  Column(
+                                    crossAxisAlignment:
+                                        CrossAxisAlignment.start,
+                                    children: [
+                                      bookInfo(
+                                        infoText: searchBookData.author!,
+                                        fontSize: 13.0,
+                                        fontColor: bookDescriptionColor,
+                                      ),
+                                      const SizedBox(height: 1.0),
+                                      bookInfo(
+                                        infoText:
+                                            '${publishDate.year}.${publishDate.month}',
+                                        fontSize: 13.0,
+                                        fontColor: bookDescriptionColor,
+                                      ),
+                                    ],
+                                  ),
+                                ],
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+              );
+            },
+            separatorBuilder: (BuildContext context, int index) {
+              return const Divider(
+                thickness: 1,
+                height: 1,
+                color: greyF1F2F5,
+              );
+            },
+          ),
         ),
       ),
     );

--- a/frontend/lib/ui/search/search_book_list/components/search_user_info.dart
+++ b/frontend/lib/ui/search/search_book_list/components/search_user_info.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/material.dart';
+import 'package:mybrary/res/constants/color.dart';
+import 'package:mybrary/res/constants/style.dart';
+
+class SearchUserInfo extends StatelessWidget {
+  final String nickname;
+  final String profileImageUrl;
+
+  const SearchUserInfo({
+    required this.nickname,
+    required this.profileImageUrl,
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        CircleAvatar(
+          radius: 20.0,
+          backgroundColor: greyACACAC,
+          backgroundImage: NetworkImage(
+            profileImageUrl,
+          ),
+        ),
+        const SizedBox(
+          width: 16.0,
+        ),
+        Text(
+          nickname,
+          style: followNicknameStyle,
+        ),
+      ],
+    );
+  }
+}

--- a/frontend/lib/ui/search/search_book_list/components/search_user_layout.dart
+++ b/frontend/lib/ui/search/search_book_list/components/search_user_layout.dart
@@ -1,0 +1,25 @@
+import 'package:flutter/material.dart';
+
+class SearchUserLayout extends StatelessWidget {
+  final List<Widget> children;
+
+  const SearchUserLayout({
+    required this.children,
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(
+        horizontal: 16.0,
+        vertical: 8.0,
+      ),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        crossAxisAlignment: CrossAxisAlignment.center,
+        children: children,
+      ),
+    );
+  }
+}

--- a/frontend/lib/ui/search/search_book_list/search_book_list.dart
+++ b/frontend/lib/ui/search/search_book_list/search_book_list.dart
@@ -359,6 +359,7 @@ class _SearchBookListState extends State<SearchBookList>
       return Padding(
         padding: EdgeInsets.only(top: paddingTopHeight),
         child: ListView.builder(
+          physics: const BouncingScrollPhysics(),
           itemCount: searchedUsers.length,
           itemBuilder: (context, index) {
             SearchedUsers searchedUser = searchedUsers[index];

--- a/frontend/lib/ui/search/search_book_list/search_book_list.dart
+++ b/frontend/lib/ui/search/search_book_list/search_book_list.dart
@@ -35,20 +35,20 @@ class _SearchBookListState extends State<SearchBookList>
     vsync: this,
   );
 
-  final TextEditingController _bookSearchKeywordController =
-      TextEditingController();
   final ScrollController _searchScrollController = ScrollController();
   final ScrollController _tabScrollController = ScrollController();
+  final TextEditingController _bookSearchKeywordController =
+      TextEditingController();
 
   final _searchRepository = SearchRepository();
   late Future<BookSearchResponseData> _bookSearchResponse;
   late Future<UserSearchResponseData> _userSearchResponse;
 
   late String _bookSearchNextUrl;
+  late List<BookSearchResult> _bookSearchResultData = [];
   final String _bookSearchKeywordRequestUrl =
       getBookServiceApi(API.getBookSearchKeyword);
 
-  late List<BookSearchResult> _bookSearchResultData = [];
   late bool _isError = false;
   late bool _isScrollLoading = false;
   late bool _isClearButtonVisible = false;
@@ -155,14 +155,20 @@ class _SearchBookListState extends State<SearchBookList>
                   return Column(
                     children: [
                       searchInputBox(),
-                      SearchBookListHeader(
-                        keyword: _bookSearchKeywordController.text,
-                        bookSearchDataList: _bookSearchResultData,
-                      ),
-                      SearchBookListInfo(
-                        bookSearchDataList: _bookSearchResultData,
-                        scrollController: _searchScrollController,
-                      ),
+                      if (_bookSearchResultData.isEmpty) ...[
+                        const SingleDataError(
+                          errorMessage: '검색된 책이 없습니다.',
+                        ),
+                      ] else ...[
+                        SearchBookListHeader(
+                          keyword: _bookSearchKeywordController.text,
+                          bookSearchDataList: _bookSearchResultData,
+                        ),
+                        SearchBookListInfo(
+                          bookSearchDataList: _bookSearchResultData,
+                          scrollController: _searchScrollController,
+                        ),
+                      ],
                     ],
                   );
                 }
@@ -344,11 +350,7 @@ class _SearchBookListState extends State<SearchBookList>
       unselectedLabelStyle: commonButtonTextStyle.copyWith(
         fontWeight: FontWeight.w400,
       ),
-      tabs: searchTabs
-          .map(
-            (String name) => Tab(text: name),
-          )
-          .toList(),
+      tabs: searchTabs.map((String name) => Tab(text: name)).toList(),
     );
   }
 
@@ -360,7 +362,6 @@ class _SearchBookListState extends State<SearchBookList>
           itemCount: searchedUsers.length,
           itemBuilder: (context, index) {
             SearchedUsers searchedUser = searchedUsers[index];
-            String searchedUserId = searchedUser.userId!;
 
             return SearchUserLayout(
               children: [

--- a/frontend/lib/ui/search/search_book_list/search_book_list.dart
+++ b/frontend/lib/ui/search/search_book_list/search_book_list.dart
@@ -1,21 +1,25 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:mybrary/data/model/search/book_search_response.dart';
+import 'package:mybrary/data/model/search/user_search_response.dart';
 import 'package:mybrary/data/network/api.dart';
 import 'package:mybrary/data/repository/search_repository.dart';
 import 'package:mybrary/res/constants/color.dart';
 import 'package:mybrary/res/constants/style.dart';
 import 'package:mybrary/ui/common/components/error_page.dart';
+import 'package:mybrary/ui/common/components/single_data_error.dart';
 import 'package:mybrary/ui/common/layout/subpage_layout.dart';
 import 'package:mybrary/ui/search/components/search_loading.dart';
 import 'package:mybrary/ui/search/search_book_list/components/search_book_list_header.dart';
 import 'package:mybrary/ui/search/search_book_list/components/search_book_list_info.dart';
+import 'package:mybrary/ui/search/search_book_list/components/search_user_info.dart';
+import 'package:mybrary/ui/search/search_book_list/components/search_user_layout.dart';
 
 class SearchBookList extends StatefulWidget {
-  final String bookSearchKeyword;
+  final String searchKeyword;
 
   const SearchBookList({
-    required this.bookSearchKeyword,
+    required this.searchKeyword,
     super.key,
   });
 
@@ -23,121 +27,183 @@ class SearchBookList extends StatefulWidget {
   State<SearchBookList> createState() => _SearchBookListState();
 }
 
-class _SearchBookListState extends State<SearchBookList> {
-  final _searchRepository = SearchRepository();
-
-  late bool _isClearButtonVisible = false;
-  late String _bookSearchNextUrl;
-  final String _bookSearchKeywordRequestUrl =
-      getBookServiceApi(API.getBookSearchKeyword);
-  late Future<BookSearchResponseData> _bookSearchResponse;
-  late List<BookSearchResult> _bookSearchResultData = [];
-  late bool _isScrollLoading = false;
-  late bool _isError = false;
+class _SearchBookListState extends State<SearchBookList>
+    with TickerProviderStateMixin {
+  late final List<String> _searchTabs = ['도서 전체', '사용자'];
+  late final TabController _tabController = TabController(
+    length: _searchTabs.length,
+    vsync: this,
+  );
 
   final TextEditingController _bookSearchKeywordController =
       TextEditingController();
   final ScrollController _searchScrollController = ScrollController();
+  final ScrollController _tabScrollController = ScrollController();
+
+  final _searchRepository = SearchRepository();
+  late Future<BookSearchResponseData> _bookSearchResponse;
+  late Future<UserSearchResponseData> _userSearchResponse;
+
+  late String _bookSearchNextUrl;
+  final String _bookSearchKeywordRequestUrl =
+      getBookServiceApi(API.getBookSearchKeyword);
+
+  late List<BookSearchResult> _bookSearchResultData = [];
+  late bool _isError = false;
+  late bool _isScrollLoading = false;
+  late bool _isClearButtonVisible = false;
 
   @override
   void initState() {
     super.initState();
 
-    _bookSearchKeywordController.text = widget.bookSearchKeyword;
+    _bookSearchKeywordController.text = widget.searchKeyword;
     _isClearButtonVisible = true;
     _bookSearchResponse = _searchRepository.getBookSearchResponse(
       context: context,
       requestUrl:
-          '$_bookSearchKeywordRequestUrl?keyword=${widget.bookSearchKeyword}',
+          '$_bookSearchKeywordRequestUrl?keyword=${widget.searchKeyword}',
     );
+    _userSearchResponse = _searchRepository.getUserSearchResponse(
+      context: context,
+      nickname: widget.searchKeyword,
+    );
+    _searchScrollController.addListener(_infiniteScrollUpdateBookList);
+  }
+
+  void _infiniteScrollUpdateBookList() {
+    setState(() {
+      if (_searchScrollController.position.pixels >
+          _searchScrollController.position.maxScrollExtent * 0.85) {
+        _isScrollLoading = true;
+      } else {
+        _isScrollLoading = false;
+      }
+    });
   }
 
   @override
   void dispose() {
     _bookSearchKeywordController.dispose();
+    _searchScrollController.dispose();
+    _tabScrollController.dispose();
     super.dispose();
   }
 
   @override
   Widget build(BuildContext context) {
     return SubPageLayout(
-      appBarTitle: '검색',
-      child: NotificationListener<ScrollUpdateNotification>(
-        onNotification: (ScrollUpdateNotification notification) {
-          if (notification.metrics.maxScrollExtent * 0.85 <
-              notification.metrics.pixels) {
-            setState(() {
-              _isScrollLoading = true;
-            });
-          } else {
-            setState(() {
-              _isScrollLoading = false;
-            });
-          }
-          return false;
+      child: NestedScrollView(
+        controller: _tabScrollController,
+        headerSliverBuilder: (BuildContext context, bool innerBoxIsScrolled) {
+          return searchPageSliverBuilder(
+            context,
+            innerBoxIsScrolled,
+            _searchTabs,
+            _tabController,
+          );
         },
-        child: FutureBuilder<BookSearchResponseData>(
-          future: _bookSearchResponse,
-          builder: (context, snapshot) {
-            if (_isError || snapshot.hasError) {
-              return Column(
-                children: [
-                  searchInputBox(),
-                  const ErrorPage(
-                    errorMessage: '검색 결과를 불러오는데 실패했습니다.',
-                  ),
-                ],
-              );
-            }
+        body: TabBarView(
+          controller: _tabController,
+          children: [
+            FutureBuilder<BookSearchResponseData>(
+              future: _bookSearchResponse,
+              builder: (context, snapshot) {
+                if (_isError || snapshot.hasError) {
+                  return SubPageLayout(
+                    appBarTitle: '검색',
+                    child: Column(
+                      children: [
+                        searchInputBox(),
+                        const ErrorPage(
+                          errorMessage: '검색 결과를 불러오는데 실패했습니다.',
+                        ),
+                      ],
+                    ),
+                  );
+                }
 
-            if (!snapshot.hasData) {
-              return const SearchLoading();
-            }
+                if (!snapshot.hasData) {
+                  return const SearchLoading();
+                }
 
-            if (snapshot.hasData) {
-              BookSearchResponseData bookSearchResponse = snapshot.data!;
+                if (snapshot.hasData) {
+                  BookSearchResponseData bookSearchResponse = snapshot.data!;
 
-              if (_bookSearchResultData.isEmpty) {
-                _bookSearchResultData
-                    .addAll(bookSearchResponse.bookSearchResult!);
-                _bookSearchNextUrl = bookSearchResponse.nextRequestUrl!;
-              }
+                  if (_bookSearchResultData.isEmpty) {
+                    _bookSearchResultData
+                        .addAll(bookSearchResponse.bookSearchResult!);
+                    _bookSearchNextUrl = bookSearchResponse.nextRequestUrl!;
+                  }
 
-              if (_bookSearchNextUrl != "" && _isScrollLoading) {
-                _searchRepository
-                    .getBookSearchResponse(
-                      context: context,
-                      requestUrl:
-                          '${getBookServiceApi(API.getBookService)}$_bookSearchNextUrl',
-                    )
-                    .then((value) => setState(() {
-                          _bookSearchResultData.addAll(value.bookSearchResult!);
-                          _bookSearchNextUrl = value.nextRequestUrl!;
-                        }));
+                  if (_bookSearchNextUrl != "" && _isScrollLoading) {
+                    _searchRepository
+                        .getBookSearchResponse(
+                          context: context,
+                          requestUrl:
+                              '${getBookServiceApi(API.getBookService)}$_bookSearchNextUrl',
+                        )
+                        .then((value) => setState(() {
+                              _bookSearchResultData
+                                  .addAll(value.bookSearchResult!);
+                              _bookSearchNextUrl = value.nextRequestUrl!;
+                            }));
 
-                _bookSearchNextUrl = "";
-                _isScrollLoading = false;
-              }
+                    _bookSearchNextUrl = "";
+                    _isScrollLoading = false;
+                  }
+                  return Column(
+                    children: [
+                      searchInputBox(),
+                      SearchBookListHeader(
+                        keyword: _bookSearchKeywordController.text,
+                        bookSearchDataList: _bookSearchResultData,
+                      ),
+                      SearchBookListInfo(
+                        bookSearchDataList: _bookSearchResultData,
+                        scrollController: _searchScrollController,
+                      ),
+                    ],
+                  );
+                }
+                return const SingleDataError(
+                  errorMessage: '검색 결과를 불러오는데 실패했습니다.',
+                );
+              },
+            ),
+            FutureBuilder<UserSearchResponseData>(
+              future: _userSearchResponse,
+              builder: (context, snapshot) {
+                if (snapshot.hasError) {
+                  return SubPageLayout(
+                    appBarTitle: '검색',
+                    child: Column(
+                      children: [
+                        searchInputBox(),
+                        const ErrorPage(
+                          errorMessage: '검색 결과를 불러오는데 실패했습니다.',
+                        ),
+                      ],
+                    ),
+                  );
+                }
 
-              return Column(
-                children: [
-                  searchInputBox(),
-                  SearchBookListHeader(
-                    keyword: _bookSearchKeywordController.text,
-                    bookSearchDataList: _bookSearchResultData,
-                  ),
-                  SearchBookListInfo(
-                    bookSearchDataList: _bookSearchResultData,
-                    scrollController: _searchScrollController,
-                  ),
-                ],
-              );
-            }
+                if (!snapshot.hasData) {
+                  return const SearchLoading();
+                }
 
-            return const ErrorPage(
-              errorMessage: '검색 결과를 불러오는데 실패했습니다.',
-            );
-          },
+                if (snapshot.hasData) {
+                  UserSearchResponseData userSearchResponse = snapshot.data!;
+                  return searchedUsersScreen(
+                    userSearchResponse.searchedUsers!,
+                  );
+                }
+                return const SingleDataError(
+                  errorMessage: '검색 결과를 불러오는데 실패했습니다.',
+                );
+              },
+            ),
+          ],
         ),
       ),
     );
@@ -227,5 +293,90 @@ class _SearchBookListState extends State<SearchBookList> {
         ),
       ),
     );
+  }
+
+  List<Widget> searchPageSliverBuilder(
+    BuildContext context,
+    bool innerBoxIsScrolled,
+    List<String> followerTabs,
+    TabController tabController,
+  ) {
+    return <Widget>[
+      SliverOverlapAbsorber(
+        handle: NestedScrollView.sliverOverlapAbsorberHandleFor(context),
+        sliver: SliverAppBar(
+          elevation: 0,
+          foregroundColor: commonBlackColor,
+          backgroundColor: commonWhiteColor,
+          // expandedHeight: 120,
+          flexibleSpace: FlexibleSpaceBar(
+            background: Container(
+              color: commonWhiteColor,
+            ),
+          ),
+          title: const Text('검색'),
+          titleTextStyle: appBarTitleStyle.copyWith(
+            fontSize: 16.0,
+          ),
+          centerTitle: true,
+          pinned: true,
+          expandedHeight: 104.01,
+          forceElevated: innerBoxIsScrolled,
+          bottom: searchTabBar(
+            tabController,
+            followerTabs,
+          ),
+        ),
+      ),
+    ];
+  }
+
+  TabBar searchTabBar(
+    TabController tabController,
+    List<String> searchTabs,
+  ) {
+    return TabBar(
+      controller: tabController,
+      indicatorColor: grey262626,
+      labelColor: grey262626,
+      labelStyle: commonButtonTextStyle,
+      unselectedLabelColor: greyACACAC,
+      unselectedLabelStyle: commonButtonTextStyle.copyWith(
+        fontWeight: FontWeight.w400,
+      ),
+      tabs: searchTabs
+          .map(
+            (String name) => Tab(text: name),
+          )
+          .toList(),
+    );
+  }
+
+  Widget searchedUsersScreen(List<SearchedUsers> searchedUsers) {
+    if (searchedUsers.isNotEmpty) {
+      return Padding(
+        padding: EdgeInsets.only(top: paddingTopHeight),
+        child: ListView.builder(
+          itemCount: searchedUsers.length,
+          itemBuilder: (context, index) {
+            SearchedUsers searchedUser = searchedUsers[index];
+            String searchedUserId = searchedUser.userId!;
+
+            return SearchUserLayout(
+              children: [
+                SearchUserInfo(
+                  nickname: searchedUser.nickname!,
+                  profileImageUrl: searchedUser.profileImageUrl!,
+                ),
+              ],
+            );
+          },
+        ),
+      );
+    } else {
+      return const SingleDataError(
+        errorMessage: '검색된 사용자가 없습니다.',
+      );
+    }
   }
 }

--- a/frontend/lib/ui/search/search_detail/components/book_detail_header.dart
+++ b/frontend/lib/ui/search/search_detail/components/book_detail_header.dart
@@ -161,7 +161,7 @@ class _BookDetailHeaderState extends State<BookDetailHeader> {
                   child: Column(
                     children: [
                       SvgPicture.asset(
-                        'assets/svg/icon/small/${widget.completed ? 'heart_green.svg' : 'heart.svg'}',
+                        'assets/svg/icon/small/${widget.completed ? 'read_green.svg' : 'read.svg'}',
                       ),
                       const SizedBox(height: 4.0),
                       const Text('완독했어요', style: bookStatusStyle),

--- a/frontend/lib/ui/search/search_detail/components/book_detail_info.dart
+++ b/frontend/lib/ui/search/search_detail/components/book_detail_info.dart
@@ -10,6 +10,7 @@ class BookDetailInfo extends StatelessWidget {
   final int pages;
   final String publisher;
   final double starRating;
+  final int reviewCount;
   final String link;
   final double aladinStarRating;
 
@@ -19,6 +20,7 @@ class BookDetailInfo extends StatelessWidget {
     required this.pages,
     required this.publisher,
     required this.starRating,
+    required this.reviewCount,
     required this.link,
     required this.aladinStarRating,
     super.key,
@@ -53,7 +55,7 @@ class BookDetailInfo extends StatelessWidget {
                 ],
               ),
               Text(
-                '리뷰 0개',
+                '리뷰 $reviewCount개',
                 style: bookDetailSubStyle.copyWith(
                   decoration: TextDecoration.underline,
                 ),

--- a/frontend/lib/ui/search/search_detail/search_detail_screen.dart
+++ b/frontend/lib/ui/search/search_detail/search_detail_screen.dart
@@ -197,6 +197,7 @@ class _SearchDetailScreenState extends State<SearchDetailScreen> {
                           pages: bookSearchDetail.pages!,
                           publisher: bookSearchDetail.publisher!,
                           starRating: bookSearchDetail.starRating!,
+                          reviewCount: bookSearchDetail.reviewCount!,
                           link: bookSearchDetail.link!,
                           aladinStarRating: bookSearchDetail.aladinStarRating!,
                         ),

--- a/frontend/lib/ui/search/search_screen.dart
+++ b/frontend/lib/ui/search/search_screen.dart
@@ -107,7 +107,7 @@ class _SearchScreenState extends State<SearchScreen> {
                                 context,
                                 MaterialPageRoute(
                                   builder: (_) => SearchBookList(
-                                    bookSearchKeyword: value,
+                                    searchKeyword: value,
                                   ),
                                 ),
                               ).then(

--- a/frontend/lib/utils/dios/auth_dio.dart
+++ b/frontend/lib/utils/dios/auth_dio.dart
@@ -26,20 +26,6 @@ Future<Dio> authDio(BuildContext context) async {
 
       var refreshDio = Dio();
 
-      refreshDio.interceptors.clear();
-      refreshDio.interceptors
-          .add(InterceptorsWrapper(onError: (error, handler) async {
-        if (error.response?.statusCode == 401) {
-          log('ERROR: Refresh 토큰 만료에 대한 서버 에러가 발생했습니다.');
-          await secureStorage.deleteAll();
-
-          if (!context.mounted) return;
-          Navigator.of(context).pushNamedAndRemoveUntil(
-              '/signin', (Route<dynamic> route) => false);
-        }
-        return handler.next(error);
-      }));
-
       refreshDio.options.headers[accessTokenHeaderKey] =
           '$jwtHeaderBearer$accessToken';
       refreshDio.options.headers[refreshTokenHeaderKey] =
@@ -69,6 +55,15 @@ Future<Dio> authDio(BuildContext context) async {
 
       return handler.resolve(clonedRequest);
     }
+    if (error.response?.statusCode == 401) {
+      log('ERROR: Refresh 토큰 만료에 대한 서버 에러가 발생했습니다.');
+      await secureStorage.deleteAll();
+
+      if (!context.mounted) return;
+      Navigator.of(context)
+          .pushNamedAndRemoveUntil('/signin', (Route<dynamic> route) => false);
+    }
+    return handler.next(error);
   }));
 
   return dio;

--- a/frontend/pubspec.lock
+++ b/frontend/pubspec.lock
@@ -53,10 +53,10 @@ packages:
     dependency: transitive
     description:
       name: collection
-      sha256: "4a07be6cb69c84d677a6c3096fcf960cc3285a8330b4603e0d463d15d9bd934c"
+      sha256: f092b211a4319e98e5ff58223576de6c2803db36221657b46c82574721240687
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.1"
+    version: "1.17.2"
   cross_file:
     dependency: transitive
     description:
@@ -428,18 +428,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "6501fbd55da300384b768785b83e5ce66991266cec21af89ab9ae7f5ce1c4cbb"
+      sha256: "1803e76e6653768d64ed8ff2e1e67bea3ad4b923eb5c56a295c3e634bad5960e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.15"
+    version: "0.12.16"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: d92141dc6fe1dad30722f9aa826c7fbc896d021d792f80678280601aff8cf724
+      sha256: "9528f2f296073ff54cb9fee677df673ace1218163c3bc7628093e7eed5203d41"
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.0"
+    version: "0.5.0"
   meta:
     dependency: transitive
     description:
@@ -641,10 +641,10 @@ packages:
     dependency: transitive
     description:
       name: source_span
-      sha256: dd904f795d4b4f3b870833847c461801f6750a9fa8e61ea5ac53f9422b31f250
+      sha256: "53e943d4206a5e30df338fd4c6e7a077e02254531b138a15aec3bd143c1a8b3c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.1"
+    version: "1.10.0"
   stack_trace:
     dependency: transitive
     description:
@@ -689,10 +689,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: eb6ac1540b26de412b3403a163d919ba86f6a973fe6cc50ae3541b80092fdcfb
+      sha256: "75760ffd7786fffdfb9597c35c5b27eaeec82be8edfb6d71d32651128ed7aab8"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.1"
+    version: "0.6.0"
   typed_data:
     dependency: transitive
     description:
@@ -797,6 +797,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
+  web:
+    dependency: transitive
+    description:
+      name: web
+      sha256: dc8ccd225a2005c1be616fe02951e2e342092edf968cf0844220383757ef8f10
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.4-beta"
   win32:
     dependency: transitive
     description:
@@ -822,5 +830,5 @@ packages:
     source: hosted
     version: "6.3.0"
 sdks:
-  dart: ">=3.0.3 <4.0.0"
+  dart: ">=3.1.0-185.0.dev <4.0.0"
   flutter: ">=3.10.0"


### PR DESCRIPTION
## 🧑‍💻 작업 사항

### 검색 페이지 - 사용자 검색 성공 / 사용자 검색 실패

<div>
<img src="https://github.com/SWM-IDLE/mybrary/assets/97138841/06168fac-c00d-40b1-8e79-1e1a48f3b398" alt="사용자 검색 성공" width="290" height="630"/>
<img src="https://github.com/SWM-IDLE/mybrary/assets/97138841/4f42cc43-9b74-420f-b34c-a0847589a010" alt="사용자 검색 실패" width="290" height="630"/>
</div>

<br>

검색 페이지
- 기존 단일 도서 검색 목록 화면에서 좌우 스와이프 스크롤 형태로 변경
- 사용자 검색 UI 구현 및 api 연동
- 사용자 검색 스크롤에 bounce 애니메이션 적용
- 추후 확장성을 고려하여 futureBuilder를 도서 검색과 사용자 검색 각각 분리

<br>

이슈 해결 사항
- 기존 로직은 도서 검색에서 scroll notification 으로 스크롤이 모바일 하단에 닿을 시 nextRequestUrl 요청
- 검색 페이지 변경에 따라 사용자 검색에서도 스크롤이 모바일 하단에 닿으면 도서 무한 스크롤이 요청되는 이슈 발생
  - scroll 컨트롤러를 도서 검색 목록에만 할당하고, notification 위젯은 삭제
  - 이후, 도서 검색 무한 스크롤도 잘 되면서 사용자 검색에서는 더 이상 도서 관련 요청을 보내지 않도록 해결

<br><br>

### 검색 페이지 수정

<div>
<img width="290" alt="스크린샷 2023-08-21 오후 2 14 26" src="https://github.com/SWM-IDLE/mybrary/assets/97138841/4fb81d63-e5ce-43a5-8fab-6433ca2b6ab8">
<img width="290" alt="image" src="https://github.com/SWM-IDLE/mybrary/assets/97138841/4500d265-22e3-455c-848e-243dc12e836b">
</div>

<br>

- 검색 메인 화면과 동일한 헤더 컴포넌트로 수정하였습니다.
- 도서 전체 및 사용자 결과와 동시에 검색이 가능합니다.

<br><br>

## 🔗 링크

<br><br>

## 🐰 시급한 정도

🐢 천천히 : 급하지 않습니다. 

<br><br>

## 📖 참고 사항

- 다음 진행할 [IDLE-210] 에서 타 사용자 프로필 컴포넌트가 구현되면, 사용자 검색에서도 클릭시 해당 유저의 프로필로 연동할 예정입니다.
- 사용자 검색 결과가 없을 때, 빈 리스트로 받게 되면(현재는 에러코드) gif처럼 결과가 없습니다로 나올 예정입니다.
- 도서 검색 결과가 없을 때도 빈 리스트로 받게 되면 검색된 책이 없습니다로 나올 예정입니다.

<br>


[IDLE-210]: https://swm-idle.atlassian.net/browse/IDLE-210?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ