### PR TITLE
[IDLE-230] 프로필 이미지 저장/조회 로직 수정

### DIFF
--- a/backend/user-service/build.gradle
+++ b/backend/user-service/build.gradle
@@ -41,7 +41,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 	implementation 'org.apache.commons:commons-lang3'
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
-	implementation 'io.awspring.cloud:spring-cloud-aws-starter-s3:3.0.1'
+	implementation 'io.awspring.cloud:spring-cloud-aws-starter-s3:3.0.2'
 	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
 	implementation 'org.springframework.cloud:spring-cloud-config-client'
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'

--- a/backend/user-service/src/main/java/kr/mybrary/userservice/authentication/domain/oauth2/service/CustomOAuth2UserService.java
+++ b/backend/user-service/src/main/java/kr/mybrary/userservice/authentication/domain/oauth2/service/CustomOAuth2UserService.java
@@ -18,6 +18,8 @@ import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
 
+import static kr.mybrary.userservice.global.constant.ImageConstant.*;
+
 @Service
 @RequiredArgsConstructor
 @Slf4j
@@ -93,7 +95,14 @@ public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
     private User saveUser(OAuthAttributes attributes, SocialType socialType) {
         User createdUser = attributes.toEntity(socialType, attributes.getOAuth2UserInfo());
         createdUser.updatePassword(passwordEncoder.encode(createdUser.getPassword()));
+        setDefaultProfileImage(createdUser);
         return userRepository.save(createdUser);
+    }
+
+    private void setDefaultProfileImage(User createdUser) {
+        createdUser.updateProfileImageUrl(DEFAULT_PROFILE_IMAGE.getUrl());
+        createdUser.updateProfileImageThumbnailTinyUrl(DEFAULT_PROFILE_IMAGE_TINY.getUrl());
+        createdUser.updateProfileImageThumbnailSmallUrl(DEFAULT_PROFILE_IMAGE_SMALL.getUrl());
     }
 
 }

--- a/backend/user-service/src/main/java/kr/mybrary/userservice/global/constant/ImageConstant.java
+++ b/backend/user-service/src/main/java/kr/mybrary/userservice/global/constant/ImageConstant.java
@@ -1,0 +1,18 @@
+package kr.mybrary.userservice.global.constant;
+
+public enum ImageConstant {
+
+    DEFAULT_PROFILE_IMAGE("https://mybrary-user-service.s3.ap-northeast-2.amazonaws.com/profile/profileImage/default.jpg"),
+    DEFAULT_PROFILE_IMAGE_TINY("https://mybrary-user-service-resized.s3.ap-northeast-2.amazonaws.com/tiny-profile/profileImage/default.jpg"),
+    DEFAULT_PROFILE_IMAGE_SMALL("https://mybrary-user-service-resized.s3.ap-northeast-2.amazonaws.com/small-profile/profileImage/default.jpg");
+
+    private final String url;
+
+    ImageConstant(String url) {
+        this.url = url;
+    }
+
+    public String getUrl() {
+        return url;
+    }
+}

