### PR TITLE
[IDLE-228] Resilience4j Retry, CircuitBreaker 적용

### DIFF
--- a/backend/book-service/build.gradle
+++ b/backend/book-service/build.gradle
@@ -71,6 +71,9 @@ dependencies {
 
 	// h2
 	runtimeOnly 'com.h2database:h2'
+
+	// resilience4j
+	implementation "io.github.resilience4j:resilience4j-spring-boot3"
 }
 
 tasks.named('test') {

--- a/backend/book-service/src/main/java/kr/mybrary/bookservice/booksearch/domain/exception/AladinApiUnavailableException.java
+++ b/backend/book-service/src/main/java/kr/mybrary/bookservice/booksearch/domain/exception/AladinApiUnavailableException.java
@@ -1,0 +1,15 @@
+package kr.mybrary.bookservice.booksearch.domain.exception;
+
+import kr.mybrary.bookservice.global.exception.ApplicationException;
+
+public class AladinApiUnavailableException extends ApplicationException {
+
+    private final static int STATUS = 404;
+    private final static String ERROR_CODE = "B-11";
+    private final static String ERROR_MESSAGE = "알라딘 API 서버가 응답하지 않습니다.";
+
+    public AladinApiUnavailableException() {
+        super(STATUS, ERROR_CODE, ERROR_MESSAGE);
+    }
+
+}

--- a/backend/book-service/src/main/java/kr/mybrary/bookservice/client/user/api/UserServiceClient.java
+++ b/backend/book-service/src/main/java/kr/mybrary/bookservice/client/user/api/UserServiceClient.java
@@ -1,8 +1,11 @@
 package kr.mybrary.bookservice.client.user.api;
 
 import feign.Headers;
+import io.github.resilience4j.retry.annotation.Retry;
 import kr.mybrary.bookservice.client.user.dto.request.UserInfoRequest;
 import kr.mybrary.bookservice.client.user.dto.response.UserInfoServiceResponse;
+import kr.mybrary.bookservice.client.user.dto.response.UserInfoServiceResponse.UserInfoList;
+import org.jetbrains.annotations.NotNull;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -10,8 +13,33 @@ import org.springframework.web.bind.annotation.RequestBody;
 @FeignClient(name = "user-service")
 public interface UserServiceClient {
 
+    String DEFAULT_PROFILE_IMAGE_URL = "https://mybrary-user-service-resized.s3.ap-northeast-2.amazonaws.com/tiny-profile/profileImage/default.jpg";
+    
     @PostMapping("/api/v1/users/info")
     @Headers("Content-Type: application/json")
+    @Retry(name = "userServiceRetryConfig", fallbackMethod = "getUsersInfoFallback")
     UserInfoServiceResponse getUsersInfo(@RequestBody UserInfoRequest userInfoRequest);
 
+    default UserInfoServiceResponse getUsersInfoFallback(UserInfoRequest userInfoRequest, Exception ex) {
+        return UserInfoServiceResponse.builder()
+                .data(makeTemporaryResponse(userInfoRequest))
+                .build();
+    }
+
+    private UserInfoList makeTemporaryResponse(UserInfoRequest userInfoRequest) {
+        return UserInfoList.builder()
+                .userInfoElements(userInfoRequest.getUserIds().stream()
+                        .map(userId -> UserInfoServiceResponse.UserInfo.builder()
+                                .userId(userId)
+                                .nickname(makeTemporaryNickname(userId))
+                                .profileImageUrl(DEFAULT_PROFILE_IMAGE_URL)
+                                .build()
+                        ).toList()
+        ).build();
+    }
+
+    @NotNull
+    private String makeTemporaryNickname(String userId) {
+        return "user_" + userId.substring(0, 5).toLowerCase();
+    }
 }

--- a/backend/book-service/src/main/java/kr/mybrary/bookservice/client/user/api/UserServiceClient.java
+++ b/backend/book-service/src/main/java/kr/mybrary/bookservice/client/user/api/UserServiceClient.java
@@ -1,6 +1,7 @@
 package kr.mybrary.bookservice.client.user.api;
 
 import feign.Headers;
+import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
 import io.github.resilience4j.retry.annotation.Retry;
 import kr.mybrary.bookservice.client.user.dto.request.UserInfoRequest;
 import kr.mybrary.bookservice.client.user.dto.response.UserInfoServiceResponse;
@@ -18,6 +19,7 @@ public interface UserServiceClient {
     @PostMapping("/api/v1/users/info")
     @Headers("Content-Type: application/json")
     @Retry(name = "userServiceRetryConfig", fallbackMethod = "getUsersInfoFallback")
+    @CircuitBreaker(name = "userServiceCircuitBreakerConfig", fallbackMethod = "getUsersInfoFallback")
     UserInfoServiceResponse getUsersInfo(@RequestBody UserInfoRequest userInfoRequest);
 
     default UserInfoServiceResponse getUsersInfoFallback(UserInfoRequest userInfoRequest, Exception ex) {

--- a/backend/book-service/src/main/java/kr/mybrary/bookservice/global/config/Resilience4jConfig.java
+++ b/backend/book-service/src/main/java/kr/mybrary/bookservice/global/config/Resilience4jConfig.java
@@ -1,0 +1,38 @@
+package kr.mybrary.bookservice.global.config;
+
+import io.github.resilience4j.core.registry.EntryAddedEvent;
+import io.github.resilience4j.core.registry.EntryRemovedEvent;
+import io.github.resilience4j.core.registry.EntryReplacedEvent;
+import io.github.resilience4j.core.registry.RegistryEventConsumer;
+import io.github.resilience4j.retry.Retry;
+import lombok.extern.slf4j.Slf4j;
+import org.jetbrains.annotations.NotNull;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@Slf4j
+public class Resilience4jConfig {
+
+    @Bean
+    public RegistryEventConsumer<Retry> myRegistryEventConsumer() {
+
+        return new RegistryEventConsumer<>() {
+            @Override
+            public void onEntryAddedEvent(@NotNull EntryAddedEvent<Retry> entryAddedEvent) {
+                log.info("RegistryEventConsumer.onEntryAddedEvent");
+                entryAddedEvent.getAddedEntry().getEventPublisher().onEvent(event -> log.info(event.toString()));
+            }
+
+            @Override
+            public void onEntryRemovedEvent(@NotNull EntryRemovedEvent<Retry> entryRemoveEvent) {
+                log.info("RegistryEventConsumer.onEntryRemovedEvent");
+            }
+
+            @Override
+            public void onEntryReplacedEvent(@NotNull EntryReplacedEvent<Retry> entryReplacedEvent) {
+                log.info("RegistryEventConsumer.onEntryReplacedEvent");
+            }
+        };
+    }
+}

--- a/backend/book-service/src/main/resources/application-dev.yml
+++ b/backend/book-service/src/main/resources/application-dev.yml
@@ -5,6 +5,9 @@ spring:
   application:
     name: book-service
 
+  config:
+    import: classpath:application-resilience4j.yml
+
   jpa:
     hibernate:
       ddl-auto: create

--- a/backend/book-service/src/main/resources/application-local.yml
+++ b/backend/book-service/src/main/resources/application-local.yml
@@ -2,6 +2,9 @@ spring:
   application:
     name: book-service
 
+  config:
+    import: classpath:application-resilience4j.yml
+
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
     url: jdbc:mysql://localhost:3306/mybrary

--- a/backend/book-service/src/main/resources/application-resilience4j.yml
+++ b/backend/book-service/src/main/resources/application-resilience4j.yml
@@ -1,0 +1,13 @@
+resilience4j.retry:
+  configs:
+    aladinApiRetryConfig:
+      maxAttempts: 3
+      waitDuration: 1000
+      retryExceptions:
+        - org.springframework.web.client.HttpServerErrorException
+        - org.springframework.web.client.ResourceAccessException
+        - java.net.SocketTimeoutException
+
+  instances:
+    aladinAPIRetryConfig:
+      baseConfig: aladinApiRetryConfig

--- a/backend/book-service/src/main/resources/application-resilience4j.yml
+++ b/backend/book-service/src/main/resources/application-resilience4j.yml
@@ -7,11 +7,14 @@ resilience4j.retry:
         - org.springframework.web.client.HttpServerErrorException
         - org.springframework.web.client.ResourceAccessException
         - java.net.SocketTimeoutException
+        - java.net.ConnectException
     userServiceFeignClientRetryConfig:
       maxAttempts: 3
       waitDuration: 1000
       retryExceptions:
         - java.net.UnknownHostException
+        - java.net.SocketTimeoutException
+        - java.net.ConnectException
         - feign.RetryableException
         - feign.FeignException.InternalServerError
         - feign.FeignException.BadGateway
@@ -23,3 +26,30 @@ resilience4j.retry:
       baseConfig: aladinApiRetryConfig
     userServiceRetryConfig:
       baseConfig: userServiceFeignClientRetryConfig
+
+resilience4j.circuitbreaker:
+  configs:
+    aladinApiCircuitBreakerConfig:
+      slidingWindowType: COUNT_BASED
+      minimumNumberOfCalls: 10
+      slidingWindowSize: 10
+      waitDurationInOpenState: 10s
+
+      failureRateThreshold: 50
+
+      slowCallDurationThreshold: 10000
+      slowCallRateThreshold: 100
+
+      permittedNumberOfCallsInHalfOpenState: 10
+      automaticTransitionFromOpenToHalfOpenEnabled: true
+
+      eventConsumerBufferSize: 100
+
+      recordExceptions:
+        - org.springframework.web.client.HttpServerErrorException
+        - org.springframework.web.client.ResourceAccessException
+        - java.net.SocketTimeoutException
+        - java.net.ConnectException
+  instances:
+    aladinAPICircuitBreakerConfig:
+      baseConfig: aladinApiCircuitBreakerConfig

--- a/backend/book-service/src/main/resources/application-resilience4j.yml
+++ b/backend/book-service/src/main/resources/application-resilience4j.yml
@@ -50,6 +50,33 @@ resilience4j.circuitbreaker:
         - org.springframework.web.client.ResourceAccessException
         - java.net.SocketTimeoutException
         - java.net.ConnectException
+    userServiceFeignClientCircuitBreakerConfig:
+      slidingWindowType: COUNT_BASED
+      minimumNumberOfCalls: 10
+      slidingWindowSize: 10
+      waitDurationInOpenState: 10s
+
+      failureRateThreshold: 50
+
+      slowCallDurationThreshold: 10000
+      slowCallRateThreshold: 100
+
+      permittedNumberOfCallsInHalfOpenState: 10
+      automaticTransitionFromOpenToHalfOpenEnabled: true
+
+      eventConsumerBufferSize: 100
+
+      recordExceptions:
+        - java.net.UnknownHostException
+        - java.net.SocketTimeoutException
+        - java.net.ConnectException
+        - feign.RetryableException
+        - feign.FeignException.InternalServerError
+        - feign.FeignException.BadGateway
+        - feign.FeignException.GatewayTimeout
+        - feign.FeignException.TooManyRequests
   instances:
     aladinAPICircuitBreakerConfig:
       baseConfig: aladinApiCircuitBreakerConfig
+    userServiceCircuitBreakerConfig:
+      baseConfig: userServiceFeignClientCircuitBreakerConfig

--- a/backend/book-service/src/main/resources/application-resilience4j.yml
+++ b/backend/book-service/src/main/resources/application-resilience4j.yml
@@ -7,7 +7,19 @@ resilience4j.retry:
         - org.springframework.web.client.HttpServerErrorException
         - org.springframework.web.client.ResourceAccessException
         - java.net.SocketTimeoutException
+    userServiceFeignClientRetryConfig:
+      maxAttempts: 3
+      waitDuration: 1000
+      retryExceptions:
+        - java.net.UnknownHostException
+        - feign.RetryableException
+        - feign.FeignException.InternalServerError
+        - feign.FeignException.BadGateway
+        - feign.FeignException.GatewayTimeout
+        - feign.FeignException.TooManyRequests
 
   instances:
     aladinAPIRetryConfig:
       baseConfig: aladinApiRetryConfig
+    userServiceRetryConfig:
+      baseConfig: userServiceFeignClientRetryConfig

--- a/backend/book-service/src/test/java/kr/mybrary/bookservice/booksearch/domain/AladinBookSearchApiServiceTest.java
+++ b/backend/book-service/src/test/java/kr/mybrary/bookservice/booksearch/domain/AladinBookSearchApiServiceTest.java
@@ -256,7 +256,7 @@ class AladinBookSearchApiServiceTest {
 
         // then
         assertAll(
-                () -> assertThat(response.getBooks().size()).isEqualTo(10)
+                () -> assertThat(response.getBooks().size()).isLessThan(11)
         );
     }
 


### PR DESCRIPTION
## 🧑‍💻 작업 사항

### 알라딘 API 호출과 FeignClient 호출에 Retry와 CircuitBreaker 적용
- `Resilience4j` 사용하였습니다. 아래는 한글로 번역된 문서와 공식문서입니다.
- https://godekdls.github.io/Spring%20Cloud%20Circuit%20Breaker/contents/
- https://resilience4j.readme.io/docs

### Retry 적용 확인
```
userServiceFeignClientRetryConfig:
  maxAttempts: 3
  waitDuration: 1000
  retryExceptions:
    - java.net.UnknownHostException
    - java.net.SocketTimeoutException
    - java.net.ConnectException
    - feign.RetryableException
    - feign.FeignException.InternalServerError
    - feign.FeignException.BadGateway
    - feign.FeignException.GatewayTimeout
    - feign.FeignException.TooManyRequests
```
```
2023-08-29T05:27:57.455+09:00  WARN 61321 --- [nio-8080-exec-1] o.s.c.l.core.RoundRobinLoadBalancer      : No servers available for service: user-service
2023-08-29T05:27:57.457+09:00  WARN 61321 --- [nio-8080-exec-1] RetryableFeignBlockingLoadBalancerClient : Service instance was not resolved, executing the original request
2023-08-29T05:27:57.471+09:00  INFO 61321 --- [nio-8080-exec-1] k.m.b.global.config.Resilience4jConfig   : 2023-08-29T05:27:57.466939+09:00[Asia/Seoul]: Retry 'userServiceRetryConfig', waiting PT1S until attempt '1'. Last attempt failed with exception 'feign.RetryableException: user-service executing POST http://user-service/api/v1/users/info'.
2023-08-29T05:27:58.481+09:00  WARN 61321 --- [nio-8080-exec-1] o.s.c.l.core.RoundRobinLoadBalancer      : No servers available for service: user-service
2023-08-29T05:27:58.481+09:00  WARN 61321 --- [nio-8080-exec-1] RetryableFeignBlockingLoadBalancerClient : Service instance was not resolved, executing the original request
2023-08-29T05:27:58.483+09:00  INFO 61321 --- [nio-8080-exec-1] k.m.b.global.config.Resilience4jConfig   : 2023-08-29T05:27:58.482801+09:00[Asia/Seoul]: Retry 'userServiceRetryConfig', waiting PT1S until attempt '2'. Last attempt failed with exception 'feign.RetryableException: user-service executing POST http://user-service/api/v1/users/info'.
2023-08-29T05:27:59.489+09:00  WARN 61321 --- [nio-8080-exec-1] o.s.c.l.core.RoundRobinLoadBalancer      : No servers available for service: user-service
2023-08-29T05:27:59.489+09:00  WARN 61321 --- [nio-8080-exec-1] RetryableFeignBlockingLoadBalancerClient : Service instance was not resolved, executing the original request
2023-08-29T05:27:59.492+09:00  INFO 61321 --- [nio-8080-exec-1] k.m.b.global.config.Resilience4jConfig   : 2023-08-29T05:27:59.491805+09:00[Asia/Seoul]: Retry 'userServiceRetryConfig' recorded a failed retry attempt. Number of retry attempts: '3'. Giving up. Last exception was: 'feign.RetryableException: user-service executing POST http://user-service/api/v1/users/info'.
2023-08-29T05:27:59.498+09:00  INFO 61321 --- [nio-8080-exec-1] k.m.b.review.domain.MyReviewReadService  : usersInfo: [kr.mybrary.bookservice.client.user.dto.response.UserInfoServiceResponse$UserInfo@2145fb86, kr.mybrary.bookservice.client.user.dto.response.UserInfoServiceResponse$UserInfo@6e797be9, kr.mybrary.bookservice.client.user.dto.response.UserInfoServiceResponse$UserInfo@4df0fafd]
2023-08-29T05:27:59.505+09:00  INFO 61321 --- [nio-8080-exec-1] k.m.b.g.aspect.RequestLoggingAspect      : Request: GET /api/v1/books/9791158512767/reviews < 0:0:0:0:0:0:0:1 (2506ms)
```
- Retry의 설정 중 `retryExceptions`에 해당 하는 예외 발생시, 1초 간격으로 3번의 재시도가 일어남을 확인할 수 있습니다. (위의 설정값에 따라)
- `retryExceptions`의 경우 네트워크 문제 혹은 일시적인 서버 문제로인해 발생할 수 있는 예외에 대해서 설정하였습니다.
- `retryExceptions`와 `maxAttempts`, `waitDuration` 값에 대한 적절한 값은 지속적으로 테스트를 진행해보며 설정해야 할 것 같습니다.

### CircuitBreaker 적용 확인
```
slidingWindowType: COUNT_BASED
minimumNumberOfCalls: 10
slidingWindowSize: 10
waitDurationInOpenState: 10s

failureRateThreshold: 50

slowCallDurationThreshold: 10000
slowCallRateThreshold: 100

permittedNumberOfCallsInHalfOpenState: 10
automaticTransitionFromOpenToHalfOpenEnabled: true

eventConsumerBufferSize: 100
```

```
{
   "circuitBreakerEvents":[
      {
         "circuitBreakerName":"userServiceCircuitBreakerConfig",
         "type":"ERROR",
         "creationTime":"2023-08-30T00:57:50.129101+09:00[Asia/Seoul]",
         "errorMessage":"feign.RetryableException: user-service executing POST http://user-service/api/v1/users/info",
         "durationInMs":160,
         "stateTransition":null
      },
      {
         "circuitBreakerName":"userServiceCircuitBreakerConfig",
         "type":"ERROR",
         "creationTime":"2023-08-30T00:57:50.957647+09:00[Asia/Seoul]",
         "errorMessage":"feign.RetryableException: user-service executing POST http://user-service/api/v1/users/info",
         "durationInMs":2,
         "stateTransition":null
      },
      {
         "circuitBreakerName":"userServiceCircuitBreakerConfig",
         "type":"ERROR",
         "creationTime":"2023-08-30T00:57:51.888410+09:00[Asia/Seoul]",
         "errorMessage":"feign.RetryableException: user-service executing POST http://user-service/api/v1/users/info",
         "durationInMs":2,
         "stateTransition":null
      },
      {
         "circuitBreakerName":"userServiceCircuitBreakerConfig",
         "type":"ERROR",
         "creationTime":"2023-08-30T00:57:52.884369+09:00[Asia/Seoul]",
         "errorMessage":"feign.RetryableException: user-service executing POST http://user-service/api/v1/users/info",
         "durationInMs":2,
         "stateTransition":null
      },
      {
         "circuitBreakerName":"userServiceCircuitBreakerConfig",
         "type":"ERROR",
         "creationTime":"2023-08-30T00:57:53.850780+09:00[Asia/Seoul]",
         "errorMessage":"feign.RetryableException: user-service executing POST http://user-service/api/v1/users/info",
         "durationInMs":1,
         "stateTransition":null
      },
      {
         "circuitBreakerName":"userServiceCircuitBreakerConfig",
         "type":"ERROR",
         "creationTime":"2023-08-30T00:57:54.921101+09:00[Asia/Seoul]",
         "errorMessage":"feign.RetryableException: user-service executing POST http://user-service/api/v1/users/info",
         "durationInMs":2,
         "stateTransition":null
      },
      {
         "circuitBreakerName":"userServiceCircuitBreakerConfig",
         "type":"ERROR",
         "creationTime":"2023-08-30T00:57:55.993618+09:00[Asia/Seoul]",
         "errorMessage":"feign.RetryableException: user-service executing POST http://user-service/api/v1/users/info",
         "durationInMs":3,
         "stateTransition":null
      },
      {
         "circuitBreakerName":"userServiceCircuitBreakerConfig",
         "type":"ERROR",
         "creationTime":"2023-08-30T00:57:57.132301+09:00[Asia/Seoul]",
         "errorMessage":"feign.RetryableException: user-service executing POST http://user-service/api/v1/users/info",
         "durationInMs":2,
         "stateTransition":null
      },
      {
         "circuitBreakerName":"userServiceCircuitBreakerConfig",
         "type":"ERROR",
         "creationTime":"2023-08-30T00:57:58.145902+09:00[Asia/Seoul]",
         "errorMessage":"feign.RetryableException: user-service executing POST http://user-service/api/v1/users/info",
         "durationInMs":2,
         "stateTransition":null
      },
      {
         "circuitBreakerName":"userServiceCircuitBreakerConfig",
         "type":"ERROR",
         "creationTime":"2023-08-30T00:57:59.196012+09:00[Asia/Seoul]",
         "errorMessage":"feign.RetryableException: user-service executing POST http://user-service/api/v1/users/info",
         "durationInMs":3,
         "stateTransition":null
      },
      {
         "circuitBreakerName":"userServiceCircuitBreakerConfig",
         "type":"FAILURE_RATE_EXCEEDED",
         "creationTime":"2023-08-30T00:57:59.197829+09:00[Asia/Seoul]",
         "errorMessage":null,
         "durationInMs":null,
         "stateTransition":null
      },
      {
         "circuitBreakerName":"userServiceCircuitBreakerConfig",
         "type":"STATE_TRANSITION",
         "creationTime":"2023-08-30T00:57:59.203963+09:00[Asia/Seoul]",
         "errorMessage":null,
         "durationInMs":null,
         "stateTransition":"CLOSED_TO_OPEN"
      },
      {
         "circuitBreakerName":"userServiceCircuitBreakerConfig",
         "type":"NOT_PERMITTED",
         "creationTime":"2023-08-30T00:58:00.232438+09:00[Asia/Seoul]",
         "errorMessage":null,
         "durationInMs":null,
         "stateTransition":null
      },
      {
         "circuitBreakerName":"userServiceCircuitBreakerConfig",
         "type":"STATE_TRANSITION",
         "creationTime":"2023-08-30T00:58:10.103963+09:00[Asia/Seoul]",
         "errorMessage":null,
         "durationInMs":null,
         "stateTransition":"OPEN_TO_HALF_OPEN"
      }
   ]
}
```

- `Spring Actuator`의 `circuitbreakerevents` 엔드포인트를 통해 기록된 이벤트를 위와 같이 확인할 수 있습니다.
- `recordExceptions`에 등록된 예외가 10번 발생하여 circuitbreaker의 상태가 CLOSE에서 OPEN으로 전환된 것을 확인할 수 있습니다.
    - CLOSE : 정상적인 상태
    - OPEN : 차단된 상태 (이후 요청은 차단됩니다.)
    - HALF_OPEN : 차단 상태에서 정상적인 상태로 갈 수 있는지 확인하는 상태
- `slidingWindowSize`와 `minimumNumberOfCalls`가 10이므로, 10번째 요청까지 확인 이후 11번째 요청에서 `failureRateThreshold`을 계산하여 circuitbreaker 상태를 OPEN으로 전환할지 결정한다. 실제 10번 중에 10번 모두 실패하였기에, `failureRateThreshold`의 수치가 넘어 12번째 요청에서 CLOSE에서 OPEN 상태로 전환됨을 확인할 수 있습니다.
- `waitDurationInOpenState`가 10s이기 때문에, OPEN 상태에서 10초가 지난 이후 HALF_OPEN으로 자동으로 전환됨을 확인할 수 있습니다.
    - `automaticTransitionFromOpenToHalfOpenEnabled`가 true이기 때문에 10초 이후 자동으로 전환이 되었으며,
    - false 라면 10초 이후 다음 요청이 발생하면 HALF_OPEN으로 전환됩니다.
- `permittedNumberOfCallsInHalfOpenState`를 통해 HALF_OPEN 상태에서 10번째까지의 요청을 받아 OPEN 상태로 넘어갈지, CLOSE 상태로 전환할지 결정합니다.
    - HALF_OPEN에서의 `slidingWindowSize`라고 생각하면 좋을 것 같습니다. 
- circuitbreaker 설정값 또한 적절한 설정값을 찾기 위해서 스트레스 테스트 등 여러 테스트 과정을 통해 해봐야할 것 같습니다.

### feignClient를 통해 POST "/api/v1/users/info" 요청 실패시 fallback 함수 정의
- feignClient를 통해 해당 API 요청을 보냈을 때 실패하였다면, Retry과 CircuitBreaker를 통해 `fallback 함수`가 동작합니다.
- 유저의 닉네임과 프로필 사진은 도서 리뷰를 조회할 때, 리뷰에 비해 중요한 데이터가 아니기 때문에, 아래와 같이 임시의 유저 닉네임과 default 프로필 사진 URL을 반환하도록 구현하였습니다.
- 결과적으로 user-service가 일시적으로 문제가 발생하거나, 동작하지 않는 상태에서도 book-service에는 장애가 전파되지 않도록 fallback 함수를 구현하였습니다.
![image](https://github.com/SWM-IDLE/mybrary/assets/71378475/dd20dec1-2369-4ea5-9e58-e85517744144)

<br/>

**코드 리뷰시 궁금한 점이나 이해가 되지 않는 점이 있으면 언제든지 물어봐주세요!!!!**
<br><br>

## 🔗 링크

<!-- 관련된 대화가 이루어진 슬랙 링크 혹은 피그마 링크를 첨부. -->
<!-- - [프레이머](https://framer.com/projects/2--gSDcZoNKqU6dqCUQUYQe-53rEr?node=tQMWSSKqy)  -->

<br><br>

## 🐰 시급한 정도

 🐢 천천히 : 급하지 않습니다.

<br><br>

## 📖 참고 사항

<!-- 공유할 내용, 레퍼런스, 추가로 발생할 것으로 예상되는 이슈, 스크린샷 등을 넣어 주세요.  -->
<!-- 변경사항이 큰 경우 집중해야 할 부분, 또는 불안해서 봐주었으면 하는 부분 등 -->