--- a/backend/user-service/src/main/java/kr/mybrary/userservice/global/util/MultipartFileUtil.java
+++ b/backend/user-service/src/main/java/kr/mybrary/userservice/global/util/MultipartFileUtil.java
@@ -2,14 +2,22 @@ package kr.mybrary.userservice.global.util;
 
 import org.springframework.web.multipart.MultipartFile;
 
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
 public class MultipartFileUtil {
 
-    public static String generateFilePath(String path, String fileName, MultipartFile multipartFile) {
-        return path + fileName + "." + getFileExtension(multipartFile);
+    public static String generateFilePath(String path, String fileName, String fileExtension) {
+        return path + fileName + "." + fileExtension;
     }
 
     public static String getFileExtension(MultipartFile multipartFile) {
         return multipartFile.getContentType().split("/")[1];
+    }
+
+    public static String generateTimestampFileName(Date date) {
+        SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd_HH-mm-ss-SSS");
+        return dateFormat.format(date);
     }
 
 }

--- a/backend/user-service/src/main/java/kr/mybrary/userservice/global/util/MultipartFileUtil.java
+++ b/backend/user-service/src/main/java/kr/mybrary/userservice/global/util/MultipartFileUtil.java
@@ -2,8 +2,8 @@ package kr.mybrary.userservice.global.util;
 
 import org.springframework.web.multipart.MultipartFile;
 
-import java.text.SimpleDateFormat;
-import java.util.Date;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 
 public class MultipartFileUtil {
 
@@ -15,9 +15,9 @@ public class MultipartFileUtil {
         return multipartFile.getContentType().split("/")[1];
     }
 
-    public static String generateTimestampFileName(Date date) {
-        SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd_HH-mm-ss-SSS");
-        return dateFormat.format(date);
+    public static String generateTimestampFileName(LocalDateTime localDateTime) {
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd_HH-mm-ss-SSS");
+        return localDateTime.format(formatter);
     }
 
 }

--- a/backend/user-service/src/main/java/kr/mybrary/userservice/user/domain/UserService.java
+++ b/backend/user-service/src/main/java/kr/mybrary/userservice/user/domain/UserService.java
@@ -13,7 +13,7 @@ public interface UserService {
 
     ProfileServiceResponse updateProfile(ProfileUpdateServiceRequest serviceRequest);
 
-    ProfileImageUrlServiceResponse getProfileImageUrl(String loginId);
+    ProfileImageUrlServiceResponse getProfileImageUrl(ProfileImageUrlServiceRequest serviceRequest);
 
     ProfileImageUrlServiceResponse updateProfileImage(ProfileImageUpdateServiceRequest serviceRequest);
 

--- a/backend/user-service/src/main/java/kr/mybrary/userservice/user/domain/UserServiceImpl.java
+++ b/backend/user-service/src/main/java/kr/mybrary/userservice/user/domain/UserServiceImpl.java
@@ -7,6 +7,7 @@ import kr.mybrary.userservice.user.domain.dto.request.*;
 import kr.mybrary.userservice.user.domain.dto.response.*;
 import kr.mybrary.userservice.user.domain.exception.follow.DuplicateFollowException;
 import kr.mybrary.userservice.user.domain.exception.follow.SameSourceTargetUserException;
+import kr.mybrary.userservice.user.domain.exception.profile.ProfileImageSizeOptionNotSupportedException;
 import kr.mybrary.userservice.user.domain.exception.profile.ProfileUpdateRequestNotAuthenticated;
 import kr.mybrary.userservice.user.domain.exception.user.DuplicateLoginIdException;
 import kr.mybrary.userservice.user.domain.exception.user.DuplicateNicknameException;
@@ -172,7 +173,7 @@ public class UserServiceImpl implements UserService {
         if(size.equals("small")) {
             return user.getProfileImageThumbnailSmallUrl();
         }
-        throw  new IllegalArgumentException("size 값이 잘못되었습니다.");
+        throw new ProfileImageSizeOptionNotSupportedException();
     }
 
     private void updateProfileImageThumbnailUrl(User user, String size) {
@@ -184,7 +185,7 @@ public class UserServiceImpl implements UserService {
             user.updateProfileImageThumbnailSmallUrl(storageService.getResizedUrl(user.getProfileImageUrl(), size));
             return;
         }
-        throw  new IllegalArgumentException("size 값이 잘못되었습니다.");
+        throw new ProfileImageSizeOptionNotSupportedException();
     }
 
     @Override

--- a/backend/user-service/src/main/java/kr/mybrary/userservice/user/domain/UserServiceImpl.java
+++ b/backend/user-service/src/main/java/kr/mybrary/userservice/user/domain/UserServiceImpl.java
@@ -185,9 +185,7 @@ public class UserServiceImpl implements UserService {
         }
         if(size.equals(PROFILE_IMAGE_SIZE_SMALL)) {
             user.updateProfileImageThumbnailSmallUrl(storageService.getResizedUrl(user.getProfileImageUrl(), size));
-            return;
         }
-        throw new ProfileImageSizeOptionNotSupportedException();
     }
 
     @Override
@@ -200,7 +198,7 @@ public class UserServiceImpl implements UserService {
 
         String profileImageUrl = storageService.putFile(serviceRequest.getProfileImage(),
                 MultipartFileUtil.generateFilePath(String.format(PROFILE_IMAGE_PATH_FORMAT, serviceRequest.getLoginId()),
-                        MultipartFileUtil.generateTimestampFileName(serviceRequest.getDate()),
+                        MultipartFileUtil.generateTimestampFileName(serviceRequest.getLocalDateTime()),
                         MultipartFileUtil.getFileExtension(serviceRequest.getProfileImage())));
 
         user.updateProfileImageUrl(profileImageUrl);

--- a/backend/user-service/src/main/java/kr/mybrary/userservice/user/domain/UserServiceImpl.java
+++ b/backend/user-service/src/main/java/kr/mybrary/userservice/user/domain/UserServiceImpl.java
@@ -29,6 +29,8 @@ import org.springframework.web.multipart.MultipartFile;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static kr.mybrary.userservice.global.constant.ImageConstant.*;
+
 @Service
 @Transactional
 @RequiredArgsConstructor
@@ -37,11 +39,8 @@ public class UserServiceImpl implements UserService {
 
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
-    // TODO: StorageService 결합도 낮추기
     private final StorageService storageService;
-
-    private static final String DEFAULT_PROFILE_IMAGE_URL = "https://mybrary-user-service.s3.ap-northeast-2.amazonaws.com/profile/profileImage/default.jpg";
-    private static final String PROFILE_IMAGE_PATH = "profile/profileImage/";
+    private static final String PROFILE_IMAGE_PATH_FORMAT = "profile/profileImage/%s/";
     private static final int MAX_PROFILE_IMAGE_SIZE = 5 * 1024 * 1024;
 
     @Override
@@ -53,11 +52,17 @@ public class UserServiceImpl implements UserService {
         User user = UserMapper.INSTANCE.toEntity(serviceRequest);
         user.updatePassword(passwordEncoder.encode(user.getPassword()));
         user.updateRole(Role.USER);
-        user.updateProfileImageUrl(DEFAULT_PROFILE_IMAGE_URL);
+        setDefaultProfileImage(user);
         SignUpServiceResponse serviceResponse = UserMapper.INSTANCE.toSignUpServiceResponse(
                 userRepository.save(user));
 
         return serviceResponse;
+    }
+
+    private void setDefaultProfileImage(User user) {
+        user.updateProfileImageUrl(DEFAULT_PROFILE_IMAGE.getUrl());
+        user.updateProfileImageThumbnailTinyUrl(DEFAULT_PROFILE_IMAGE_TINY.getUrl());
+        user.updateProfileImageThumbnailSmallUrl(DEFAULT_PROFILE_IMAGE_SMALL.getUrl());
     }
 
     private void validateDuplicateNickname(String nickname) {
@@ -120,22 +125,66 @@ public class UserServiceImpl implements UserService {
 
     @Override
     @Transactional(readOnly = true)
-    public ProfileImageUrlServiceResponse getProfileImageUrl(String loginId) {
-        User user = getUser(loginId);
-
-        checkProfileImageUrlExistence(user);
-
-        ProfileImageUrlServiceResponse serviceResponse = ProfileImageUrlServiceResponse.builder()
-                .profileImageUrl(user.getProfileImageUrl())
+    public ProfileImageUrlServiceResponse getProfileImageUrl(ProfileImageUrlServiceRequest serviceRequest) {
+        return ProfileImageUrlServiceResponse.builder()
+                .profileImageUrl(getProfileImageUrlBy(getUser(serviceRequest.getUserId()), serviceRequest.getSize()))
                 .build();
+    }
 
-        return serviceResponse;
+    private String getProfileImageUrlBy(User user, String size) {
+        if(size.equals("original")) {
+            return getOriginalProfileImageUrl(user);
+        }
+        return getResizedProfileImageUrl(user, size);
+    }
+
+    private String getOriginalProfileImageUrl(User user) {
+        checkProfileImageUrlExistence(user);
+        return user.getProfileImageUrl();
     }
 
     private void checkProfileImageUrlExistence(User user) {
         if (user.getProfileImageUrl() == null) {
             throw new ProfileImageUrlNotFoundException();
         }
+    }
+
+    private String getResizedProfileImageUrl(User user, String size) {
+        if(isProfileImageThumbnailUrlUpdated(user, size)) {
+            return getProfileImageThumbnailUrl(user, size);
+        }
+        if(storageService.hasResizedFiles(storageService.getPathFromUrl(user.getProfileImageUrl()), size)) {
+            updateProfileImageThumbnailUrl(user, size);
+            return getProfileImageThumbnailUrl(user, size);
+        }
+        return getOriginalProfileImageUrl(user);
+    }
+
+    private boolean isProfileImageThumbnailUrlUpdated(User user, String size) {
+        return storageService.getPathFromUrl(getProfileImageThumbnailUrl(user, size))
+                .equals(size + "-" + storageService.getPathFromUrl(user.getProfileImageUrl()));
+    }
+
+    private String getProfileImageThumbnailUrl(User user, String size) {
+        if(size.equals("tiny")) {
+            return user.getProfileImageThumbnailTinyUrl();
+        }
+        if(size.equals("small")) {
+            return user.getProfileImageThumbnailSmallUrl();
+        }
+        throw  new IllegalArgumentException("size 값이 잘못되었습니다.");
+    }
+
+    private void updateProfileImageThumbnailUrl(User user, String size) {
+        if(size.equals("tiny")) {
+            user.updateProfileImageThumbnailTinyUrl(storageService.getResizedUrl(user.getProfileImageUrl(), size));
+            return;
+        }
+        if(size.equals("small")) {
+            user.updateProfileImageThumbnailSmallUrl(storageService.getResizedUrl(user.getProfileImageUrl(), size));
+            return;
+        }
+        throw  new IllegalArgumentException("size 값이 잘못되었습니다.");
     }
 
     @Override
@@ -147,7 +196,9 @@ public class UserServiceImpl implements UserService {
         User user = getUser(serviceRequest.getLoginId());
 
         String profileImageUrl = storageService.putFile(serviceRequest.getProfileImage(),
-                MultipartFileUtil.generateFilePath(PROFILE_IMAGE_PATH, serviceRequest.getLoginId(), serviceRequest.getProfileImage()));
+                MultipartFileUtil.generateFilePath(String.format(PROFILE_IMAGE_PATH_FORMAT, serviceRequest.getLoginId()),
+                        MultipartFileUtil.generateTimestampFileName(serviceRequest.getDate()),
+                        MultipartFileUtil.getFileExtension(serviceRequest.getProfileImage())));
 
         user.updateProfileImageUrl(profileImageUrl);
         ProfileImageUrlServiceResponse serviceResponse = ProfileImageUrlServiceResponse.builder()
@@ -180,8 +231,7 @@ public class UserServiceImpl implements UserService {
         checkProfileImageUpdateRequestAuthentication(serviceRequest);
 
         User user = getUser(serviceRequest.getLoginId());
-
-        user.updateProfileImageUrl(DEFAULT_PROFILE_IMAGE_URL);
+        setDefaultProfileImage(user);
         ProfileImageUrlServiceResponse serviceResponse = ProfileImageUrlServiceResponse.builder()
                 .profileImageUrl(user.getProfileImageUrl())
                 .build();

--- a/backend/user-service/src/main/java/kr/mybrary/userservice/user/domain/dto/UserMapper.java
+++ b/backend/user-service/src/main/java/kr/mybrary/userservice/user/domain/dto/UserMapper.java
@@ -21,7 +21,4 @@ public interface UserMapper {
     SignUpServiceResponse toSignUpServiceResponse(User user);
 
     ProfileServiceResponse toProfileServiceResponse(User user);
-
-    @Mapping(target = "userId", source = "loginId")
-    SearchServiceResponse.SearchedUser toSearchedUser(User user);
 }

--- a/backend/user-service/src/main/java/kr/mybrary/userservice/user/domain/dto/request/ProfileImageUpdateServiceRequest.java
+++ b/backend/user-service/src/main/java/kr/mybrary/userservice/user/domain/dto/request/ProfileImageUpdateServiceRequest.java
@@ -4,7 +4,7 @@ import lombok.Builder;
 import lombok.Getter;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.util.Date;
+import java.time.LocalDateTime;
 
 @Getter
 @Builder
@@ -13,14 +13,14 @@ public class ProfileImageUpdateServiceRequest {
     private MultipartFile profileImage;
     private String loginId;
     private String userId;
-    private Date date;
+    private LocalDateTime localDateTime;
 
-    public static ProfileImageUpdateServiceRequest of(MultipartFile profileImage, String loginId, String userId, Date date) {
+    public static ProfileImageUpdateServiceRequest of(MultipartFile profileImage, String loginId, String userId, LocalDateTime localDateTime) {
         return ProfileImageUpdateServiceRequest.builder()
                 .profileImage(profileImage)
                 .loginId(loginId)
                 .userId(userId)
-                .date(date)
+                .localDateTime(localDateTime)
                 .build();
     }
 

--- a/backend/user-service/src/main/java/kr/mybrary/userservice/user/domain/dto/request/ProfileImageUpdateServiceRequest.java
+++ b/backend/user-service/src/main/java/kr/mybrary/userservice/user/domain/dto/request/ProfileImageUpdateServiceRequest.java
@@ -4,6 +4,8 @@ import lombok.Builder;
 import lombok.Getter;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.util.Date;
+
 @Getter
 @Builder
 public class ProfileImageUpdateServiceRequest {
@@ -11,12 +13,14 @@ public class ProfileImageUpdateServiceRequest {
     private MultipartFile profileImage;
     private String loginId;
     private String userId;
+    private Date date;
 
-    public static ProfileImageUpdateServiceRequest of(MultipartFile profileImage, String loginId, String userId) {
+    public static ProfileImageUpdateServiceRequest of(MultipartFile profileImage, String loginId, String userId, Date date) {
         return ProfileImageUpdateServiceRequest.builder()
                 .profileImage(profileImage)
                 .loginId(loginId)
                 .userId(userId)
+                .date(date)
                 .build();
     }
 

--- a/backend/user-service/src/main/java/kr/mybrary/userservice/user/domain/dto/request/ProfileImageUrlServiceRequest.java
+++ b/backend/user-service/src/main/java/kr/mybrary/userservice/user/domain/dto/request/ProfileImageUrlServiceRequest.java
@@ -1,0 +1,19 @@
+package kr.mybrary.userservice.user.domain.dto.request;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ProfileImageUrlServiceRequest {
+
+    private String userId;
+    private String size;
+
+    public static ProfileImageUrlServiceRequest of(String userId, String size) {
+        return ProfileImageUrlServiceRequest.builder()
+                .userId(userId)
+                .size(size)
+                .build();
+    }
+}

--- a/backend/user-service/src/main/java/kr/mybrary/userservice/user/domain/dto/response/UserInfoServiceResponse.java
+++ b/backend/user-service/src/main/java/kr/mybrary/userservice/user/domain/dto/response/UserInfoServiceResponse.java
@@ -20,14 +20,6 @@ public class UserInfoServiceResponse {
         private String nickname;
         private String profileImageUrl;
 
-        public static UserInfoElement of(UserInfoModel userInfoModel) {
-            return UserInfoElement.builder()
-                    .userId(userInfoModel.getLoginId())
-                    .nickname(userInfoModel.getNickname())
-                    .profileImageUrl(userInfoModel.getProfileImageUrl())
-                    .build();
-        }
-
     }
 
 }

--- a/backend/user-service/src/main/java/kr/mybrary/userservice/user/domain/exception/profile/ProfileImageSizeOptionNotSupportedException.java
+++ b/backend/user-service/src/main/java/kr/mybrary/userservice/user/domain/exception/profile/ProfileImageSizeOptionNotSupportedException.java
@@ -1,0 +1,14 @@
+package kr.mybrary.userservice.user.domain.exception.profile;
+
+import kr.mybrary.userservice.global.exception.ApplicationException;
+
+public class ProfileImageSizeOptionNotSupportedException extends ApplicationException {
+
+    private final static int STATUS = 404;
+    private final static String ERROR_CODE = "P-04";
+    private final static String ERROR_MESSAGE = "지원되지 않는 프로필 이미지 크기 옵션입니다. 현재 지원하는 옵션은 tiny, small, original 입니다.";
+
+    public ProfileImageSizeOptionNotSupportedException() {
+        super(STATUS, ERROR_CODE, ERROR_MESSAGE);
+    }
+}

--- a/backend/user-service/src/main/java/kr/mybrary/userservice/user/domain/storage/StorageService.java
+++ b/backend/user-service/src/main/java/kr/mybrary/userservice/user/domain/storage/StorageService.java
@@ -6,4 +6,10 @@ public interface StorageService {
 
     String putFile(MultipartFile multipartFile, String path);
 
+    String getPathFromUrl(String url);
+
+    boolean hasResizedFiles(String path, String size);
+
+    String getResizedUrl(String url, String size);
+
 }

--- a/backend/user-service/src/main/java/kr/mybrary/userservice/user/persistence/User.java
+++ b/backend/user-service/src/main/java/kr/mybrary/userservice/user/persistence/User.java
@@ -90,6 +90,14 @@ public class User extends BaseEntity {
         this.profileImageUrl = profileImageUrl;
     }
 
+    public void updateProfileImageThumbnailTinyUrl(String profileImageThumbnailTinyUrl) {
+        this.profileImageThumbnailTinyUrl = profileImageThumbnailTinyUrl;
+    }
+
+    public void updateProfileImageThumbnailSmallUrl(String profileImageThumbnailSmallUrl) {
+        this.profileImageThumbnailSmallUrl = profileImageThumbnailSmallUrl;
+    }
+
     public void follow(User target) {
         Follow follow = Follow.builder()
             .source(this)

--- a/backend/user-service/src/main/java/kr/mybrary/userservice/user/persistence/User.java
+++ b/backend/user-service/src/main/java/kr/mybrary/userservice/user/persistence/User.java
@@ -61,6 +61,10 @@ public class User extends BaseEntity {
 
     private String profileImageUrl;
 
+    private String profileImageThumbnailTinyUrl;
+
+    private String profileImageThumbnailSmallUrl;
+
     @OneToMany(mappedBy = "target", cascade = CascadeType.PERSIST, orphanRemoval = true)
     private List<Follow> followers;
 

--- a/backend/user-service/src/main/java/kr/mybrary/userservice/user/presentation/UserController.java
+++ b/backend/user-service/src/main/java/kr/mybrary/userservice/user/presentation/UserController.java
@@ -12,7 +12,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.util.Date;
+import java.time.LocalDateTime;
 
 @RestController
 @RequiredArgsConstructor
@@ -69,7 +69,7 @@ public class UserController {
                                                               @RequestParam("profileImage") MultipartFile profileImage) {
         return ResponseEntity.ok().body(
                 SuccessResponse.of(HttpStatus.OK.toString(), "로그인 된 사용자의 프로필 이미지를 등록했습니다.",
-                        userService.updateProfileImage(ProfileImageUpdateServiceRequest.of(profileImage, loginId, userId, new Date()))));
+                        userService.updateProfileImage(ProfileImageUpdateServiceRequest.of(profileImage, loginId, userId, LocalDateTime.now()))));
     }
 
     @DeleteMapping("/{userId}/profile/image")

--- a/backend/user-service/src/main/java/kr/mybrary/userservice/user/presentation/UserController.java
+++ b/backend/user-service/src/main/java/kr/mybrary/userservice/user/presentation/UserController.java
@@ -12,6 +12,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.util.Date;
+
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/users")
@@ -29,7 +31,7 @@ public class UserController {
         );
     }
 
-     @GetMapping("/{userId}/profile")
+    @GetMapping("/{userId}/profile")
     public ResponseEntity<SuccessResponse> getProfile(@PathVariable("userId") String userId) {
         ProfileServiceResponse serviceResponse = userService.getProfile(userId);
 
@@ -54,28 +56,20 @@ public class UserController {
     }
 
     @GetMapping("/{userId}/profile/image")
-    public ResponseEntity<SuccessResponse> getProfileImageUrl(@PathVariable("userId") String userId) {
-        ProfileImageUrlServiceResponse serviceResponse = userService.getProfileImageUrl(userId);
-
+    public ResponseEntity<SuccessResponse> getProfileImageUrl(@PathVariable("userId") String userId,
+                                                              @RequestParam(value = "size", required = false, defaultValue = "original") String size) {
         return ResponseEntity.ok().body(
                 SuccessResponse.of(HttpStatus.OK.toString(), "사용자의 프로필 이미지 URL입니다.",
-                        serviceResponse)
-        );
+                        userService.getProfileImageUrl(ProfileImageUrlServiceRequest.of(userId, size))));
     }
 
     @PutMapping("/{userId}/profile/image")
     public ResponseEntity<SuccessResponse> updateProfileImage(@PathVariable("userId") String userId,
                                                               @RequestHeader("USER-ID") String loginId,
                                                               @RequestParam("profileImage") MultipartFile profileImage) {
-        ProfileImageUpdateServiceRequest serviceRequest = ProfileImageUpdateServiceRequest.of(
-                profileImage, loginId, userId);
-        ProfileImageUrlServiceResponse serviceResponse = userService.updateProfileImage(
-                serviceRequest);
-
         return ResponseEntity.ok().body(
                 SuccessResponse.of(HttpStatus.OK.toString(), "로그인 된 사용자의 프로필 이미지를 등록했습니다.",
-                        serviceResponse)
-        );
+                        userService.updateProfileImage(ProfileImageUpdateServiceRequest.of(profileImage, loginId, userId, new Date()))));
     }
 
     @DeleteMapping("/{userId}/profile/image")

--- a/backend/user-service/src/test/java/kr/mybrary/userservice/user/UserFixture.java
+++ b/backend/user-service/src/test/java/kr/mybrary/userservice/user/UserFixture.java
@@ -14,28 +14,34 @@ public enum UserFixture {
 
     COMMON_USER(1L, "loginId", "nickname", "encodedPassword", Role.USER,
             "socialId", SocialType.GOOGLE, "email@mail.com", "introduction", "profileImageUrl",
+            "profileImageThumbnailTinyUrl", "profileImageThumbnailSmallUrl",
             Collections.emptyList(), Collections.emptyList()),
     
     USER_WITHOUT_PROFILE_IMAGE_URL(1L, "loginId", "nickname", "encodedPassword", Role.USER,
             "socialId", SocialType.GOOGLE, "email@mail.com", "introduction", null,
+            "profileImageThumbnailTinyUrl", "profileImageThumbnailSmallUrl",
             Collections.emptyList(), Collections.emptyList()),
 
     USER_WITHOUT_EMAIL(1L, "loginId", "nickname", "encodedPassword", Role.USER,
             "socialId", SocialType.GOOGLE, null, "introduction", "profileImageUrl",
+            "profileImageThumbnailTinyUrl", "profileImageThumbnailSmallUrl",
             Collections.emptyList(), Collections.emptyList()),
 
     USER_WITH_FOLLOWER(1L, "followingId", "nickname", "encodedPassword", Role.USER,
             "socialId", SocialType.GOOGLE, "email@mail.com", "introduction", "profileImageUrl",
+            "profileImageThumbnailTinyUrl", "profileImageThumbnailSmallUrl",
             List.of(Follow.builder().source(User.builder().loginId("followerId").build()).target(User.builder().loginId("followingId").build()).build()),
             Collections.emptyList()),
 
     USER_AS_FOLLOWER(1L, "followerId", "nickname", "encodedPassword", Role.USER,
             "socialId", SocialType.GOOGLE, "email@mail.com", "introduction", "profileImageUrl",
+            "profileImageThumbnailTinyUrl", "profileImageThumbnailSmallUrl",
             Collections.emptyList(),
             List.of(Follow.builder().source(User.builder().loginId("followerId").build()).target(User.builder().loginId("followingId").build()).build())),
 
     USER_WITH_SIMILAR_NICKNAME(2L, "loginId123", "nickname123", "encodedPassword", Role.USER,
             "socialId123", SocialType.GOOGLE, "email@mail.com", "introduction", "profileImageUrl",
+            "profileImageThumbnailTinyUrl", "profileImageThumbnailSmallUrl",
             Collections.emptyList(), Collections.emptyList());
 
     private final Long id;
@@ -48,6 +54,8 @@ public enum UserFixture {
     private final String email;
     private final String introduction;
     private final String profileImageUrl;
+    private final String profileImageThumbnailTinyUrl;
+    private final String profileImageThumbnailSmallUrl;
     private final List<Follow> followers;
     private final List<Follow> followings;
 
@@ -63,6 +71,8 @@ public enum UserFixture {
                 .email(email)
                 .introduction(introduction)
                 .profileImageUrl(profileImageUrl)
+                .profileImageThumbnailTinyUrl(profileImageThumbnailTinyUrl)
+                .profileImageThumbnailSmallUrl(profileImageThumbnailSmallUrl)
                 .followers(followers)
                 .followings(followings)
                 .build();

--- a/backend/user-service/src/test/java/kr/mybrary/userservice/user/UserTestData.java
+++ b/backend/user-service/src/test/java/kr/mybrary/userservice/user/UserTestData.java
@@ -31,9 +31,13 @@ public class UserTestData {
         return ProfileImageUpdateServiceRequest.builder()
                 .userId("loginId")
                 .loginId("loginId")
-                .profileImage(new MockMultipartFile("profileImage", "user1.png", "image/jpg",
-                        new FileInputStream("src/test/resources/images/Image1MB.jpg")))
+                .profileImage(createMockMultipartFile())
                 .build();
+    }
+
+    public static MockMultipartFile createMockMultipartFile() throws Exception {
+        return new MockMultipartFile("profileImage", "user1.png", "image/jpg",
+                new FileInputStream("src/test/resources/images/Image1MB.jpg"));
     }
 
     public static ProfileImageUpdateServiceRequest createProfileImageUpdateServiceRequestWithEmptyFile() {
@@ -49,8 +53,12 @@ public class UserTestData {
         return ProfileImageUpdateServiceRequest.builder()
                 .userId("loginId")
                 .loginId("loginId")
-                .profileImage(new MockMultipartFile("profileImage", "user1.png", "image/jpeg",
-                        new FileInputStream("src/test/resources/images/Image6MB.jpeg")))
+                .profileImage(createMockMultipartFileFileSizeExceeded())
                 .build();
+    }
+
+    public static MockMultipartFile createMockMultipartFileFileSizeExceeded() throws Exception {
+        return new MockMultipartFile("profileImage", "user1.png", "image/jpg",
+                new FileInputStream("src/test/resources/images/Image6MB.jpeg"));
     }
 }

--- a/backend/user-service/src/test/java/kr/mybrary/userservice/user/domain/UserServiceImplTest.java
+++ b/backend/user-service/src/test/java/kr/mybrary/userservice/user/domain/UserServiceImplTest.java
@@ -1,12 +1,12 @@
 package kr.mybrary.userservice.user.domain;
 
-import kr.mybrary.userservice.global.util.MultipartFileUtil;
 import kr.mybrary.userservice.user.UserFixture;
 import kr.mybrary.userservice.user.UserTestData;
 import kr.mybrary.userservice.user.domain.dto.request.*;
 import kr.mybrary.userservice.user.domain.dto.response.*;
 import kr.mybrary.userservice.user.domain.exception.io.EmptyFileException;
 import kr.mybrary.userservice.user.domain.exception.profile.ProfileImageFileSizeExceededException;
+import kr.mybrary.userservice.user.domain.exception.profile.ProfileImageSizeOptionNotSupportedException;
 import kr.mybrary.userservice.user.domain.exception.profile.ProfileImageUrlNotFoundException;
 import kr.mybrary.userservice.user.domain.exception.profile.ProfileUpdateRequestNotAuthenticated;
 import kr.mybrary.userservice.user.domain.exception.user.DuplicateLoginIdException;
@@ -27,6 +27,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
+import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Optional;
@@ -34,9 +35,9 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
@@ -54,7 +55,6 @@ class UserServiceImplTest {
     static final String LOGIN_ID = "loginId";
     static final String FOLLOWING_ID = "followingId";
     static final String FOLLOWER_ID = "followerId";
-    static final String PROFILE_IMAGE_PATH = "profile/profileImage/";
     static final String PROFILE_IMAGE_BASE_URL = "https://mybrary-user-service.s3.ap-northeast-2.amazonaws.com/profile/profileImage/";
 
     @Test
@@ -205,14 +205,18 @@ class UserServiceImplTest {
     }
 
     @Test
-    @DisplayName("로그인 아이디로 사용자 프로필 이미지 URL을 조회한다")
+    @DisplayName("로그인 아이디로 사용자 프로필 이미지 원본 URL을 조회한다")
     void getProfileImageUrl() {
         // Given
-        given(userRepository.findByLoginId(LOGIN_ID)).willReturn(
-                Optional.of(UserFixture.COMMON_USER.getUser()));
+        ProfileImageUrlServiceRequest serviceRequest = ProfileImageUrlServiceRequest.builder()
+                .userId(LOGIN_ID)
+                .size("original")
+                .build();
+
+        given(userRepository.findByLoginId(LOGIN_ID)).willReturn(Optional.of(UserFixture.COMMON_USER.getUser()));
 
         // When
-        ProfileImageUrlServiceResponse profileImage = userService.getProfileImageUrl(LOGIN_ID);
+        ProfileImageUrlServiceResponse profileImage = userService.getProfileImageUrl(serviceRequest);
 
         // Then
         assertThat(profileImage.getProfileImageUrl()).isEqualTo(
@@ -222,13 +226,18 @@ class UserServiceImplTest {
     }
 
     @Test
-    @DisplayName("로그인 아이디로 사용자 프로필 이미지 URL을 조회할 때 사용자가 없으면 예외를 던진다")
+    @DisplayName("로그인 아이디로 사용자 프로필 이미지 원본 URL을 조회할 때 사용자가 없으면 예외를 던진다")
     void getProfileImageUrlWithNotExistUser() {
         // Given
+        ProfileImageUrlServiceRequest serviceRequest = ProfileImageUrlServiceRequest.builder()
+                .userId(LOGIN_ID)
+                .size("original")
+                .build();
+
         given(userRepository.findByLoginId(LOGIN_ID)).willReturn(Optional.empty());
 
         // When
-        assertThatThrownBy(() -> userService.getProfileImageUrl(LOGIN_ID))
+        assertThatThrownBy(() -> userService.getProfileImageUrl(serviceRequest))
                 .isInstanceOf(UserNotFoundException.class)
                 .hasFieldOrPropertyWithValue("status", 404)
                 .hasFieldOrPropertyWithValue("errorCode", "U-05")
@@ -239,14 +248,19 @@ class UserServiceImplTest {
     }
 
     @Test
-    @DisplayName("로그인 아이디로 사용자 프로필 이미지 URL을 조회할 때 프로필 이미지 URL이 없으면 예외를 던진다")
+    @DisplayName("로그인 아이디로 사용자 프로필 이미지 원본 URL을 조회할 때 프로필 이미지 원본 URL이 없으면 예외를 던진다")
     void getProfileImageUrlWithNoProfileImageUrl() {
         // Given
+        ProfileImageUrlServiceRequest serviceRequest = ProfileImageUrlServiceRequest.builder()
+                .userId(LOGIN_ID)
+                .size("original")
+                .build();
+
         given(userRepository.findByLoginId(LOGIN_ID)).willReturn(
                 Optional.of(UserFixture.USER_WITHOUT_PROFILE_IMAGE_URL.getUser()));
 
         // When
-        assertThatThrownBy(() -> userService.getProfileImageUrl(LOGIN_ID))
+        assertThatThrownBy(() -> userService.getProfileImageUrl(serviceRequest))
                 .isInstanceOf(ProfileImageUrlNotFoundException.class)
                 .hasFieldOrPropertyWithValue("status", 404)
                 .hasFieldOrPropertyWithValue("errorCode", "P-01")
@@ -254,6 +268,187 @@ class UserServiceImplTest {
 
         // Then
         verify(userRepository).findByLoginId(LOGIN_ID);
+    }
+
+    @Test
+    @DisplayName("로그인 아이디로 사용자 프로필 이미지 썸네일 (tiny) URL을 조회한다. 썸네일 URL이 업데이트 되어 있다면 바로 반환한다.")
+    void getProfileImagThumbnailTinyUrl() {
+        // Given
+        ProfileImageUrlServiceRequest serviceRequest = ProfileImageUrlServiceRequest.builder()
+                .userId(LOGIN_ID)
+                .size("tiny")
+                .build();
+
+        given(userRepository.findByLoginId(LOGIN_ID)).willReturn(Optional.of(UserFixture.COMMON_USER.getUser()));
+        given(storageService.getPathFromUrl("profileImageThumbnailTinyUrl")).willReturn("tiny-profileImagePath");
+        given(storageService.getPathFromUrl("profileImageUrl")).willReturn("profileImagePath");
+
+        // When
+        ProfileImageUrlServiceResponse profileImage = userService.getProfileImageUrl(serviceRequest);
+
+        // Then
+        assertThat(profileImage.getProfileImageUrl()).isEqualTo(UserFixture.COMMON_USER.getUser().getProfileImageThumbnailTinyUrl());
+
+        verify(userRepository).findByLoginId(LOGIN_ID);
+        verify(storageService).getPathFromUrl("profileImageThumbnailTinyUrl");
+        verify(storageService).getPathFromUrl("profileImageUrl");
+    }
+
+    @Test
+    @DisplayName("로그인 아이디로 사용자 프로필 이미지 썸네일 (small) URL을 조회한다. 썸네일 URL이 업데이트 되어 있다면 바로 반환한다.")
+    void getProfileImagThumbnailSmallUrl() {
+        // Given
+        ProfileImageUrlServiceRequest serviceRequest = ProfileImageUrlServiceRequest.builder()
+                .userId(LOGIN_ID)
+                .size("small")
+                .build();
+
+        given(userRepository.findByLoginId(LOGIN_ID)).willReturn(Optional.of(UserFixture.COMMON_USER.getUser()));
+        given(storageService.getPathFromUrl("profileImageThumbnailSmallUrl")).willReturn("small-profileImagePath");
+        given(storageService.getPathFromUrl("profileImageUrl")).willReturn("profileImagePath");
+
+        // When
+        ProfileImageUrlServiceResponse profileImage = userService.getProfileImageUrl(serviceRequest);
+
+        // Then
+        assertThat(profileImage.getProfileImageUrl()).isEqualTo(UserFixture.COMMON_USER.getUser().getProfileImageThumbnailSmallUrl());
+
+        verify(userRepository).findByLoginId(LOGIN_ID);
+        verify(storageService).getPathFromUrl("profileImageThumbnailSmallUrl");
+        verify(storageService).getPathFromUrl("profileImageUrl");
+    }
+
+    @Test
+    @DisplayName("로그인 아이디로 사용자 프로필 이미지 썸네일 URL을 조회한다. 지원하지 않는 썸네일 사이즈 옵션이라면 예외를 던진다.")
+    void getProfileImagThumbnailNotSupportedSizeUrl() {
+        // Given
+        ProfileImageUrlServiceRequest serviceRequest = ProfileImageUrlServiceRequest.builder()
+                .userId(LOGIN_ID)
+                .size("notSupportedSize")
+                .build();
+
+        given(userRepository.findByLoginId(LOGIN_ID)).willReturn(Optional.of(UserFixture.COMMON_USER.getUser()));
+
+        // When
+        assertThatThrownBy(() -> userService.getProfileImageUrl(serviceRequest))
+                .isInstanceOf(ProfileImageSizeOptionNotSupportedException.class)
+                .hasFieldOrPropertyWithValue("status", 404)
+                .hasFieldOrPropertyWithValue("errorCode", "P-04")
+                .hasFieldOrPropertyWithValue("errorMessage", "지원되지 않는 프로필 이미지 크기 옵션입니다. 현재 지원하는 옵션은 tiny, small, original 입니다.");
+
+        verify(userRepository).findByLoginId(LOGIN_ID);
+    }
+
+    @Test
+    @DisplayName("로그인 아이디로 사용자 프로필 이미지 썸네일 (tiny) URL을 조회한다." +
+            "썸네일 URL이 업데이트 되어 있지 않다면 스토리지에서 조회한 뒤, 썸네일 파일이 있다면 URL을 업데이트 하여 반환한다.")
+    void getProfileImagThumbnailTinyUrlNotUpdated() {
+        // Given
+        ProfileImageUrlServiceRequest serviceRequest = ProfileImageUrlServiceRequest.builder()
+                .userId(LOGIN_ID)
+                .size("tiny")
+                .build();
+
+        given(userRepository.findByLoginId(LOGIN_ID)).willReturn(Optional.of(UserFixture.COMMON_USER.getUser()));
+        given(storageService.getPathFromUrl("profileImageThumbnailTinyUrl")).willReturn("tiny-profileImagePath-notUpdated");
+        given(storageService.getPathFromUrl("profileImageUrl")).willReturn("profileImagePath");
+        given(storageService.hasResizedFiles("profileImagePath", "tiny")).willReturn(true);
+        given(storageService.getResizedUrl("profileImageUrl", "tiny")).willReturn("profileImageThumbnailTinyUrl");
+
+        // When
+        ProfileImageUrlServiceResponse profileImage = userService.getProfileImageUrl(serviceRequest);
+
+        // Then
+        assertThat(profileImage.getProfileImageUrl()).isEqualTo(UserFixture.COMMON_USER.getUser().getProfileImageThumbnailTinyUrl());
+
+        verify(userRepository).findByLoginId(LOGIN_ID);
+        verify(storageService).getPathFromUrl("profileImageThumbnailTinyUrl");
+        verify(storageService, times(2)).getPathFromUrl("profileImageUrl");
+        verify(storageService).hasResizedFiles("profileImagePath", "tiny");
+        verify(storageService).getResizedUrl("profileImageUrl", "tiny");
+    }
+
+    @Test
+    @DisplayName("로그인 아이디로 사용자 프로필 이미지 썸네일 (small) URL을 조회한다." +
+            "썸네일 URL이 업데이트 되어 있지 않다면 스토리지에서 조회한 뒤, 썸네일 파일이 있다면 URL을 업데이트 하여 반환한다.")
+    void getProfileImagThumbnailSmallUrlNotUpdated() {
+        // Given
+        ProfileImageUrlServiceRequest serviceRequest = ProfileImageUrlServiceRequest.builder()
+                .userId(LOGIN_ID)
+                .size("small")
+                .build();
+
+        given(userRepository.findByLoginId(LOGIN_ID)).willReturn(Optional.of(UserFixture.COMMON_USER.getUser()));
+        given(storageService.getPathFromUrl("profileImageThumbnailSmallUrl")).willReturn("small-profileImagePath-notUpdated");
+        given(storageService.getPathFromUrl("profileImageUrl")).willReturn("profileImagePath");
+        given(storageService.hasResizedFiles("profileImagePath", "small")).willReturn(true);
+        given(storageService.getResizedUrl("profileImageUrl", "small")).willReturn("profileImageThumbnailSmallUrl");
+
+        // When
+        ProfileImageUrlServiceResponse profileImage = userService.getProfileImageUrl(serviceRequest);
+
+        // Then
+        assertThat(profileImage.getProfileImageUrl()).isEqualTo(UserFixture.COMMON_USER.getUser().getProfileImageThumbnailSmallUrl());
+
+        verify(userRepository).findByLoginId(LOGIN_ID);
+        verify(storageService).getPathFromUrl("profileImageThumbnailSmallUrl");
+        verify(storageService, times(2)).getPathFromUrl("profileImageUrl");
+        verify(storageService).hasResizedFiles("profileImagePath", "small");
+        verify(storageService).getResizedUrl("profileImageUrl", "small");
+    }
+
+    @Test
+    @DisplayName("로그인 아이디로 사용자 프로필 이미지 썸네일 (tiny) URL을 조회한다." +
+            "썸네일 URL이 업데이트 되어 있지 않다면 스토리지에서 조회한 뒤, 썸네일 파일이 없다면 원본 URL을 반환한다.")
+    void getProfileImagThumbnailTinyUrlNotUpdatedNotStored() {
+        // Given
+        ProfileImageUrlServiceRequest serviceRequest = ProfileImageUrlServiceRequest.builder()
+                .userId(LOGIN_ID)
+                .size("tiny")
+                .build();
+
+        given(userRepository.findByLoginId(LOGIN_ID)).willReturn(Optional.of(UserFixture.COMMON_USER.getUser()));
+        given(storageService.getPathFromUrl("profileImageThumbnailTinyUrl")).willReturn("tiny-profileImagePath-notUpdated");
+        given(storageService.getPathFromUrl("profileImageUrl")).willReturn("profileImagePath");
+        given(storageService.hasResizedFiles("profileImagePath", "tiny")).willReturn(false);
+
+        // When
+        ProfileImageUrlServiceResponse profileImage = userService.getProfileImageUrl(serviceRequest);
+
+        // Then
+        assertThat(profileImage.getProfileImageUrl()).isEqualTo(UserFixture.COMMON_USER.getUser().getProfileImageUrl());
+
+        verify(userRepository).findByLoginId(LOGIN_ID);
+        verify(storageService).getPathFromUrl("profileImageThumbnailTinyUrl");
+        verify(storageService, times(2)).getPathFromUrl("profileImageUrl");
+        verify(storageService).hasResizedFiles("profileImagePath", "tiny");
+    }
+
+    @Test
+    @DisplayName("로그인 아이디로 사용자 프로필 이미지 썸네일 (small) URL을 조회한다." +
+            "썸네일 URL이 업데이트 되어 있지 않다면 스토리지에서 조회한 뒤, 썸네일 파일이 없다면 원본 URL을 반환한다.")
+    void getProfileImagThumbnailSmallUrlNotUpdatedNotStored() {
+        // Given
+        ProfileImageUrlServiceRequest serviceRequest = ProfileImageUrlServiceRequest.builder()
+                .userId(LOGIN_ID)
+                .size("small")
+                .build();
+
+        given(userRepository.findByLoginId(LOGIN_ID)).willReturn(Optional.of(UserFixture.COMMON_USER.getUser()));
+        given(storageService.getPathFromUrl("profileImageThumbnailSmallUrl")).willReturn("small-profileImagePath-notUpdated");
+        given(storageService.getPathFromUrl("profileImageUrl")).willReturn("profileImagePath");
+        given(storageService.hasResizedFiles("profileImagePath", "small")).willReturn(false);
+
+        // When
+        ProfileImageUrlServiceResponse profileImage = userService.getProfileImageUrl(serviceRequest);
+
+        // Then
+        assertThat(profileImage.getProfileImageUrl()).isEqualTo(UserFixture.COMMON_USER.getUser().getProfileImageUrl());
+
+        verify(userRepository).findByLoginId(LOGIN_ID);
+        verify(storageService).getPathFromUrl("profileImageThumbnailSmallUrl");
+        verify(storageService, times(2)).getPathFromUrl("profileImageUrl");
+        verify(storageService).hasResizedFiles("profileImagePath", "small");
     }
 
     @Test
@@ -316,26 +511,26 @@ class UserServiceImplTest {
     @DisplayName("로그인 아이디로 사용자 프로필 이미지를 수정한다")
     void updateProfileImage() throws Exception {
         // Given
-        ProfileImageUpdateServiceRequest serviceRequest = UserTestData.createProfileImageUpdateServiceRequest();
-        given(userRepository.findByLoginId(LOGIN_ID)).willReturn(
-                Optional.of(UserFixture.COMMON_USER.getUser()));
-        given(storageService.putFile(serviceRequest.getProfileImage(),
-                MultipartFileUtil.generateFilePath(PROFILE_IMAGE_PATH, LOGIN_ID, serviceRequest.getProfileImage())))
+        ProfileImageUpdateServiceRequest serviceRequest = ProfileImageUpdateServiceRequest.builder()
+                .userId(LOGIN_ID)
+                .loginId(LOGIN_ID)
+                .profileImage(UserTestData.createMockMultipartFile())
+                .localDateTime(LocalDateTime.of(2023, 1, 1, 0, 0, 0, 123000000))
+                .build();
+        given(userRepository.findByLoginId(LOGIN_ID)).willReturn(Optional.of(UserFixture.COMMON_USER.getUser()));
+        given(storageService.putFile(serviceRequest.getProfileImage(), "profile/profileImage/loginId/2023-01-01_00-00-00-123.jpg"))
                 .willReturn(PROFILE_IMAGE_BASE_URL + LOGIN_ID);
 
         // When
-        ProfileImageUrlServiceResponse updatedProfileImage = userService.updateProfileImage(
-                serviceRequest);
+        ProfileImageUrlServiceResponse updatedProfileImage = userService.updateProfileImage(serviceRequest);
 
         // Then
         assertAll(
-                () -> assertThat(updatedProfileImage.getProfileImageUrl()).isEqualTo(
-                        PROFILE_IMAGE_BASE_URL + LOGIN_ID)
+                () -> assertThat(updatedProfileImage.getProfileImageUrl()).isEqualTo(PROFILE_IMAGE_BASE_URL + LOGIN_ID)
         );
 
         verify(userRepository).findByLoginId(LOGIN_ID);
-        verify(storageService).putFile(serviceRequest.getProfileImage(),
-                MultipartFileUtil.generateFilePath(PROFILE_IMAGE_PATH, LOGIN_ID, serviceRequest.getProfileImage()));
+        verify(storageService).putFile(serviceRequest.getProfileImage(), "profile/profileImage/loginId/2023-01-01_00-00-00-123.jpg");
     }
 
     @Test
@@ -548,6 +743,9 @@ class UserServiceImplTest {
         // Given
         given(userRepository.findByNicknameContaining("nickname")).willReturn(
                 Arrays.asList(UserFixture.COMMON_USER.getUser(), UserFixture.USER_WITH_SIMILAR_NICKNAME.getUser()));
+        given(storageService.getPathFromUrl("profileImageThumbnailTinyUrl")).willReturn("tiny-profileImagePath");
+        given(storageService.getPathFromUrl("profileImageUrl")).willReturn("profileImagePath");
+
 
         // When
         SearchServiceResponse searchServiceResponse = userService.searchByNickname("nickname");
@@ -559,6 +757,8 @@ class UserServiceImplTest {
         );
 
         verify(userRepository).findByNicknameContaining("nickname");
+        verify(storageService, times(2)).getPathFromUrl("profileImageThumbnailTinyUrl");
+        verify(storageService, times(2)).getPathFromUrl("profileImageUrl");
     }
 
     @Test
@@ -619,6 +819,34 @@ class UserServiceImplTest {
                         UserInfoModel.builder().loginId("userId2").nickname("nickname2").profileImageUrl("profileImageUrl2").build(),
                         UserInfoModel.builder().loginId("userId3").nickname("nickname3").profileImageUrl("profileImageUrl3").build()));
 
+        given(userRepository.findByLoginId("userId1")).willReturn(Optional.ofNullable(User.builder()
+                .loginId("userId1")
+                .nickname("nickname1")
+                .profileImageUrl("profileImageUrl1")
+                .profileImageThumbnailTinyUrl("profileImageThumbnailTinyUrl1")
+                .build()));
+        given(storageService.getPathFromUrl("profileImageThumbnailTinyUrl1")).willReturn("tiny-profileImagePath1");
+        given(storageService.getPathFromUrl("profileImageUrl1")).willReturn("profileImagePath1");
+
+        given(userRepository.findByLoginId("userId2")).willReturn(Optional.ofNullable(User.builder()
+                .loginId("userId2")
+                .nickname("nickname2")
+                .profileImageUrl("profileImageUrl2")
+                .profileImageThumbnailTinyUrl("profileImageThumbnailTinyUrl2")
+                .build()));
+        given(storageService.getPathFromUrl("profileImageThumbnailTinyUrl2")).willReturn("tiny-profileImagePath2");
+        given(storageService.getPathFromUrl("profileImageUrl2")).willReturn("profileImagePath2");
+
+        given(userRepository.findByLoginId("userId3")).willReturn(Optional.ofNullable(User.builder()
+                .loginId("userId3")
+                .nickname("nickname3")
+                .profileImageUrl("profileImageUrl3")
+                .profileImageThumbnailTinyUrl("profileImageThumbnailTinyUrl3")
+                .build()));
+        given(storageService.getPathFromUrl("profileImageThumbnailTinyUrl3")).willReturn("tiny-profileImagePath3");
+        given(storageService.getPathFromUrl("profileImageUrl3")).willReturn("profileImagePath3");
+
+
         // When
         UserInfoServiceResponse userInfoServiceResponse = userService.getUserInfo(
                 UserInfoServiceRequest.builder().userIds(Arrays.asList("userId1", "userId2", "userId3")).build());
@@ -628,10 +856,12 @@ class UserServiceImplTest {
                 () -> assertThat(userInfoServiceResponse.getUserInfoElements()).hasSize(3),
                 () -> assertThat(userInfoServiceResponse.getUserInfoElements()).extracting("userId").containsExactly("userId1", "userId2", "userId3"),
                 () -> assertThat(userInfoServiceResponse.getUserInfoElements()).extracting("nickname").containsExactly("nickname1", "nickname2", "nickname3"),
-                () -> assertThat(userInfoServiceResponse.getUserInfoElements()).extracting("profileImageUrl").containsExactly("profileImageUrl1", "profileImageUrl2", "profileImageUrl3")
+                () -> assertThat(userInfoServiceResponse.getUserInfoElements()).extracting("profileImageUrl").containsExactly("profileImageThumbnailTinyUrl1", "profileImageThumbnailTinyUrl2", "profileImageThumbnailTinyUrl3")
         );
 
         verify(userRepository).findAllUserInfoByLoginIds(Arrays.asList("userId1", "userId2", "userId3"));
+        verify(userRepository, times(3)).findByLoginId(anyString());
+        verify(storageService, times(6)).getPathFromUrl(anyString());
     }
 
 }

--- a/backend/user-service/src/test/java/kr/mybrary/userservice/user/domain/dto/UserMapperTest.java
+++ b/backend/user-service/src/test/java/kr/mybrary/userservice/user/domain/dto/UserMapperTest.java
@@ -70,21 +70,4 @@ class UserMapperTest {
             () -> assertEquals(user.getIntroduction(), serviceResponse.getIntroduction())
         );
     }
-
-    @Test
-    @DisplayName("User 엔티티를 검색된 사용자 DTO로 변환한다.")
-    void toSearchedUser() {
-        // given
-        User user = UserFixture.COMMON_USER.getUser();
-
-        // when
-        SearchServiceResponse.SearchedUser searchedUser = UserMapper.INSTANCE.toSearchedUser(user);
-
-        // then
-        assertAll(
-            () -> assertEquals(user.getLoginId(), searchedUser.getUserId()),
-            () -> assertEquals(user.getNickname(), searchedUser.getNickname()),
-            () -> assertEquals(user.getProfileImageUrl(), searchedUser.getProfileImageUrl())
-        );
-    }
 }

--- a/backend/user-service/src/test/java/kr/mybrary/userservice/user/presentation/UserControllerTest.java
+++ b/backend/user-service/src/test/java/kr/mybrary/userservice/user/presentation/UserControllerTest.java
@@ -215,7 +215,7 @@ class UserControllerTest {
 
         ProfileServiceResponse profileServiceResponse = ProfileServiceResponse.builder()
                 .nickname(profileUpdateRequest.getNickname())
-                .profileImageUrl("profileImageUrl_1")
+                .profileImageUrl("profileImageUrl")
                 .introduction(profileUpdateRequest.getIntroduction())
                 .build();
 
@@ -288,16 +288,16 @@ class UserControllerTest {
     void getProfileImageUrl() throws Exception {
         // given
         ProfileImageUrlServiceResponse profileImageUrlServiceResponse = ProfileImageUrlServiceResponse.builder()
-                .profileImageUrl("profileImageUrl_1")
+                .profileImageUrl("tiny_profileImageUrl")
                 .build();
 
-        given(userService.getProfileImageUrl(anyString())).willReturn(
+        given(userService.getProfileImageUrl(any(ProfileImageUrlServiceRequest.class))).willReturn(
                 profileImageUrlServiceResponse);
 
         // when
         ResultActions actions = mockMvc.perform(
                 RestDocumentationRequestBuilders.get(BASE_URL+"/{userId}/profile/image", USER_ID)
-                        .with(csrf()));
+                        .param("size", "tiny"));
 
         // then
         actions
@@ -307,7 +307,7 @@ class UserControllerTest {
                 .andExpect(jsonPath("$.data.profileImageUrl").value(
                         profileImageUrlServiceResponse.getProfileImageUrl()));
 
-        verify(userService).getProfileImageUrl(anyString());
+        verify(userService).getProfileImageUrl(any(ProfileImageUrlServiceRequest.class));
 
         // docs
         actions.andDo(document("get-user-profile-image",
@@ -317,9 +317,13 @@ class UserControllerTest {
                         ResourceSnippetParameters.builder()
                                 .tag("user-profile")
                                 .summary("사용자의 프로필 이미지 URL을 조회한다.")
+                                .description("size는 tiny, small, original이 가능하다. 기본값은 original이다. 리사이징 된 이미지가 없으면 original 이미지 url을 반환한다.")
                                 .requestSchema(Schema.schema("get_user_profile_image_request_body"))
                                 .pathParameters(
                                         parameterWithName("userId").description("사용자의 아이디")
+                                )
+                                .queryParameters(
+                                        parameterWithName("size").type(SimpleType.STRING).description("프로필 이미지의 크기")
                                 )
                                 .responseSchema(
                                         Schema.schema("get_user_profile_image_response_body"))
@@ -341,10 +345,10 @@ class UserControllerTest {
     void updateProfileImage() throws Exception {
         // given
         MockMultipartFile profileImage = new MockMultipartFile("profileImage", "user1.png", "image/jpg",
-                "profileImage".getBytes());
+                "new_profileImage".getBytes());
 
         ProfileImageUrlServiceResponse profileImageUrlServiceResponse = ProfileImageUrlServiceResponse.builder()
-                .profileImageUrl("profileImageUrl")
+                .profileImageUrl("new_profileImageUrl")
                 .build();
 
         given(userService.updateProfileImage(any(ProfileImageUpdateServiceRequest.class))).willReturn(
@@ -408,7 +412,7 @@ class UserControllerTest {
     void deleteProfileImage() throws Exception {
         // given
         ProfileImageUrlServiceResponse profileImageUrlServiceResponse = ProfileImageUrlServiceResponse.builder()
-                .profileImageUrl("profileImageUrl_1")
+                .profileImageUrl("default_profileImageUrl")
                 .build();
 
         given(userService.deleteProfileImage(any(ProfileImageUpdateServiceRequest.class))).willReturn(


### PR DESCRIPTION
## 🧑‍💻 작업 사항

### 1. 프로필 이미지 저장 경로 수정
- 기존: profile/profileImage/userId.jpg
- 변경: profile/profileImage/userId/2023-08-21_16-21-34-146.jpg

- 기존 이미지에 덮어씌우지 않고 수정 일시의 타임스탬프 파일명으로 새로운 파일을 업로드합니다.
- 저장된 파일이 너무 많다 싶으면 한 달 간격으로 예전 파일을 삭제하는 것도 고려해보겠습니다.

### 2. 프로필 이미지 리사이징
- profile/profileImage/ 에 새로운 파일이 올라오면 해당 파일을 리사이징 하여 resized 버킷에 저장하는 lambda 함수를 추가했습니다.
- 현재 리사이징은 1/20 로 축소하는 tiny와 1/10 로 축소하는 small이 있습니다.
- 리사이징 함수는 다음과 같습니다.
```
def resize_image_tiny(image_path, resized_path):
  with Image.open(image_path) as image:
    image.thumbnail(tuple(x / 20 for x in image.size))
    image.save(resized_path)

def resize_image_small(image_path, resized_path):
  with Image.open(image_path) as image:
    image.thumbnail(tuple(x / 10 for x in image.size))
    image.save(resized_path)

def lambda_handler(event, context):
  for record in event['Records']:
    bucket = record['s3']['bucket']['name']
    key = unquote_plus(record['s3']['object']['key'])
    tmpkey = key.replace('/', '')
    download_path = '/tmp/{}{}'.format(uuid.uuid4(), tmpkey)
    s3_client.download_file(bucket, key, download_path)

    response = s3_client.head_object(Bucket=bucket, Key=key)
    content_type = response['ContentType']

    upload_path_tiny = '/tmp/tiny-{}'.format(tmpkey)
    resize_image_tiny(download_path, upload_path_tiny)
    s3_client.upload_file(upload_path_tiny, '{}-resized'.format(bucket), 'tiny-{}'.format(key), ExtraArgs={'ContentType': content_type, 'ContentDisposition': 'inline; filename=tiny-{}'.format(key)})

    upload_path_small = '/tmp/small-{}'.format(tmpkey)
    resize_image_small(download_path, upload_path_small)
    s3_client.upload_file(upload_path_small, '{}-resized'.format(bucket), 'small-{}'.format(key), ExtraArgs={'ContentType': content_type, 'ContentDisposition': 'inline; filename=small-{}'.format(key)})
```
- aws 예제 코드를 참고해 작성하였고, 중복되는 코드가 조금 아쉬워서 다음에 수정해보겠습니다 😅

### 3. 프로필 이미지 조회 API 수정
- 기존: 프로필 이미지 원본 url 반환
- 변경: size 를 쿼리 파라미터로 받아, 요청된 size에 해당하는 프로필 이미지 썸네일 url 반화
- size는 tiny, small, original이 있고 size 생략 시 original로 요청됩니다.

- 사용자가 프로필 이미지를 수정해 profile.jpg 파일이 업로드 되면, lambda가 이벤트를 감지해 리사이징 작업 후 tiny-profile.jpg와 small-profile.jpg를 업로드 합니다.
- 이때 리사이징 작업에 시간이 소요되기 때문에, 프로필 이미지 수정 즉시 리사이징된 이미지 url을 응답하면 해당 url로 파일을 찾을 수 없는 문제가 발생합니다.
- 따라서 리사이징된 이미지 url을 응답할 때, 다음과 같은 과정을 거칩니다.
```
1. user 테이블에서 썸네일 url이 업데이트 되어 있는지 확인한다. (원본 이미지 url의 타임스탬프와 썸네일 url의 타임스탬프 비교)
2. 업데이트 되어 있다면, 바로 썸네일 url을 반환한다.
3. 업데이트 되어 있지 않다면, resize 버킷에서 리사이징된 썸네일 파일을 찾는다.
4. 썸네일 파일이 있으면, 해당 썸네일 url을 테이블에 저장하고 반환한다.
5. 썸네일 파일이 없으면, 원본 이미지 url을 반환한다.
```

### 4. 사용자 검색, UserInfo 응답 값 변경
- 기존) profileImageUrl에 원본 이미지 url 반환
- 변경) profileImageUrl에 썸네일(tiny) 이미지 url 반환

### 5. 소셜 로그인 시 마이브러리 기본 이미지 지정
- 기존) 각 플랫폼에서 받아온 프로필 이미지 url 저장
- 변경) 마이브러리 기본 이미지 url로 저장

<br><br>

## 🔗 링크

<br><br>

## 🐰 시급한 정도

🏃‍♂️ 보통 : 최대한 빠르게 리뷰 부탁드립니다.


<br><br>

## 📖 참고 사항

### 사용자 검색, UserInfo 응답 시 썸네일 url 반환값 관련
- 썸네일 url 반환 시, 바로 테이블에서 썸네일 url을 가져올 수 있지만,
- 썸네일 url이 업데이트 되지 않았을 수 있기에 작업사항 3 에서 설명한 로직대로 '업데이트 확인' 과정을 거치고 있습니다.
- 따라서 쿼리가 한 번 씩 더 나가게 되는데, 특히 UserInfo는 쿼리를 최적화 하기 위해 QueryDsl을 적용했지만
- 결국 userRepository.findUserByLoginId가 추가되어 QueryDsl을 적용한 의미가 없어졌습니다. 🥲
- 다음에 어떻게 개선하면 좋을 지 의논해보면 좋겠습니다.

### lamda 이미지 리사이징 관련 레퍼런스
[AWS Lambda Image Resize 도입기](https://oliveyoung.tech/blog/2023-05-19/aws-lambda-resize/)
[자습서: Amazon S3 트리거를 사용하여 썸네일 이미지 생성](https://docs.aws.amazon.com/ko_kr/lambda/latest/dg/with-s3-tutorial.html)
