### PR TITLE
[feat] Thymeleaf MPA 프론트엔드 전환 + 로컬 개발 환경 구성 (Phase 2)

### DIFF
--- a/MIGRATION_PLAN.md
+++ b/MIGRATION_PLAN.md
@@ -27,13 +27,15 @@
 - [x] **P1-08** API 경로 재설계 (/user-service/, /book-service/ 프리픽스 제거)
 - [x] **P1-09** CI/CD 파이프라인 통합 (ECS/ECR 단일화)
 
-### Phase 2 — 프론트엔드 WebView 전환 — `phase2/webview`
+### Phase 2 — 프론트엔드 Thymeleaf MPA 전환 — `phase2/webview`
 
-- [x] **P2-01** Flutter webview_flutter 도입 + Shell 구조 변경
-- [ ] **P2-02** JS Bridge 구현 (Flutter ↔ Web 양방향)
-- [ ] **P2-03** 소셜 로그인 JS Bridge 연동 (Kakao/Naver/Google)
-- [ ] **P2-04** API 경로 업데이트 + 웹 프론트엔드 API 설정
-- [ ] **P2-05** FCM 푸시 알림 + 카메라·갤러리 네이티브 연동 검증
+> Flutter WebView 대신 Thymeleaf MPA(서버사이드 렌더링)로 방향 변경
+
+- [x] **P2-01** Thymeleaf MPA 전체 페이지 구현 (login/signup/home/search/mybook/profile/interests/settings 등 14개 화면)
+- [x] **P2-02** 로컬 개발 환경 세팅 (Docker Compose MySQL+Redis + 파일 기반 로컬 스토리지)
+- [x] **P2-03** 로컬 시드 데이터 자동 초기화 (admin 계정 + 샘플 도서 10권 + MyBook 등록)
+- [x] **P2-04** 이중 SecurityFilterChain (/web/** 세션 기반 / /api/v1/** JWT 기반)
+- [x] **P2-05** Thymeleaf 3.1 #request 비활성화 이슈 수정 (@ModelAttribute currentPath 주입)
 
 ### Phase 3 — 정리 및 배포 — `phase3/cleanup`
 

--- a/MIGRATION_PLAN.md
+++ b/MIGRATION_PLAN.md
@@ -29,7 +29,7 @@
 
 ### Phase 2 — 프론트엔드 WebView 전환 — `phase2/webview`
 
-- [ ] **P2-01** Flutter webview_flutter 도입 + Shell 구조 변경
+- [x] **P2-01** Flutter webview_flutter 도입 + Shell 구조 변경
 - [ ] **P2-02** JS Bridge 구현 (Flutter ↔ Web 양방향)
 - [ ] **P2-03** 소셜 로그인 JS Bridge 연동 (Kakao/Naver/Google)
 - [ ] **P2-04** API 경로 업데이트 + 웹 프론트엔드 API 설정

--- a/backend/mybrary-server/.gitignore
+++ b/backend/mybrary-server/.gitignore
@@ -1,0 +1,1 @@
+local-uploads/

--- a/backend/mybrary-server/build.gradle
+++ b/backend/mybrary-server/build.gradle
@@ -39,6 +39,11 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-aop'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
 
+    // Thymeleaf MPA
+    implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
+    implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity6'
+    implementation 'nz.net.ultraq.thymeleaf:thymeleaf-layout-dialect'
+
     // Security + OAuth2
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'

--- a/backend/mybrary-server/docker-compose.yml
+++ b/backend/mybrary-server/docker-compose.yml
@@ -1,0 +1,32 @@
+services:
+  mysql:
+    image: mysql:8.0
+    container_name: mybrary-mysql
+    environment:
+      MYSQL_ROOT_PASSWORD: mybrary
+      MYSQL_DATABASE: mybrary
+      TZ: Asia/Seoul
+    ports:
+      - "3306:3306"
+    volumes:
+      - mybrary_mysql_data:/var/lib/mysql
+    command: --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-pmybrary"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  redis:
+    image: redis:7.2
+    container_name: mybrary-redis
+    ports:
+      - "6379:6379"
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+volumes:
+  mybrary_mysql_data:

--- a/backend/mybrary-server/src/main/java/kr/mybrary/global/config/LocalDataInitializer.java
+++ b/backend/mybrary-server/src/main/java/kr/mybrary/global/config/LocalDataInitializer.java
@@ -1,5 +1,13 @@
 package kr.mybrary.global.config;
 
+import kr.mybrary.book.persistence.Book;
+import kr.mybrary.book.persistence.bookInfo.Author;
+import kr.mybrary.book.persistence.bookInfo.BookAuthor;
+import kr.mybrary.book.persistence.bookInfo.BookCategory;
+import kr.mybrary.book.persistence.repository.BookCategoryRepository;
+import kr.mybrary.book.persistence.repository.BookRepository;
+import kr.mybrary.mybook.persistence.MyBook;
+import kr.mybrary.mybook.persistence.repository.MyBookRepository;
 import kr.mybrary.user.persistence.Role;
 import kr.mybrary.user.persistence.User;
 import kr.mybrary.user.persistence.repository.UserRepository;
@@ -9,6 +17,10 @@ import org.springframework.boot.CommandLineRunner;
 import org.springframework.context.annotation.Profile;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
 
 @Component
 @Profile("local")
@@ -18,29 +30,117 @@ public class LocalDataInitializer implements CommandLineRunner {
 
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
+    private final BookRepository bookRepository;
+    private final BookCategoryRepository bookCategoryRepository;
+    private final MyBookRepository myBookRepository;
 
     private static final String ADMIN_LOGIN_ID = "admin@mybrary.kr";
     private static final String ADMIN_NICKNAME = "admin";
     private static final String ADMIN_PASSWORD = "admin1234!";
 
     @Override
+    @Transactional
     public void run(String... args) {
-        if (!userRepository.existsByLoginId(ADMIN_LOGIN_ID)) {
-            User admin = User.builder()
-                    .loginId(ADMIN_LOGIN_ID)
-                    .nickname(ADMIN_NICKNAME)
-                    .password(passwordEncoder.encode(ADMIN_PASSWORD))
-                    .role(Role.ADMIN)
-                    .introduction("로컬 개발용 어드민 계정")
-                    .profileImageUrl("")
-                    .profileImageThumbnailTinyUrl("")
-                    .profileImageThumbnailSmallUrl("")
-                    .build();
-            userRepository.save(admin);
-            log.info("===== [LOCAL] 어드민 계정 생성 =====");
-            log.info("ID: {}", ADMIN_LOGIN_ID);
-            log.info("PW: {}", ADMIN_PASSWORD);
-            log.info("===================================");
-        }
+        User admin = initAdmin();
+        initBooks(admin);
     }
+
+    private User initAdmin() {
+        if (userRepository.existsByLoginId(ADMIN_LOGIN_ID)) {
+            return userRepository.findByLoginId(ADMIN_LOGIN_ID).orElseThrow();
+        }
+        User admin = User.builder()
+                .loginId(ADMIN_LOGIN_ID)
+                .nickname(ADMIN_NICKNAME)
+                .password(passwordEncoder.encode(ADMIN_PASSWORD))
+                .role(Role.ADMIN)
+                .introduction("로컬 개발용 어드민 계정")
+                .profileImageUrl("")
+                .profileImageThumbnailTinyUrl("")
+                .profileImageThumbnailSmallUrl("")
+                .build();
+        userRepository.save(admin);
+        log.info("===== [LOCAL] 어드민 계정 생성: {} / {} =====", ADMIN_LOGIN_ID, ADMIN_PASSWORD);
+        return admin;
+    }
+
+    private void initBooks(User admin) {
+        if (bookRepository.count() > 0) return;
+
+        BookCategory novel = bookCategoryRepository.save(BookCategory.builder().cid(1).name("소설").build());
+        BookCategory selfHelp = bookCategoryRepository.save(BookCategory.builder().cid(2).name("자기계발").build());
+        BookCategory science = bookCategoryRepository.save(BookCategory.builder().cid(3).name("과학").build());
+        BookCategory history = bookCategoryRepository.save(BookCategory.builder().cid(4).name("역사").build());
+        BookCategory it = bookCategoryRepository.save(BookCategory.builder().cid(5).name("IT/컴퓨터").build());
+
+        List<BookSeed> seeds = List.of(
+            new BookSeed("9788936434588", "채식주의자", "한강", "문학동네",
+                "https://image.aladin.co.kr/product/20/11/cover/8936434586_1.jpg",
+                "한강의 부커상 수상작. 평범한 여자가 어느 날 채식주의자가 되기로 결심하며 시작되는 이야기.", novel, 247, 13800),
+            new BookSeed("9788936433598", "소년이 온다", "한강", "창비",
+                "https://image.aladin.co.kr/product/7897/1/cover/8936433598_1.jpg",
+                "5·18 광주민주화운동을 배경으로 한 한강의 장편소설.", novel, 216, 14000),
+            new BookSeed("9788901259673", "아몬드", "손원평", "창비",
+                "https://image.aladin.co.kr/product/19504/13/cover/8901259672_1.jpg",
+                "감정을 느끼지 못하는 소년 윤재의 성장 이야기.", novel, 264, 13500),
+            new BookSeed("9788960776708", "미움받을 용기", "기시미 이치로", "인플루엔셜",
+                "https://image.aladin.co.kr/product/5466/13/cover/896077670X_2.jpg",
+                "아들러 심리학을 바탕으로 자유롭고 행복한 삶을 위한 철학적 대화.", selfHelp, 336, 15800),
+            new BookSeed("9788937460449", "코스모스", "칼 세이건", "사이언스북스",
+                "https://image.aladin.co.kr/product/163/43/cover/8937460440_1.jpg",
+                "칼 세이건의 우주 과학 명저. 인류와 우주의 관계를 탐구한다.", science, 758, 28000),
+            new BookSeed("9788934990772", "사피엔스", "유발 하라리", "김영사",
+                "https://image.aladin.co.kr/product/6247/90/cover/8934990775_2.jpg",
+                "인류의 역사를 거시적 관점으로 바라본 베스트셀러.", history, 636, 22000),
+            new BookSeed("9791162241691", "클린 코드", "로버트 C. 마틴", "인사이트",
+                "https://image.aladin.co.kr/product/1449/42/cover/8966260950_1.jpg",
+                "읽기 좋은 코드를 작성하는 방법을 설명하는 소프트웨어 개발 명저.", it, 584, 33000),
+            new BookSeed("9791190665162", "82년생 김지영", "조남주", "민음사",
+                "https://image.aladin.co.kr/product/16235/50/cover/8937488604_1.jpg",
+                "대한민국 평범한 여성의 삶을 통해 성차별 문제를 조명한 소설.", novel, 190, 13000),
+            new BookSeed("9788954631150", "원씽", "게리 켈러", "비즈니스북스",
+                "https://image.aladin.co.kr/product/5527/38/cover/895463115X_1.jpg",
+                "한 가지에 집중하는 삶의 방식을 제안하는 자기계발서.", selfHelp, 292, 16000),
+            new BookSeed("9791186900956", "파친코", "이민진", "인플루엔셜",
+                "https://image.aladin.co.kr/product/23558/27/cover/K762637011_1.jpg",
+                "재일교포 4대에 걸친 삶을 그린 대하 역사소설.", history, 864, 25000)
+        );
+
+        for (BookSeed s : seeds) {
+            Author author = Author.builder().aid(0).name(s.authorName).build();
+            Book book = Book.builder()
+                    .isbn13(s.isbn13)
+                    .title(s.title)
+                    .author(s.authorName)
+                    .thumbnailUrl(s.thumbnailUrl)
+                    .publisher(s.publisher)
+                    .description(s.description)
+                    .pages(s.pages)
+                    .priceStandard(s.price)
+                    .priceSales(s.price)
+                    .publicationDate(LocalDateTime.of(2020, 1, 1, 0, 0))
+                    .holderCount(0)
+                    .readCount(0)
+                    .interestCount(0)
+                    .starRating(0.0)
+                    .reviewCount(0)
+                    .aladinStarRating(0.0)
+                    .aladinReviewCount(0)
+                    .bookCategory(s.category)
+                    .build();
+
+            BookAuthor bookAuthor = BookAuthor.builder().author(author).build();
+            book.addBookAuthor(List.of(bookAuthor));
+            Book savedBook = bookRepository.save(book);
+
+            // 어드민 MyBook 등록
+            myBookRepository.save(MyBook.of(savedBook, ADMIN_LOGIN_ID));
+        }
+
+        log.info("===== [LOCAL] 샘플 도서 {}권 + MyBook 등록 완료 =====", seeds.size());
+    }
+
+    private record BookSeed(String isbn13, String title, String authorName, String publisher,
+                            String thumbnailUrl, String description, BookCategory category,
+                            int pages, int price) {}
 }

--- a/backend/mybrary-server/src/main/java/kr/mybrary/global/config/LocalDataInitializer.java
+++ b/backend/mybrary-server/src/main/java/kr/mybrary/global/config/LocalDataInitializer.java
@@ -65,7 +65,15 @@ public class LocalDataInitializer implements CommandLineRunner {
     }
 
     private void initBooks(User admin) {
-        if (bookRepository.count() > 0) return;
+        // 도서가 이미 있어도 admin MyBook이 없으면 등록
+        if (bookRepository.count() > 0) {
+            if (myBookRepository.countByUserId(ADMIN_LOGIN_ID) == 0) {
+                bookRepository.findAll().forEach(book ->
+                        myBookRepository.save(MyBook.of(book, ADMIN_LOGIN_ID)));
+                log.info("===== [LOCAL] admin MyBook {}권 재등록 완료 =====", bookRepository.count());
+            }
+            return;
+        }
 
         BookCategory novel = bookCategoryRepository.save(BookCategory.builder().cid(1).name("소설").build());
         BookCategory selfHelp = bookCategoryRepository.save(BookCategory.builder().cid(2).name("자기계발").build());

--- a/backend/mybrary-server/src/main/java/kr/mybrary/global/config/LocalDataInitializer.java
+++ b/backend/mybrary-server/src/main/java/kr/mybrary/global/config/LocalDataInitializer.java
@@ -34,9 +34,9 @@ public class LocalDataInitializer implements CommandLineRunner {
     private final BookCategoryRepository bookCategoryRepository;
     private final MyBookRepository myBookRepository;
 
-    private static final String ADMIN_LOGIN_ID = "admin@mybrary.kr";
+    private static final String ADMIN_LOGIN_ID = "admin";
     private static final String ADMIN_NICKNAME = "admin";
-    private static final String ADMIN_PASSWORD = "admin1234!";
+    private static final String ADMIN_PASSWORD = "admin";
 
     @Override
     @Transactional

--- a/backend/mybrary-server/src/main/java/kr/mybrary/global/config/LocalDataInitializer.java
+++ b/backend/mybrary-server/src/main/java/kr/mybrary/global/config/LocalDataInitializer.java
@@ -1,0 +1,46 @@
+package kr.mybrary.global.config;
+
+import kr.mybrary.user.persistence.Role;
+import kr.mybrary.user.persistence.User;
+import kr.mybrary.user.persistence.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.context.annotation.Profile;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Component;
+
+@Component
+@Profile("local")
+@RequiredArgsConstructor
+@Slf4j
+public class LocalDataInitializer implements CommandLineRunner {
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    private static final String ADMIN_LOGIN_ID = "admin@mybrary.kr";
+    private static final String ADMIN_NICKNAME = "admin";
+    private static final String ADMIN_PASSWORD = "admin1234!";
+
+    @Override
+    public void run(String... args) {
+        if (!userRepository.existsByLoginId(ADMIN_LOGIN_ID)) {
+            User admin = User.builder()
+                    .loginId(ADMIN_LOGIN_ID)
+                    .nickname(ADMIN_NICKNAME)
+                    .password(passwordEncoder.encode(ADMIN_PASSWORD))
+                    .role(Role.ADMIN)
+                    .introduction("로컬 개발용 어드민 계정")
+                    .profileImageUrl("")
+                    .profileImageThumbnailTinyUrl("")
+                    .profileImageThumbnailSmallUrl("")
+                    .build();
+            userRepository.save(admin);
+            log.info("===== [LOCAL] 어드민 계정 생성 =====");
+            log.info("ID: {}", ADMIN_LOGIN_ID);
+            log.info("PW: {}", ADMIN_PASSWORD);
+            log.info("===================================");
+        }
+    }
+}

--- a/backend/mybrary-server/src/main/java/kr/mybrary/global/config/LocalWebMvcConfig.java
+++ b/backend/mybrary-server/src/main/java/kr/mybrary/global/config/LocalWebMvcConfig.java
@@ -1,0 +1,25 @@
+package kr.mybrary.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+@Configuration
+@Profile("local")
+public class LocalWebMvcConfig implements WebMvcConfigurer {
+
+    @Value("${local.storage.upload-dir:./local-uploads}")
+    private String uploadDir;
+
+    @Override
+    public void addResourceHandlers(ResourceHandlerRegistry registry) {
+        Path path = Paths.get(uploadDir).toAbsolutePath();
+        registry.addResourceHandler("/uploads/**")
+                .addResourceLocations("file:" + path + "/");
+    }
+}

--- a/backend/mybrary-server/src/main/java/kr/mybrary/global/config/WebSecurityConfig.java
+++ b/backend/mybrary-server/src/main/java/kr/mybrary/global/config/WebSecurityConfig.java
@@ -16,6 +16,7 @@ import kr.mybrary.global.util.RedisUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.ProviderManager;
@@ -44,8 +45,43 @@ public class WebSecurityConfig {
     private final OAuth2LoginSuccessHandler oAuth2LoginSuccessHandler;
     private final OAuth2LoginFailureHandler oAuth2LoginFailureHandler;
 
+    /**
+     * /web/** 경로: 세션 기반 폼 로그인 (Thymeleaf MPA 용)
+     * JWT 필터를 적용하지 않고 Spring Security 기본 세션 인증을 사용한다.
+     */
     @Bean
-    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+    @Order(1)
+    public SecurityFilterChain webFilterChain(HttpSecurity http) throws Exception {
+        http
+                .securityMatcher("/web/**")
+                .csrf(AbstractHttpConfigurer::disable)
+                .formLogin(form -> form
+                        .loginPage("/web/login")
+                        .loginProcessingUrl("/web/login")
+                        .defaultSuccessUrl("/web", true)
+                        .failureUrl("/web/login?error=true")
+                        .permitAll()
+                )
+                .logout(logout -> logout
+                        .logoutUrl("/web/logout")
+                        .logoutSuccessUrl("/web/login")
+                        .invalidateHttpSession(true)
+                        .clearAuthentication(true)
+                        .permitAll()
+                )
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/web/login", "/web/signup", "/web/find-password").permitAll()
+                        .anyRequest().authenticated()
+                );
+        return http.build();
+    }
+
+    /**
+     * /api/v1/**, /auth/v1/** 경로: 기존 JWT 기반 인증 (REST API 용)
+     */
+    @Bean
+    @Order(2)
+    public SecurityFilterChain apiFilterChain(HttpSecurity http) throws Exception {
         http
                 .formLogin(AbstractHttpConfigurer::disable)
                 .httpBasic(AbstractHttpConfigurer::disable)

--- a/backend/mybrary-server/src/main/java/kr/mybrary/mybook/persistence/repository/MyBookRepository.java
+++ b/backend/mybrary-server/src/main/java/kr/mybrary/mybook/persistence/repository/MyBookRepository.java
@@ -11,6 +11,8 @@ public interface MyBookRepository extends JpaRepository<MyBook, Long>, MyBookRep
 
     boolean existsByUserIdAndBook(String userId, Book book);
 
+    long countByUserId(String userId);
+
     List<MyBook> findAllByUserId(String userId);
 
     @Query("select m from MyBook m "

--- a/backend/mybrary-server/src/main/java/kr/mybrary/user/domain/storage/AmazonS3Service.java
+++ b/backend/mybrary-server/src/main/java/kr/mybrary/user/domain/storage/AmazonS3Service.java
@@ -8,12 +8,14 @@ import kr.mybrary.user.domain.exception.storage.StorageClientException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
 
 @Service
+@Profile("!local")
 @Slf4j
 @RequiredArgsConstructor
 public class AmazonS3Service implements StorageService {

--- a/backend/mybrary-server/src/main/java/kr/mybrary/user/domain/storage/LocalStorageService.java
+++ b/backend/mybrary-server/src/main/java/kr/mybrary/user/domain/storage/LocalStorageService.java
@@ -1,0 +1,52 @@
+package kr.mybrary.user.domain.storage;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+@Service
+@Profile("local")
+@Slf4j
+public class LocalStorageService implements StorageService {
+
+    private static final String BASE_URL = "http://localhost:8080/uploads/";
+
+    @Value("${local.storage.upload-dir:./local-uploads}")
+    private String uploadDir;
+
+    @Override
+    public String putFile(MultipartFile multipartFile, String path) {
+        try {
+            Path target = Paths.get(uploadDir, path);
+            Files.createDirectories(target.getParent());
+            multipartFile.transferTo(target.toAbsolutePath());
+            log.debug("로컬 파일 저장: {}", target.toAbsolutePath());
+            return BASE_URL + path;
+        } catch (IOException e) {
+            throw new RuntimeException("로컬 파일 저장 실패: " + path, e);
+        }
+    }
+
+    @Override
+    public String getPathFromUrl(String url) {
+        return url.replace(BASE_URL, "");
+    }
+
+    // 로컬 환경에서는 리사이즈 없이 원본 반환
+    @Override
+    public boolean hasResizedFiles(String path, String size) {
+        return false;
+    }
+
+    @Override
+    public String getResizedUrl(String url, String size) {
+        return url;
+    }
+}

--- a/backend/mybrary-server/src/main/java/kr/mybrary/web/WebController.java
+++ b/backend/mybrary-server/src/main/java/kr/mybrary/web/WebController.java
@@ -1,0 +1,664 @@
+package kr.mybrary.web;
+
+import kr.mybrary.book.domain.BookInterestService;
+import kr.mybrary.book.domain.dto.request.BookInterestServiceRequest;
+import kr.mybrary.book.domain.dto.request.BookInterestStatusServiceRequest;
+import kr.mybrary.book.domain.dto.request.BookMyInterestFindServiceRequest;
+import kr.mybrary.book.persistence.BookOrderType;
+import kr.mybrary.booksearch.domain.BookSearchRankingService;
+import kr.mybrary.booksearch.domain.PlatformBookSearchApiService;
+import kr.mybrary.booksearch.domain.dto.request.BookListByCategorySearchServiceRequest;
+import kr.mybrary.booksearch.domain.dto.request.BookSearchServiceRequest;
+import kr.mybrary.booksearch.presentation.dto.response.BookListByCategorySearchResultResponse;
+import kr.mybrary.booksearch.presentation.dto.response.BookSearchDetailResponse;
+import kr.mybrary.booksearch.presentation.dto.response.BookSearchRankingResponse;
+import kr.mybrary.booksearch.presentation.dto.response.BookSearchResultResponse;
+import kr.mybrary.interest.domain.InterestService;
+import kr.mybrary.interest.domain.dto.request.UserInterestAndBookRecommendationsServiceRequest;
+import kr.mybrary.interest.domain.dto.request.UserInterestUpdateServiceRequest;
+import kr.mybrary.interest.domain.dto.response.InterestResponse;
+import kr.mybrary.mybook.domain.MyBookService;
+import kr.mybrary.mybook.domain.dto.request.MyBookCreateServiceRequest;
+import kr.mybrary.mybook.domain.dto.request.MyBookDeleteServiceRequest;
+import kr.mybrary.mybook.domain.dto.request.MyBookDetailServiceRequest;
+import kr.mybrary.mybook.domain.dto.request.MyBookFindAllServiceRequest;
+import kr.mybrary.mybook.domain.dto.request.MyBookRegisteredStatusServiceRequest;
+import kr.mybrary.mybook.domain.dto.request.MybookUpdateServiceRequest;
+import kr.mybrary.mybook.persistence.MyBookOrderType;
+import kr.mybrary.mybook.persistence.ReadStatus;
+import kr.mybrary.mybook.presentation.dto.response.MyBookDetailResponse;
+import kr.mybrary.mybook.presentation.dto.response.MyBookElementResponse;
+import kr.mybrary.mybook.presentation.dto.response.MyBookRegistrationCountResponse;
+import kr.mybrary.review.presentation.dto.response.MyReviewsOfBookGetResponse;
+import kr.mybrary.review.domain.MyReviewReadService;
+import kr.mybrary.review.domain.MyReviewWriteService;
+import kr.mybrary.review.domain.dto.request.MyReviewCreateServiceRequest;
+import kr.mybrary.review.domain.dto.request.MyReviewDeleteServiceRequest;
+import kr.mybrary.review.domain.dto.request.MyReviewOfMyBookGetServiceRequest;
+import kr.mybrary.review.domain.dto.request.MyReviewsOfBookGetServiceRequest;
+import kr.mybrary.review.domain.dto.request.MyReviewUpdateServiceRequest;
+import kr.mybrary.review.presentation.dto.response.MyReviewOfMyBookGetResponse;
+import kr.mybrary.user.domain.UserService;
+import kr.mybrary.user.domain.dto.request.FollowServiceRequest;
+import kr.mybrary.user.domain.dto.request.ProfileUpdateServiceRequest;
+import kr.mybrary.user.domain.dto.request.SignUpServiceRequest;
+import kr.mybrary.user.domain.dto.response.FollowerServiceResponse;
+import kr.mybrary.user.domain.dto.response.FollowingServiceResponse;
+import kr.mybrary.user.domain.dto.response.ProfileServiceResponse;
+import kr.mybrary.user.domain.dto.response.SignUpServiceResponse;
+import kr.mybrary.user.presentation.dto.request.ProfileUpdateRequest;
+import kr.mybrary.user.presentation.dto.request.SignUpRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * Thymeleaf MPA 용 컨트롤러.
+ * /web/** 경로를 담당하며, 서비스 레이어를 직접 호출한다 (HTTP 라운드트립 없음).
+ * 세션 기반 인증 (Spring Security Form Login) 사용.
+ */
+@Controller
+@RequestMapping("/web")
+@RequiredArgsConstructor
+@Slf4j
+public class WebController {
+
+    private final UserService userService;
+    private final MyBookService myBookService;
+    private final BookInterestService bookInterestService;
+    private final PlatformBookSearchApiService platformBookSearchApiService;
+    private final BookSearchRankingService bookSearchRankingService;
+    private final InterestService interestService;
+    private final MyReviewReadService myReviewReadService;
+    private final MyReviewWriteService myReviewWriteService;
+
+    // ===========================
+    // 인증 (로그인 / 회원가입)
+    // ===========================
+
+    @GetMapping("/login")
+    public String loginPage(@RequestParam(required = false) String error, Model model) {
+        if (error != null) {
+            model.addAttribute("errorMessage", "아이디 또는 비밀번호가 올바르지 않습니다.");
+        }
+        return "web/login";
+    }
+
+    @GetMapping("/signup")
+    public String signupPage(Model model) {
+        model.addAttribute("signUpRequest", new SignUpRequest());
+        return "web/signup";
+    }
+
+    @PostMapping("/signup")
+    public String signup(@ModelAttribute SignUpRequest signUpRequest,
+                         RedirectAttributes redirectAttributes) {
+        try {
+            SignUpServiceResponse response = userService.signUp(SignUpServiceRequest.of(signUpRequest));
+            redirectAttributes.addFlashAttribute("successMessage", "회원가입이 완료되었습니다. 로그인해주세요.");
+            return "redirect:/web/login";
+        } catch (Exception e) {
+            log.warn("회원가입 실패: {}", e.getMessage());
+            redirectAttributes.addFlashAttribute("errorMessage", e.getMessage());
+            return "redirect:/web/signup";
+        }
+    }
+
+    @GetMapping("/find-password")
+    public String findPasswordPage() {
+        return "web/find-password";
+    }
+
+    // ===========================
+    // 홈
+    // ===========================
+
+    @GetMapping({"", "/"})
+    public String home(Model model, Authentication auth) {
+        String loginId = auth.getName();
+
+        // 오늘 등록된 MyBook 수
+        MyBookRegistrationCountResponse todayCount = myBookService.getBookRegistrationCountOfToday();
+        model.addAttribute("todayCount", todayCount.getCount());
+
+        // 베스트셀러 (Aladin ItemNewAll categoryId=0 활용)
+        try {
+            BookListByCategorySearchResultResponse bestsellers = platformBookSearchApiService
+                    .searchBookListByCategory(BookListByCategorySearchServiceRequest.of("Bestseller", 0, 1));
+            model.addAttribute("bestsellers", bestsellers.getBooks());
+        } catch (Exception e) {
+            log.warn("베스트셀러 조회 실패: {}", e.getMessage());
+            model.addAttribute("bestsellers", List.of());
+        }
+
+        // 추천 도서 (사용자 관심사 기반)
+        try {
+            var recommendationsResponse = interestService.getInterestsAndBookRecommendations(
+                    UserInterestAndBookRecommendationsServiceRequest.of(loginId, "ItemNewAll", 1)
+            );
+            model.addAttribute("recommendations", recommendationsResponse.getBookRecommendations());
+            model.addAttribute("userInterests", recommendationsResponse.getUserInterests());
+        } catch (Exception e) {
+            log.warn("추천 도서 조회 실패: {}", e.getMessage());
+            model.addAttribute("recommendations", List.of());
+            model.addAttribute("userInterests", List.of());
+        }
+
+        model.addAttribute("loginId", loginId);
+        return "web/home";
+    }
+
+    // ===========================
+    // 도서 검색
+    // ===========================
+
+    @GetMapping("/search")
+    public String search(@RequestParam(required = false) String keyword,
+                         @RequestParam(defaultValue = "accuracy") String sort,
+                         @RequestParam(defaultValue = "1") int page,
+                         Model model) {
+
+        // 인기 검색어
+        BookSearchRankingResponse ranking = bookSearchRankingService.getBookSearchKeywordRankingList();
+        model.addAttribute("ranking", ranking.getBookSearchKeywords());
+
+        if (keyword != null && !keyword.isBlank()) {
+            try {
+                BookSearchResultResponse result = platformBookSearchApiService
+                        .searchWithKeyword(BookSearchServiceRequest.of(keyword, sort, page));
+                model.addAttribute("searchResults", result.getBookSearchResult());
+                model.addAttribute("nextRequestUrl", result.getNextRequestUrl());
+                bookSearchRankingService.increaseSearchRankingScore(keyword);
+            } catch (Exception e) {
+                log.warn("도서 검색 실패: keyword={}, error={}", keyword, e.getMessage());
+                model.addAttribute("searchResults", List.of());
+                model.addAttribute("searchError", "도서 검색 중 오류가 발생했습니다.");
+            }
+            model.addAttribute("keyword", keyword);
+            model.addAttribute("sort", sort);
+            model.addAttribute("page", page);
+        }
+
+        return "web/search";
+    }
+
+    @GetMapping("/search/detail")
+    public String searchDetail(@RequestParam String isbn13,
+                               @RequestParam(required = false) String isbn10,
+                               Model model, Authentication auth) {
+        String loginId = auth.getName();
+        try {
+            BookSearchDetailResponse detail = platformBookSearchApiService
+                    .searchBookDetailWithISBN(BookSearchServiceRequest.of(isbn13));
+            model.addAttribute("book", detail);
+
+            // 도서 리뷰 (DB에 등록된 도서라면)
+            try {
+                MyReviewsOfBookGetResponse reviews = myReviewReadService.getReviewsFromBook(
+                        MyReviewsOfBookGetServiceRequest.builder()
+                                .isbn13(isbn13)
+                                .build());
+                model.addAttribute("reviews", reviews);
+            } catch (Exception e) {
+                model.addAttribute("reviews", null);
+            }
+
+            // 관심 도서 여부
+            try {
+                boolean interested = bookInterestService.getInterestStatus(
+                        BookInterestStatusServiceRequest.builder()
+                                .loginId(loginId)
+                                .isbn13(isbn13)
+                                .build()
+                ).isInterested();
+                model.addAttribute("interested", interested);
+            } catch (Exception e) {
+                model.addAttribute("interested", false);
+            }
+
+            // MyBook 등록 여부
+            try {
+                boolean registered = myBookService.getMyBookRegisteredStatus(
+                        MyBookRegisteredStatusServiceRequest.builder()
+                                .loginId(loginId)
+                                .isbn13(isbn13)
+                                .build()
+                ).isRegistered();
+                model.addAttribute("registered", registered);
+            } catch (Exception e) {
+                model.addAttribute("registered", false);
+            }
+
+        } catch (Exception e) {
+            log.warn("도서 상세 조회 실패: isbn13={}, error={}", isbn13, e.getMessage());
+            model.addAttribute("errorMessage", "도서 정보를 불러올 수 없습니다.");
+        }
+        model.addAttribute("loginId", loginId);
+        return "web/search-detail";
+    }
+
+    // 관심 도서 토글 (POST)
+    @PostMapping("/search/interest")
+    public String toggleBookInterest(@RequestParam String isbn13,
+                                     @RequestParam(required = false) String returnUrl,
+                                     Authentication auth) {
+        String loginId = auth.getName();
+        try {
+            bookInterestService.handleBookInterest(BookInterestServiceRequest.builder()
+                    .loginId(loginId)
+                    .isbn13(isbn13)
+                    .build());
+        } catch (Exception e) {
+            log.warn("관심 도서 토글 실패: {}", e.getMessage());
+        }
+        return "redirect:" + (returnUrl != null ? returnUrl : "/web/search/detail?isbn13=" + isbn13);
+    }
+
+    // MyBook 등록 (POST)
+    @PostMapping("/search/mybook")
+    public String registerMyBook(@RequestParam String isbn13,
+                                 Authentication auth,
+                                 RedirectAttributes redirectAttributes) {
+        String loginId = auth.getName();
+        try {
+            myBookService.create(MyBookCreateServiceRequest.builder()
+                    .userId(loginId)
+                    .isbn13(isbn13)
+                    .build());
+            redirectAttributes.addFlashAttribute("successMessage", "내 책으로 등록되었습니다.");
+        } catch (Exception e) {
+            log.warn("MyBook 등록 실패: {}", e.getMessage());
+            redirectAttributes.addFlashAttribute("errorMessage", e.getMessage());
+        }
+        return "redirect:/web/search/detail?isbn13=" + isbn13;
+    }
+
+    // ===========================
+    // MyBook 목록
+    // ===========================
+
+    @GetMapping("/mybooks")
+    public String mybooks(@RequestParam(defaultValue = "NONE") String orderType,
+                          @RequestParam(required = false) String readStatus,
+                          Model model, Authentication auth) {
+        String loginId = auth.getName();
+
+        MyBookOrderType myBookOrderType = parseMyBookOrderType(orderType);
+        ReadStatus readStatusEnum = ReadStatus.of(readStatus);
+
+        List<MyBookElementResponse> myBooks = myBookService.findAllMyBooks(
+                MyBookFindAllServiceRequest.of(loginId, loginId, myBookOrderType, readStatusEnum));
+
+        model.addAttribute("mybooks", myBooks);
+        model.addAttribute("orderType", orderType);
+        model.addAttribute("readStatus", readStatus);
+        model.addAttribute("loginId", loginId);
+        return "web/mybooks";
+    }
+
+    @GetMapping("/mybooks/{id}")
+    public String mybookDetail(@PathVariable Long id, Model model, Authentication auth) {
+        String loginId = auth.getName();
+
+        MyBookDetailResponse detail = myBookService.findMyBookDetail(
+                MyBookDetailServiceRequest.builder()
+                        .mybookId(id)
+                        .loginId(loginId)
+                        .build());
+
+        MyReviewOfMyBookGetResponse review = myReviewReadService.getReviewFromMyBook(
+                MyReviewOfMyBookGetServiceRequest.of(id));
+
+        model.addAttribute("mybook", detail);
+        model.addAttribute("review", review);
+        model.addAttribute("loginId", loginId);
+        model.addAttribute("readStatusValues", ReadStatus.values());
+        return "web/mybook-detail";
+    }
+
+    // MyBook 업데이트 (POST)
+    @PostMapping("/mybooks/{id}/update")
+    public String updateMyBook(@PathVariable Long id,
+                               @RequestParam(defaultValue = "false") boolean showable,
+                               @RequestParam(defaultValue = "false") boolean exchangeable,
+                               @RequestParam(defaultValue = "false") boolean shareable,
+                               @RequestParam(required = false) String readStatus,
+                               @RequestParam(required = false) String meaningTagQuote,
+                               @RequestParam(required = false) String meaningTagColorCode,
+                               Authentication auth,
+                               RedirectAttributes redirectAttributes) {
+        String loginId = auth.getName();
+        try {
+            MybookUpdateServiceRequest request = MybookUpdateServiceRequest.builder()
+                    .loginId(loginId)
+                    .myBookId(id)
+                    .showable(showable)
+                    .exchangeable(exchangeable)
+                    .shareable(shareable)
+                    .readStatus(ReadStatus.of(readStatus))
+                    .startDateOfPossession(LocalDateTime.now())
+                    .meaningTag(MybookUpdateServiceRequest.MeaningTag.builder()
+                            .quote(meaningTagQuote != null ? meaningTagQuote : "")
+                            .colorCode(meaningTagColorCode != null ? meaningTagColorCode : "19C568")
+                            .build())
+                    .build();
+            myBookService.updateMyBookProperties(request);
+            redirectAttributes.addFlashAttribute("successMessage", "내 책 정보가 수정되었습니다.");
+        } catch (Exception e) {
+            log.warn("MyBook 수정 실패: {}", e.getMessage());
+            redirectAttributes.addFlashAttribute("errorMessage", e.getMessage());
+        }
+        return "redirect:/web/mybooks/" + id;
+    }
+
+    // MyBook 삭제 (POST)
+    @PostMapping("/mybooks/{id}/delete")
+    public String deleteMyBook(@PathVariable Long id,
+                               Authentication auth,
+                               RedirectAttributes redirectAttributes) {
+        String loginId = auth.getName();
+        try {
+            myBookService.deleteMyBook(MyBookDeleteServiceRequest.builder()
+                    .mybookId(id)
+                    .loginId(loginId)
+                    .build());
+            redirectAttributes.addFlashAttribute("successMessage", "내 책이 삭제되었습니다.");
+        } catch (Exception e) {
+            log.warn("MyBook 삭제 실패: {}", e.getMessage());
+            redirectAttributes.addFlashAttribute("errorMessage", e.getMessage());
+        }
+        return "redirect:/web/mybooks";
+    }
+
+    // ===========================
+    // 리뷰 작성 / 수정 / 삭제
+    // ===========================
+
+    @PostMapping("/mybooks/{id}/review")
+    public String createReview(@PathVariable Long id,
+                               @RequestParam String content,
+                               @RequestParam Double starRating,
+                               Authentication auth,
+                               RedirectAttributes redirectAttributes) {
+        String loginId = auth.getName();
+        try {
+            myReviewWriteService.create(MyReviewCreateServiceRequest.builder()
+                    .myBookId(id)
+                    .loginId(loginId)
+                    .content(content)
+                    .starRating(starRating)
+                    .build());
+            redirectAttributes.addFlashAttribute("successMessage", "리뷰가 등록되었습니다.");
+        } catch (Exception e) {
+            log.warn("리뷰 작성 실패: {}", e.getMessage());
+            redirectAttributes.addFlashAttribute("errorMessage", e.getMessage());
+        }
+        return "redirect:/web/mybooks/" + id;
+    }
+
+    @PostMapping("/mybooks/{id}/review/{reviewId}/update")
+    public String updateReview(@PathVariable Long id,
+                               @PathVariable Long reviewId,
+                               @RequestParam String content,
+                               @RequestParam Double starRating,
+                               Authentication auth,
+                               RedirectAttributes redirectAttributes) {
+        String loginId = auth.getName();
+        try {
+            myReviewWriteService.update(MyReviewUpdateServiceRequest.builder()
+                    .myReviewId(reviewId)
+                    .loginId(loginId)
+                    .content(content)
+                    .starRating(starRating)
+                    .build());
+            redirectAttributes.addFlashAttribute("successMessage", "리뷰가 수정되었습니다.");
+        } catch (Exception e) {
+            log.warn("리뷰 수정 실패: {}", e.getMessage());
+            redirectAttributes.addFlashAttribute("errorMessage", e.getMessage());
+        }
+        return "redirect:/web/mybooks/" + id;
+    }
+
+    @PostMapping("/mybooks/{id}/review/{reviewId}/delete")
+    public String deleteReview(@PathVariable Long id,
+                               @PathVariable Long reviewId,
+                               Authentication auth,
+                               RedirectAttributes redirectAttributes) {
+        String loginId = auth.getName();
+        try {
+            myReviewWriteService.delete(MyReviewDeleteServiceRequest.builder()
+                    .myReviewId(reviewId)
+                    .loginId(loginId)
+                    .build());
+            redirectAttributes.addFlashAttribute("successMessage", "리뷰가 삭제되었습니다.");
+        } catch (Exception e) {
+            log.warn("리뷰 삭제 실패: {}", e.getMessage());
+            redirectAttributes.addFlashAttribute("errorMessage", e.getMessage());
+        }
+        return "redirect:/web/mybooks/" + id;
+    }
+
+    // ===========================
+    // 관심 도서 목록
+    // ===========================
+
+    @GetMapping("/mybooks/interest")
+    public String mybooksInterest(@RequestParam(defaultValue = "NONE") String orderType,
+                                  Model model, Authentication auth) {
+        String loginId = auth.getName();
+        BookOrderType bookOrderType = parseBookOrderType(orderType);
+
+        var interestBooks = bookInterestService.getBookInterestList(
+                BookMyInterestFindServiceRequest.of(loginId, bookOrderType));
+
+        model.addAttribute("interestBooks", interestBooks);
+        model.addAttribute("orderType", orderType);
+        model.addAttribute("loginId", loginId);
+        return "web/mybooks-interest";
+    }
+
+    // ===========================
+    // 프로필
+    // ===========================
+
+    @GetMapping("/profile")
+    public String myProfile(Model model, Authentication auth) {
+        return profilePage(auth.getName(), model, auth);
+    }
+
+    @GetMapping("/profile/{userId}")
+    public String userProfile(@PathVariable String userId, Model model, Authentication auth) {
+        return profilePage(userId, model, auth);
+    }
+
+    private String profilePage(String targetUserId, Model model, Authentication auth) {
+        String loginId = auth.getName();
+        try {
+            ProfileServiceResponse profile = userService.getProfile(targetUserId);
+            FollowerServiceResponse followers = userService.getFollowers(targetUserId);
+            FollowingServiceResponse followings = userService.getFollowings(targetUserId);
+
+            boolean isMyProfile = loginId.equals(targetUserId);
+            boolean isFollowing = false;
+            if (!isMyProfile) {
+                isFollowing = userService.getFollowStatus(
+                        FollowServiceRequest.of(loginId, targetUserId)).isFollowing();
+            }
+
+            model.addAttribute("profile", profile);
+            model.addAttribute("targetUserId", targetUserId);
+            model.addAttribute("followerCount", followers.getFollowers().size());
+            model.addAttribute("followingCount", followings.getFollowings().size());
+            model.addAttribute("isMyProfile", isMyProfile);
+            model.addAttribute("isFollowing", isFollowing);
+            model.addAttribute("loginId", loginId);
+        } catch (Exception e) {
+            log.warn("프로필 조회 실패: userId={}, error={}", targetUserId, e.getMessage());
+            model.addAttribute("errorMessage", "프로필을 불러올 수 없습니다.");
+        }
+        return "web/profile";
+    }
+
+    @GetMapping("/profile/edit")
+    public String profileEditPage(Model model, Authentication auth) {
+        String loginId = auth.getName();
+        ProfileServiceResponse profile = userService.getProfile(loginId);
+        model.addAttribute("profile", profile);
+        model.addAttribute("loginId", loginId);
+        return "web/profile-edit";
+    }
+
+    @PostMapping("/profile/edit")
+    public String updateProfile(@RequestParam String nickname,
+                                @RequestParam(required = false) String introduction,
+                                Authentication auth,
+                                RedirectAttributes redirectAttributes) {
+        String loginId = auth.getName();
+        try {
+            ProfileUpdateRequest updateRequest = ProfileUpdateRequest.builder()
+                    .nickname(nickname)
+                    .introduction(introduction != null ? introduction : "")
+                    .build();
+
+            userService.updateProfile(ProfileUpdateServiceRequest.of(updateRequest, loginId, loginId));
+            redirectAttributes.addFlashAttribute("successMessage", "프로필이 수정되었습니다.");
+        } catch (Exception e) {
+            log.warn("프로필 수정 실패: {}", e.getMessage());
+            redirectAttributes.addFlashAttribute("errorMessage", e.getMessage());
+        }
+        return "redirect:/web/profile";
+    }
+
+    // 팔로우 / 언팔로우
+    @PostMapping("/profile/{userId}/follow")
+    public String follow(@PathVariable String userId, Authentication auth) {
+        String loginId = auth.getName();
+        try {
+            userService.follow(FollowServiceRequest.of(loginId, userId));
+        } catch (Exception e) {
+            log.warn("팔로우 실패: {}", e.getMessage());
+        }
+        return "redirect:/web/profile/" + userId;
+    }
+
+    @PostMapping("/profile/{userId}/unfollow")
+    public String unfollow(@PathVariable String userId, Authentication auth) {
+        String loginId = auth.getName();
+        try {
+            userService.unfollow(FollowServiceRequest.of(loginId, userId));
+        } catch (Exception e) {
+            log.warn("언팔로우 실패: {}", e.getMessage());
+        }
+        return "redirect:/web/profile/" + userId;
+    }
+
+    // 팔로워 / 팔로잉 목록
+    @GetMapping("/profile/{userId}/followers")
+    public String followerList(@PathVariable String userId, Model model, Authentication auth) {
+        FollowerServiceResponse followers = userService.getFollowers(userId);
+        model.addAttribute("followers", followers.getFollowers());
+        model.addAttribute("targetUserId", userId);
+        model.addAttribute("loginId", auth.getName());
+        return "web/follow-list";
+    }
+
+    @GetMapping("/profile/{userId}/followings")
+    public String followingList(@PathVariable String userId, Model model, Authentication auth) {
+        FollowingServiceResponse followings = userService.getFollowings(userId);
+        model.addAttribute("followings", followings.getFollowings());
+        model.addAttribute("targetUserId", userId);
+        model.addAttribute("loginId", auth.getName());
+        return "web/follow-list";
+    }
+
+    // ===========================
+    // 관심사
+    // ===========================
+
+    @GetMapping("/interests")
+    public String interestsPage(Model model, Authentication auth) {
+        String loginId = auth.getName();
+        var allCategories = interestService.getInterestCategories();
+        var userInterests = interestService.getUserInterests(loginId);
+
+        model.addAttribute("categories", allCategories.getInterestCategories());
+        model.addAttribute("userInterestIds",
+                userInterests.getUserInterests().stream()
+                        .map(InterestResponse::getId)
+                        .toList());
+        model.addAttribute("loginId", loginId);
+        return "web/interests";
+    }
+
+    @PostMapping("/interests")
+    public String updateInterests(@RequestParam(required = false) List<Long> interestIds,
+                                  Authentication auth,
+                                  RedirectAttributes redirectAttributes) {
+        String loginId = auth.getName();
+        try {
+            List<Long> ids = interestIds != null ? interestIds : List.of();
+            interestService.updateUserInterests(
+                    UserInterestUpdateServiceRequest.builder()
+                            .userId(loginId)
+                            .loginId(loginId)
+                            .interestIds(ids)
+                            .build());
+            redirectAttributes.addFlashAttribute("successMessage", "관심사가 저장되었습니다.");
+        } catch (Exception e) {
+            log.warn("관심사 업데이트 실패: {}", e.getMessage());
+            redirectAttributes.addFlashAttribute("errorMessage", e.getMessage());
+        }
+        return "redirect:/web/interests";
+    }
+
+    // ===========================
+    // 설정
+    // ===========================
+
+    @GetMapping("/settings")
+    public String settingsPage(Model model, Authentication auth) {
+        model.addAttribute("loginId", auth.getName());
+        return "web/settings";
+    }
+
+    @PostMapping("/settings/delete-account")
+    public String deleteAccount(Authentication auth,
+                                RedirectAttributes redirectAttributes) {
+        String loginId = auth.getName();
+        try {
+            userService.deleteAccount(loginId);
+            return "redirect:/web/login?accountDeleted=true";
+        } catch (Exception e) {
+            log.warn("계정 탈퇴 실패: {}", e.getMessage());
+            redirectAttributes.addFlashAttribute("errorMessage", "계정 탈퇴에 실패했습니다.");
+            return "redirect:/web/settings";
+        }
+    }
+
+    // ===========================
+    // 유틸리티
+    // ===========================
+
+    private MyBookOrderType parseMyBookOrderType(String orderType) {
+        try {
+            return MyBookOrderType.valueOf(orderType.toUpperCase());
+        } catch (Exception e) {
+            return MyBookOrderType.NONE;
+        }
+    }
+
+    private BookOrderType parseBookOrderType(String orderType) {
+        try {
+            return BookOrderType.valueOf(orderType.toUpperCase());
+        } catch (Exception e) {
+            return BookOrderType.NONE;
+        }
+    }
+}

--- a/backend/mybrary-server/src/main/java/kr/mybrary/web/WebController.java
+++ b/backend/mybrary-server/src/main/java/kr/mybrary/web/WebController.java
@@ -56,6 +56,7 @@ import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
+import jakarta.servlet.http.HttpServletRequest;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -78,6 +79,11 @@ public class WebController {
     private final InterestService interestService;
     private final MyReviewReadService myReviewReadService;
     private final MyReviewWriteService myReviewWriteService;
+
+    @ModelAttribute("currentPath")
+    public String currentPath(HttpServletRequest request) {
+        return request.getRequestURI();
+    }
 
     // ===========================
     // 인증 (로그인 / 회원가입)

--- a/backend/mybrary-server/src/main/resources/application-local.yml
+++ b/backend/mybrary-server/src/main/resources/application-local.yml
@@ -1,9 +1,12 @@
+server:
+  port: 8090
+
 spring:
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
     url: jdbc:mysql://localhost:3306/mybrary?useSSL=false&allowPublicKeyRetrieval=true&useUnicode=true&serverTimezone=Asia/Seoul
     username: ${DB_USERNAME:root}
-    password: ${DB_PASSWORD:}
+    password: ${DB_PASSWORD:mybrary}
 
   jpa:
     hibernate:
@@ -12,7 +15,51 @@ spring:
   flyway:
     enabled: false
 
+  # 소셜 로그인 로컬 더미값 (이메일/비밀번호 로그인은 정상 동작)
+  security:
+    oauth2:
+      client:
+        registration:
+          google:
+            client-id: ${GOOGLE_CLIENT_ID:local-dummy}
+            client-secret: ${GOOGLE_CLIENT_SECRET:local-dummy}
+          naver:
+            client-id: ${NAVER_CLIENT_ID:local-dummy}
+            client-secret: ${NAVER_CLIENT_SECRET:local-dummy}
+          kakao:
+            client-id: ${KAKAO_CLIENT_ID:local-dummy}
+            client-secret: ${KAKAO_CLIENT_SECRET:local-dummy}
+
+# JWT 로컬 전용 시크릿 (최소 32자 이상 필요)
+jwt:
+  secretKey: ${JWT_SECRET_KEY:local-dev-secret-key-for-mybrary-development-only-not-for-production}
+
+# 도서 검색 API (더미값이면 검색 결과 없음, 실제 키 있으면 .env에 설정)
+kakao:
+  api:
+    key: ${KAKAO_BOOK_API_KEY:local-dummy}
+
+aladin:
+  api:
+    key: ${ALADIN_API_KEY:local-dummy}
+
+# 로컬 파일 기반 스토리지 (S3 대신 ./local-uploads/ 디렉토리에 저장)
+# 업로드된 파일: http://localhost:8080/uploads/{path} 로 접근 가능
+local:
+  storage:
+    upload-dir: ./local-uploads
+
+# S3 자동 설정에 필요한 더미값 (local 프로파일에서는 AmazonS3Service 비활성화됨)
+cloud:
+  aws:
+    s3:
+      bucket: mybrary-local
+    credentials:
+      access-key: local-dummy
+      secret-key: local-dummy
+
 logging:
   level:
-    root: debug
+    root: info
     org.hibernate.SQL: debug
+    kr.mybrary: debug

--- a/backend/mybrary-server/src/main/resources/templates/layout/base.html
+++ b/backend/mybrary-server/src/main/resources/templates/layout/base.html
@@ -228,23 +228,23 @@
 
 <!-- 하단 네비게이션 -->
 <nav class="bottom-nav">
-    <a href="/web" th:classappend="${#httpServletRequest.requestURI == '/web' or #httpServletRequest.requestURI == '/web/'} ? 'active' : ''">
+    <a href="/web" th:classappend="${currentPath == '/web' or currentPath == '/web/'} ? 'active' : ''">
         <i class="bi bi-house-fill"></i>
         홈
     </a>
-    <a href="/web/search" th:classappend="${#httpServletRequest.requestURI.startsWith('/web/search')} ? 'active' : ''">
+    <a href="/web/search" th:classappend="${currentPath != null and currentPath.startsWith('/web/search')} ? 'active' : ''">
         <i class="bi bi-search"></i>
         검색
     </a>
-    <a href="/web/mybooks" th:classappend="${#httpServletRequest.requestURI.startsWith('/web/mybooks')} ? 'active' : ''">
+    <a href="/web/mybooks" th:classappend="${currentPath != null and currentPath.startsWith('/web/mybooks')} ? 'active' : ''">
         <i class="bi bi-book-fill"></i>
         내 책
     </a>
-    <a href="/web/profile" th:classappend="${#httpServletRequest.requestURI.startsWith('/web/profile')} ? 'active' : ''">
+    <a href="/web/profile" th:classappend="${currentPath != null and currentPath.startsWith('/web/profile')} ? 'active' : ''">
         <i class="bi bi-person-fill"></i>
         프로필
     </a>
-    <a href="/web/interests" th:classappend="${#httpServletRequest.requestURI.startsWith('/web/interests')} ? 'active' : ''">
+    <a href="/web/interests" th:classappend="${currentPath != null and currentPath.startsWith('/web/interests')} ? 'active' : ''">
         <i class="bi bi-heart-fill"></i>
         관심사
     </a>

--- a/backend/mybrary-server/src/main/resources/templates/layout/base.html
+++ b/backend/mybrary-server/src/main/resources/templates/layout/base.html
@@ -1,0 +1,269 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org"
+      xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      xmlns:sec="http://www.thymeleaf.org/extras/spring-security">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title layout:title-pattern="$CONTENT_TITLE - Mybrary">Mybrary</title>
+
+    <!-- Bootstrap 5 CSS -->
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css"
+          rel="stylesheet">
+    <!-- Bootstrap Icons -->
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css"
+          rel="stylesheet">
+
+    <style>
+        :root {
+            --mybrary-primary: #19C568;
+            --mybrary-primary-light: #CDE7BE;
+            --mybrary-orange: #FF6846;
+            --mybrary-star: #FFBB36;
+            --mybrary-grey: #A0A0A0;
+            --mybrary-light-grey: #F1F2F5;
+            --mybrary-dark: #313333;
+        }
+
+        body {
+            background-color: var(--mybrary-light-grey);
+            font-family: 'Noto Sans KR', 'Apple SD Gothic Neo', sans-serif;
+            padding-bottom: 80px;
+        }
+
+        .navbar-brand .brand-text {
+            color: var(--mybrary-primary);
+            font-weight: 700;
+            font-size: 1.4rem;
+        }
+
+        .navbar {
+            background-color: #fff;
+            box-shadow: 0 1px 4px rgba(0,0,0,0.08);
+        }
+
+        /* 하단 네비게이션 (모바일) */
+        .bottom-nav {
+            position: fixed;
+            bottom: 0;
+            left: 0;
+            right: 0;
+            background: #fff;
+            border-top: 1px solid #E7E7E7;
+            display: flex;
+            z-index: 1000;
+        }
+
+        .bottom-nav a {
+            flex: 1;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
+            padding: 10px 0 8px;
+            color: var(--mybrary-grey);
+            text-decoration: none;
+            font-size: 0.7rem;
+        }
+
+        .bottom-nav a.active {
+            color: var(--mybrary-primary);
+        }
+
+        .bottom-nav a i {
+            font-size: 1.3rem;
+            margin-bottom: 2px;
+        }
+
+        /* 도서 카드 */
+        .book-card {
+            background: #fff;
+            border-radius: 12px;
+            overflow: hidden;
+            box-shadow: 0 2px 8px rgba(0,0,0,0.06);
+            transition: transform 0.15s;
+        }
+
+        .book-card:hover {
+            transform: translateY(-2px);
+        }
+
+        .book-card img {
+            width: 100%;
+            height: 160px;
+            object-fit: cover;
+            background: #F1F2F5;
+        }
+
+        .book-card-body {
+            padding: 10px 12px;
+        }
+
+        .book-card-title {
+            font-size: 0.85rem;
+            font-weight: 600;
+            color: var(--mybrary-dark);
+            display: -webkit-box;
+            -webkit-line-clamp: 2;
+            -webkit-box-orient: vertical;
+            overflow: hidden;
+        }
+
+        .book-card-author {
+            font-size: 0.75rem;
+            color: var(--mybrary-grey);
+            margin-top: 2px;
+        }
+
+        .star-rating {
+            color: var(--mybrary-star);
+            font-size: 0.8rem;
+        }
+
+        /* 프라이머리 버튼 */
+        .btn-mybrary {
+            background-color: var(--mybrary-primary);
+            border-color: var(--mybrary-primary);
+            color: #fff;
+        }
+
+        .btn-mybrary:hover {
+            background-color: #15b05e;
+            color: #fff;
+        }
+
+        .btn-mybrary-outline {
+            border-color: var(--mybrary-primary);
+            color: var(--mybrary-primary);
+        }
+
+        .btn-mybrary-outline:hover {
+            background-color: var(--mybrary-primary);
+            color: #fff;
+        }
+
+        /* 섹션 헤더 */
+        .section-header {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            margin-bottom: 12px;
+        }
+
+        .section-title {
+            font-size: 1rem;
+            font-weight: 700;
+            color: var(--mybrary-dark);
+        }
+
+        /* 알림 / 플래시 메시지 */
+        .flash-alert {
+            position: fixed;
+            top: 70px;
+            left: 50%;
+            transform: translateX(-50%);
+            z-index: 2000;
+            min-width: 280px;
+            max-width: 90%;
+        }
+
+        .page-container {
+            max-width: 480px;
+            margin: 0 auto;
+            padding: 16px;
+        }
+
+        /* 배지 */
+        .badge-mybrary {
+            background-color: var(--mybrary-primary-light);
+            color: var(--mybrary-primary);
+            font-weight: 600;
+        }
+
+        .card {
+            border: none;
+            border-radius: 12px;
+            box-shadow: 0 2px 8px rgba(0,0,0,0.06);
+        }
+    </style>
+
+    <!-- 페이지 고유 스타일 슬롯 -->
+    <th:block layout:fragment="page-styles"></th:block>
+</head>
+<body>
+
+<!-- 상단 네비게이션 -->
+<nav class="navbar navbar-light sticky-top">
+    <div class="container-fluid px-3">
+        <a class="navbar-brand" href="/web">
+            <span class="brand-text">mybrary</span>
+        </a>
+        <div class="d-flex align-items-center gap-2">
+            <span class="text-muted small" sec:authentication="name">사용자</span>
+            <a href="/web/settings" class="btn btn-sm btn-outline-secondary">
+                <i class="bi bi-gear"></i>
+            </a>
+        </div>
+    </div>
+</nav>
+
+<!-- 플래시 메시지 (성공) -->
+<div th:if="${successMessage}" class="flash-alert alert alert-success alert-dismissible fade show" role="alert">
+    <i class="bi bi-check-circle-fill me-1"></i>
+    <span th:text="${successMessage}">성공</span>
+    <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
+</div>
+
+<!-- 플래시 메시지 (에러) -->
+<div th:if="${errorMessage}" class="flash-alert alert alert-danger alert-dismissible fade show" role="alert">
+    <i class="bi bi-exclamation-triangle-fill me-1"></i>
+    <span th:text="${errorMessage}">오류</span>
+    <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
+</div>
+
+<!-- 페이지 콘텐츠 -->
+<main>
+    <th:block layout:fragment="content"></th:block>
+</main>
+
+<!-- 하단 네비게이션 -->
+<nav class="bottom-nav">
+    <a href="/web" th:classappend="${#httpServletRequest.requestURI == '/web' or #httpServletRequest.requestURI == '/web/'} ? 'active' : ''">
+        <i class="bi bi-house-fill"></i>
+        홈
+    </a>
+    <a href="/web/search" th:classappend="${#httpServletRequest.requestURI.startsWith('/web/search')} ? 'active' : ''">
+        <i class="bi bi-search"></i>
+        검색
+    </a>
+    <a href="/web/mybooks" th:classappend="${#httpServletRequest.requestURI.startsWith('/web/mybooks')} ? 'active' : ''">
+        <i class="bi bi-book-fill"></i>
+        내 책
+    </a>
+    <a href="/web/profile" th:classappend="${#httpServletRequest.requestURI.startsWith('/web/profile')} ? 'active' : ''">
+        <i class="bi bi-person-fill"></i>
+        프로필
+    </a>
+    <a href="/web/interests" th:classappend="${#httpServletRequest.requestURI.startsWith('/web/interests')} ? 'active' : ''">
+        <i class="bi bi-heart-fill"></i>
+        관심사
+    </a>
+</nav>
+
+<!-- Bootstrap 5 JS -->
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+
+<!-- 페이지 고유 스크립트 슬롯 -->
+<th:block layout:fragment="page-scripts"></th:block>
+
+<!-- 플래시 메시지 자동 닫기 -->
+<script>
+    document.querySelectorAll('.flash-alert').forEach(function(el) {
+        setTimeout(function() {
+            var bsAlert = bootstrap.Alert.getOrCreateInstance(el);
+            bsAlert.close();
+        }, 3000);
+    });
+</script>
+</body>
+</html>

--- a/backend/mybrary-server/src/main/resources/templates/web/find-password.html
+++ b/backend/mybrary-server/src/main/resources/templates/web/find-password.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>비밀번호 찾기 - Mybrary</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <style>
+        :root { --mybrary-primary: #19C568; }
+        body { min-height: 100vh; background: linear-gradient(160deg, #60E56D 0%, #CDE7BE 100%); display: flex; align-items: center; justify-content: center; }
+        .card-box { background: #fff; border-radius: 20px; padding: 36px 28px; width: 100%; max-width: 360px; box-shadow: 0 8px 32px rgba(0,0,0,0.1); }
+        .brand-logo { color: var(--mybrary-primary); font-size: 1.5rem; font-weight: 800; }
+        .form-control { border-radius: 10px; border: 1.5px solid #DDD; }
+        .form-control:focus { border-color: var(--mybrary-primary); box-shadow: 0 0 0 3px rgba(25,197,104,0.15); }
+        .btn-primary-mybrary { background: var(--mybrary-primary); border: none; border-radius: 10px; color: #fff; padding: 12px; width: 100%; font-weight: 700; }
+        .btn-primary-mybrary:hover { background: #15b05e; color: #fff; }
+    </style>
+</head>
+<body>
+<div class="card-box">
+    <div class="brand-logo">mybrary</div>
+    <h6 class="mt-2 mb-1 fw-bold">비밀번호 찾기</h6>
+    <p class="text-muted small mb-4">현재 소셜 로그인(카카오/네이버/구글) 또는 이메일 인증을 통한 비밀번호 찾기는 앱에서 지원됩니다.</p>
+
+    <div class="alert alert-info small">
+        <strong>안내</strong><br>
+        모바일 앱(iOS/Android)에서 소셜 로그인 또는 이메일 인증을 통해 비밀번호를 재설정해 주세요.
+    </div>
+
+    <a href="/web/login" class="btn btn-primary-mybrary d-block text-decoration-none text-center mt-3">
+        로그인으로 돌아가기
+    </a>
+</div>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/backend/mybrary-server/src/main/resources/templates/web/follow-list.html
+++ b/backend/mybrary-server/src/main/resources/templates/web/follow-list.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org"
+      xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      layout:decorate="~{layout/base}">
+<head>
+    <title>팔로우 목록</title>
+</head>
+<body>
+<div layout:fragment="content">
+    <div class="page-container">
+
+        <div class="section-header mb-3">
+            <span class="section-title" th:text="${followers != null ? '팔로워' : '팔로잉'}">목록</span>
+            <a th:href="@{/web/profile/{uid}(uid=${targetUserId})}" class="btn btn-sm btn-outline-secondary">
+                <i class="bi bi-arrow-left me-1"></i>프로필
+            </a>
+        </div>
+
+        <!-- 팔로워 목록 -->
+        <div th:if="${followers != null}">
+            <div th:if="${!#lists.isEmpty(followers)}" class="d-flex flex-column gap-2">
+                <div class="card p-3 d-flex flex-row align-items-center gap-3" th:each="user : ${followers}">
+                    <img th:src="${user.profileImageUrl}"
+                         alt="프로필"
+                         class="rounded-circle"
+                         style="width:48px;height:48px;object-fit:cover;background:#EEE;"
+                         onerror="this.src='https://via.placeholder.com/48?text=?'">
+                    <div class="flex-grow-1">
+                        <div class="fw-semibold small" th:text="${user.nickname}">닉네임</div>
+                        <div class="text-muted" style="font-size:0.75rem;" th:text="${user.userId}">아이디</div>
+                    </div>
+                    <a th:href="@{/web/profile/{uid}(uid=${user.userId})}"
+                       class="btn btn-sm btn-mybrary-outline btn-outline-success">프로필</a>
+                </div>
+            </div>
+            <div th:if="${#lists.isEmpty(followers)}" class="text-center text-muted py-5">
+                <i class="bi bi-people" style="font-size:2.5rem;color:#CCC;"></i>
+                <p class="mt-2">팔로워가 없어요</p>
+            </div>
+        </div>
+
+        <!-- 팔로잉 목록 -->
+        <div th:if="${followings != null}">
+            <div th:if="${!#lists.isEmpty(followings)}" class="d-flex flex-column gap-2">
+                <div class="card p-3 d-flex flex-row align-items-center gap-3" th:each="user : ${followings}">
+                    <img th:src="${user.profileImageUrl}"
+                         alt="프로필"
+                         class="rounded-circle"
+                         style="width:48px;height:48px;object-fit:cover;background:#EEE;"
+                         onerror="this.src='https://via.placeholder.com/48?text=?'">
+                    <div class="flex-grow-1">
+                        <div class="fw-semibold small" th:text="${user.nickname}">닉네임</div>
+                        <div class="text-muted" style="font-size:0.75rem;" th:text="${user.userId}">아이디</div>
+                    </div>
+                    <a th:href="@{/web/profile/{uid}(uid=${user.userId})}"
+                       class="btn btn-sm btn-mybrary-outline btn-outline-success">프로필</a>
+                </div>
+            </div>
+            <div th:if="${#lists.isEmpty(followings)}" class="text-center text-muted py-5">
+                <i class="bi bi-people" style="font-size:2.5rem;color:#CCC;"></i>
+                <p class="mt-2">팔로잉이 없어요</p>
+            </div>
+        </div>
+
+    </div>
+</div>
+</body>
+</html>

--- a/backend/mybrary-server/src/main/resources/templates/web/home.html
+++ b/backend/mybrary-server/src/main/resources/templates/web/home.html
@@ -1,0 +1,122 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org"
+      xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      layout:decorate="~{layout/base}">
+<head>
+    <title>홈</title>
+</head>
+<body>
+<div layout:fragment="content">
+    <div class="page-container">
+
+        <!-- 오늘 등록 수 배너 -->
+        <div class="p-3 mb-3 rounded-3"
+             style="background: linear-gradient(135deg, #19C568 0%, #6ADE8D 60%, #ABE8A1 100%); color:#fff;">
+            <div class="d-flex align-items-center justify-content-between">
+                <div>
+                    <div class="fw-bold" style="font-size:1.05rem;">오늘 등록된 책</div>
+                    <div style="font-size:2rem; font-weight:800;" th:text="${todayCount != null ? todayCount : 0}">0</div>
+                    <div style="font-size:0.82rem; opacity:0.9;">권이 추가되었어요</div>
+                </div>
+                <i class="bi bi-book-fill" style="font-size:3rem; opacity:0.5;"></i>
+            </div>
+        </div>
+
+        <!-- 추천 도서 (관심사 기반) -->
+        <div th:if="${recommendations != null and !#lists.isEmpty(recommendations)}">
+            <div class="section-header">
+                <span class="section-title">관심사 기반 추천</span>
+                <a href="/web/search" class="text-decoration-none" style="font-size:0.8rem; color: var(--mybrary-grey);">더보기</a>
+            </div>
+            <div class="d-flex gap-2 overflow-auto pb-2 mb-3" style="scrollbar-width:none;">
+                <a th:each="book : ${recommendations}"
+                   th:href="@{/web/search/detail(isbn13=${book.isbn13})}"
+                   class="text-decoration-none flex-shrink-0">
+                    <div style="width:90px;">
+                        <img th:src="${book.thumbnailUrl}"
+                             th:alt="${book.isbn13}"
+                             class="rounded-2 w-100"
+                             style="height:130px; object-fit:cover; background:#EEE;"
+                             onerror="this.src='https://via.placeholder.com/90x130?text=No+Image'">
+                    </div>
+                </a>
+            </div>
+        </div>
+
+        <!-- 베스트셀러 -->
+        <div class="section-header">
+            <span class="section-title">베스트셀러</span>
+            <a href="/web/search?keyword=베스트셀러" class="text-decoration-none" style="font-size:0.8rem; color: var(--mybrary-grey);">더보기</a>
+        </div>
+
+        <div th:if="${bestsellers != null and !#lists.isEmpty(bestsellers)}">
+            <div class="row g-2">
+                <div class="col-6 col-sm-4" th:each="book, stat : ${bestsellers}" th:if="${stat.index < 6}">
+                    <a th:href="@{/web/search/detail(isbn13=${book.isbn13})}" class="text-decoration-none">
+                        <div class="book-card h-100">
+                            <div class="position-relative">
+                                <img th:src="${book.thumbnailUrl}"
+                                     alt="도서 표지"
+                                     onerror="this.src='https://via.placeholder.com/180x160?text=No+Image'">
+                                <span class="badge position-absolute top-0 start-0 m-1"
+                                      style="background:#19C568; font-size:0.65rem;"
+                                      th:text="${stat.index + 1}">1</span>
+                            </div>
+                        </div>
+                    </a>
+                </div>
+            </div>
+        </div>
+
+        <div th:if="${bestsellers == null or #lists.isEmpty(bestsellers)}" class="text-center text-muted py-4">
+            <i class="bi bi-book" style="font-size:2rem;"></i>
+            <p class="mt-2 small">베스트셀러를 불러올 수 없습니다.</p>
+        </div>
+
+        <!-- 빠른 메뉴 -->
+        <div class="section-header mt-3">
+            <span class="section-title">빠른 메뉴</span>
+        </div>
+        <div class="row g-2 mb-3">
+            <div class="col-6">
+                <a href="/web/mybooks" class="card text-decoration-none p-3 d-flex flex-row align-items-center gap-2">
+                    <i class="bi bi-book-fill text-success" style="font-size:1.4rem;"></i>
+                    <div>
+                        <div class="fw-bold small">내 책</div>
+                        <div class="text-muted" style="font-size:0.72rem;">등록된 도서</div>
+                    </div>
+                </a>
+            </div>
+            <div class="col-6">
+                <a href="/web/mybooks/interest" class="card text-decoration-none p-3 d-flex flex-row align-items-center gap-2">
+                    <i class="bi bi-heart-fill text-danger" style="font-size:1.4rem;"></i>
+                    <div>
+                        <div class="fw-bold small">관심 도서</div>
+                        <div class="text-muted" style="font-size:0.72rem;">찜한 책 목록</div>
+                    </div>
+                </a>
+            </div>
+            <div class="col-6">
+                <a href="/web/profile" class="card text-decoration-none p-3 d-flex flex-row align-items-center gap-2">
+                    <i class="bi bi-person-fill text-primary" style="font-size:1.4rem;"></i>
+                    <div>
+                        <div class="fw-bold small">내 프로필</div>
+                        <div class="text-muted" style="font-size:0.72rem;">팔로워/팔로잉</div>
+                    </div>
+                </a>
+            </div>
+            <div class="col-6">
+                <a href="/web/interests" class="card text-decoration-none p-3 d-flex flex-row align-items-center gap-2">
+                    <i class="bi bi-tag-fill text-warning" style="font-size:1.4rem;"></i>
+                    <div>
+                        <div class="fw-bold small">관심사 설정</div>
+                        <div class="text-muted" style="font-size:0.72rem;">맞춤 추천</div>
+                    </div>
+                </a>
+            </div>
+        </div>
+
+    </div>
+</div>
+</body>
+</html>

--- a/backend/mybrary-server/src/main/resources/templates/web/interests.html
+++ b/backend/mybrary-server/src/main/resources/templates/web/interests.html
@@ -1,0 +1,88 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org"
+      xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      layout:decorate="~{layout/base}">
+<head>
+    <title>관심사 설정</title>
+    <th:block layout:fragment="page-styles">
+    <style>
+        .interest-chip {
+            border-radius: 20px;
+            padding: 6px 16px;
+            font-size: 0.82rem;
+            border: 1.5px solid #DDD;
+            background: #fff;
+            color: #555;
+            cursor: pointer;
+            transition: all 0.15s;
+            user-select: none;
+        }
+        .interest-chip input { display:none; }
+        .interest-chip.selected {
+            background: #19C568;
+            border-color: #19C568;
+            color: #fff;
+        }
+        .category-title { font-size: 0.9rem; font-weight: 700; color: #313333; margin-bottom: 10px; }
+    </style>
+    </th:block>
+</head>
+<body>
+<div layout:fragment="content">
+    <div class="page-container">
+
+        <div class="section-header mb-4">
+            <span class="section-title">관심사 설정</span>
+        </div>
+
+        <p class="text-muted small mb-4">관심 있는 분야를 선택하면 맞춤 도서를 추천해드려요. (최대 5개)</p>
+
+        <form th:action="@{/web/interests}" method="post" id="interestForm">
+            <div th:each="category : ${categories}" class="mb-4">
+                <div class="category-title" th:text="${category.name}">카테고리</div>
+                <div class="d-flex flex-wrap gap-2">
+                    <label th:each="interest : ${category.interestResponses}"
+                           class="interest-chip"
+                           th:classappend="${userInterestIds != null and #lists.contains(userInterestIds, interest.id)} ? 'selected' : ''"
+                           th:for="${'interest-' + interest.id}">
+                        <input type="checkbox"
+                               name="interestIds"
+                               th:id="${'interest-' + interest.id}"
+                               th:value="${interest.id}"
+                               th:checked="${userInterestIds != null and #lists.contains(userInterestIds, interest.id)}">
+                        <span th:text="${interest.name}">관심사명</span>
+                    </label>
+                </div>
+            </div>
+
+            <div class="position-sticky" style="bottom:90px;">
+                <button type="submit" class="btn btn-mybrary w-100 py-3 fw-bold">
+                    <i class="bi bi-check-circle me-1"></i>관심사 저장
+                </button>
+            </div>
+        </form>
+
+    </div>
+</div>
+<th:block layout:fragment="page-scripts">
+<script>
+    // 칩 클릭 시 선택 토글
+    document.querySelectorAll('.interest-chip').forEach(function(chip) {
+        chip.addEventListener('click', function() {
+            const input = chip.querySelector('input[type="checkbox"]');
+            chip.classList.toggle('selected');
+        });
+    });
+
+    // 최대 5개 제한
+    document.getElementById('interestForm').addEventListener('submit', function(e) {
+        const checked = document.querySelectorAll('.interest-chip input:checked');
+        if (checked.length > 5) {
+            e.preventDefault();
+            alert('관심사는 최대 5개까지 선택 가능합니다.');
+        }
+    });
+</script>
+</th:block>
+</body>
+</html>

--- a/backend/mybrary-server/src/main/resources/templates/web/login.html
+++ b/backend/mybrary-server/src/main/resources/templates/web/login.html
@@ -1,0 +1,94 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>로그인 - Mybrary</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css" rel="stylesheet">
+    <style>
+        :root { --mybrary-primary: #19C568; }
+        body {
+            min-height: 100vh;
+            background: linear-gradient(160deg, #60E56D 0%, #CDE7BE 100%);
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            font-family: 'Apple SD Gothic Neo', 'Noto Sans KR', sans-serif;
+        }
+        .login-card {
+            background: #fff;
+            border-radius: 24px;
+            padding: 40px 32px 32px;
+            width: 100%;
+            max-width: 380px;
+            box-shadow: 0 8px 32px rgba(0,0,0,0.12);
+        }
+        .brand-logo { color: var(--mybrary-primary); font-size: 2rem; font-weight: 800; letter-spacing: -1px; }
+        .brand-sub { color: #888; font-size: 0.85rem; margin-bottom: 28px; }
+        .form-control { border-radius: 12px; border: 1.5px solid #DDD; padding: 12px 16px; }
+        .form-control:focus { border-color: var(--mybrary-primary); box-shadow: 0 0 0 3px rgba(25,197,104,0.15); }
+        .btn-login { background: var(--mybrary-primary); border: none; border-radius: 12px; padding: 14px; font-weight: 700; font-size: 1rem; color: #fff; width: 100%; }
+        .btn-login:hover { background: #15b05e; color: #fff; }
+        .divider { display: flex; align-items: center; gap: 10px; color: #bbb; margin: 20px 0; font-size: 0.8rem; }
+        .divider::before, .divider::after { content: ''; flex: 1; border-top: 1px solid #E0E0E0; }
+        .btn-kakao { background: #FFE502; color: #3A1D1D; border: none; border-radius: 12px; padding: 12px; font-weight: 700; width: 100%; }
+        .btn-naver { background: #0AC75A; color: #fff; border: none; border-radius: 12px; padding: 12px; font-weight: 700; width: 100%; }
+        .btn-google { background: #fff; color: #555; border: 1.5px solid #DDD; border-radius: 12px; padding: 12px; font-weight: 700; width: 100%; }
+        .link-area { text-align: center; margin-top: 16px; font-size: 0.85rem; color: #888; }
+        .link-area a { color: var(--mybrary-primary); text-decoration: none; font-weight: 600; }
+    </style>
+</head>
+<body>
+<div class="login-card">
+    <div class="brand-logo">mybrary</div>
+    <div class="brand-sub">책으로 이어지는 사람들</div>
+
+    <!-- 에러 메시지 -->
+    <div th:if="${errorMessage}" class="alert alert-danger py-2 px-3 mb-3 rounded-3" style="font-size:0.85rem;">
+        <i class="bi bi-exclamation-circle me-1"></i>
+        <span th:text="${errorMessage}"></span>
+    </div>
+    <div th:if="${param.accountDeleted}" class="alert alert-info py-2 px-3 mb-3 rounded-3" style="font-size:0.85rem;">
+        계정이 성공적으로 탈퇴되었습니다.
+    </div>
+    <div th:if="${successMessage}" class="alert alert-success py-2 px-3 mb-3 rounded-3" style="font-size:0.85rem;">
+        <i class="bi bi-check-circle me-1"></i>
+        <span th:text="${successMessage}"></span>
+    </div>
+
+    <!-- 폼 로그인 -->
+    <form th:action="@{/web/login}" method="post">
+        <div class="mb-3">
+            <input type="text" class="form-control" name="username" placeholder="아이디" required autocomplete="username">
+        </div>
+        <div class="mb-3">
+            <input type="password" class="form-control" name="password" placeholder="비밀번호" required autocomplete="current-password">
+        </div>
+        <button type="submit" class="btn-login">로그인</button>
+    </form>
+
+    <!-- 소셜 로그인 -->
+    <div class="divider">소셜 로그인</div>
+    <div class="d-flex flex-column gap-2">
+        <a href="/oauth2/authorization/kakao" class="btn-kakao d-flex align-items-center justify-content-center gap-2 text-decoration-none">
+            <span>카카오로 시작하기</span>
+        </a>
+        <a href="/oauth2/authorization/naver" class="btn-naver d-flex align-items-center justify-content-center gap-2 text-decoration-none">
+            <span>네이버로 시작하기</span>
+        </a>
+        <a href="/oauth2/authorization/google" class="btn-google d-flex align-items-center justify-content-center gap-2 text-decoration-none">
+            <span style="color:#D0422A;font-weight:700;">G</span>
+            <span>구글로 시작하기</span>
+        </a>
+    </div>
+
+    <div class="link-area">
+        계정이 없으신가요? <a href="/web/signup">회원가입</a>
+        &nbsp;|&nbsp;
+        <a href="/web/find-password">비밀번호 찾기</a>
+    </div>
+</div>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/backend/mybrary-server/src/main/resources/templates/web/mybook-detail.html
+++ b/backend/mybrary-server/src/main/resources/templates/web/mybook-detail.html
@@ -1,0 +1,214 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org"
+      xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      layout:decorate="~{layout/base}">
+<head>
+    <title>내 책 상세</title>
+    <th:block layout:fragment="page-styles">
+    <style>
+        .book-cover { width:100px; height:140px; object-fit:cover; border-radius:10px; box-shadow:0 4px 16px rgba(0,0,0,0.12); flex-shrink:0; }
+        .tag-chip { display:inline-block; padding:4px 12px; border-radius:16px; font-size:0.75rem; font-weight:600; color:#fff; }
+        .star-btn { background:none; border:none; font-size:1.6rem; color:#DDD; cursor:pointer; padding:0 3px; }
+        .star-btn.active { color:#FFBB36; }
+        .form-check-label { font-size:0.85rem; }
+    </style>
+    </th:block>
+</head>
+<body>
+<div layout:fragment="content">
+    <div class="page-container">
+
+        <a href="/web/mybooks" class="btn btn-sm btn-outline-secondary mb-3">
+            <i class="bi bi-arrow-left me-1"></i>목록으로
+        </a>
+
+        <div th:if="${mybook != null}">
+
+            <!-- 도서 헤더 -->
+            <div class="d-flex gap-3 mb-4">
+                <img th:src="${mybook.book.thumbnailUrl}"
+                     alt="표지"
+                     class="book-cover"
+                     onerror="this.src='https://via.placeholder.com/100x140?text=No+Image'">
+                <div class="flex-grow-1">
+                    <h6 class="fw-bold mb-1" style="color:#313333; line-height:1.4;" th:text="${mybook.book.title}">제목</h6>
+                    <div class="text-muted small mb-1" th:if="${mybook.book.authors != null}"
+                         th:text="${#strings.listJoin(mybook.book.authors, ', ')}">저자</div>
+                    <div class="text-muted small mb-1" th:if="${mybook.book.publisher}" th:text="${mybook.book.publisher}">출판사</div>
+                    <div class="d-flex align-items-center gap-1 mb-2">
+                        <span style="color:#FFBB36;"><i class="bi bi-star-fill"></i></span>
+                        <span class="small fw-bold" th:text="${mybook.book.starRating != null ? #numbers.formatDecimal(mybook.book.starRating,1,1) : '-'}">0.0</span>
+                    </div>
+                    <!-- 의미태그 표시 -->
+                    <div th:if="${mybook.meaningTag != null and mybook.meaningTag.quote != null and !#strings.isEmpty(mybook.meaningTag.quote)}">
+                        <span class="tag-chip" th:style="'background:#' + (mybook.meaningTag.colorCode != null ? mybook.meaningTag.colorCode : '19C568')"
+                              th:text="${mybook.meaningTag.quote}">의미태그</span>
+                    </div>
+                </div>
+            </div>
+
+            <!-- 편집 폼 -->
+            <div class="card mb-3">
+                <div class="card-body">
+                    <div class="section-title mb-3">독서 정보 수정</div>
+                    <form th:action="@{/web/mybooks/{id}/update(id=${mybook.id})}" method="post">
+
+                        <!-- 독서 상태 -->
+                        <div class="mb-3">
+                            <label class="form-label fw-semibold small">독서 상태</label>
+                            <div class="d-flex gap-2 flex-wrap">
+                                <div th:each="status : ${readStatusValues}">
+                                    <input type="radio" class="btn-check" name="readStatus"
+                                           th:id="${'rs-' + status.name()}"
+                                           th:value="${status.name()}"
+                                           th:checked="${mybook.readStatus != null and mybook.readStatus.name() == status.name()}">
+                                    <label class="btn btn-outline-success btn-sm" th:for="${'rs-' + status.name()}"
+                                           th:text="${status.status}">상태</label>
+                                </div>
+                            </div>
+                        </div>
+
+                        <!-- 공개 설정 -->
+                        <div class="mb-3">
+                            <label class="form-label fw-semibold small">공개 설정</label>
+                            <div class="d-flex gap-3">
+                                <div class="form-check">
+                                    <input class="form-check-input" type="checkbox" name="showable" id="showable"
+                                           th:checked="${mybook.showable}">
+                                    <label class="form-check-label" for="showable">공개</label>
+                                </div>
+                                <div class="form-check">
+                                    <input class="form-check-input" type="checkbox" name="exchangeable" id="exchangeable"
+                                           th:checked="${mybook.exchangeable}">
+                                    <label class="form-check-label" for="exchangeable">교환</label>
+                                </div>
+                                <div class="form-check">
+                                    <input class="form-check-input" type="checkbox" name="shareable" id="shareable"
+                                           th:checked="${mybook.shareable}">
+                                    <label class="form-check-label" for="shareable">나눔</label>
+                                </div>
+                            </div>
+                        </div>
+
+                        <!-- 의미태그 -->
+                        <div class="mb-3">
+                            <label class="form-label fw-semibold small">의미태그 (문구)</label>
+                            <input type="text" class="form-control form-control-sm" name="meaningTagQuote"
+                                   th:value="${mybook.meaningTag != null ? mybook.meaningTag.quote : ''}"
+                                   placeholder="이 책을 나타내는 한 마디">
+                        </div>
+                        <div class="mb-3">
+                            <label class="form-label fw-semibold small">태그 색상</label>
+                            <div class="d-flex gap-2 flex-wrap" id="colorPicker">
+                                <th:block th:each="c : ${ {'6F5DDE','2CCD80','FFB525','FA9993','EC6DD0'} }">
+                                    <input type="radio" class="btn-check" name="meaningTagColorCode"
+                                           th:id="${'color-' + c}"
+                                           th:value="${c}"
+                                           th:checked="${mybook.meaningTag != null and mybook.meaningTag.colorCode == c}">
+                                    <label th:for="${'color-' + c}"
+                                           class="rounded-circle border-2"
+                                           th:style="'width:28px;height:28px;display:inline-block;background:#' + c + ';cursor:pointer;'"
+                                           title="">
+                                    </label>
+                                </th:block>
+                            </div>
+                        </div>
+
+                        <div class="d-flex gap-2">
+                            <button type="submit" class="btn btn-mybrary flex-fill">저장</button>
+                        </div>
+                    </form>
+                </div>
+            </div>
+
+            <!-- 책 소개 -->
+            <div class="card mb-3 p-3" th:if="${mybook.book.description}">
+                <div class="section-title mb-2">책 소개</div>
+                <div style="font-size:0.83rem; color:#535353; line-height:1.6;" th:text="${mybook.book.description}">설명</div>
+            </div>
+
+            <!-- 내 리뷰 -->
+            <div class="card mb-3">
+                <div class="card-body">
+                    <div class="section-title mb-3">내 리뷰</div>
+
+                    <!-- 기존 리뷰 있을 때 -->
+                    <div th:if="${review != null}">
+                        <div class="d-flex align-items-center gap-1 mb-2">
+                            <span style="color:#FFBB36; font-size:1.1rem;" th:text="${'★'.repeat(review.starRating != null ? review.starRating.intValue() : 0)}">★</span>
+                            <span class="small text-muted" th:text="${review.starRating}">0.0</span>
+                        </div>
+                        <p style="font-size:0.85rem; color:#333;" th:text="${review.content}">리뷰 내용</p>
+                        <div class="text-muted" style="font-size:0.72rem;" th:text="${review.createdAt}">작성일</div>
+
+                        <!-- 수정 폼 토글 -->
+                        <button class="btn btn-sm btn-outline-secondary mt-2 me-1" data-bs-toggle="collapse" data-bs-target="#editReview">
+                            <i class="bi bi-pencil me-1"></i>수정
+                        </button>
+                        <form th:action="@{/web/mybooks/{id}/review/{rid}/delete(id=${mybook.id},rid=${review.id})}"
+                              method="post" class="d-inline">
+                            <button type="submit" class="btn btn-sm btn-outline-danger mt-2"
+                                    onclick="return confirm('리뷰를 삭제할까요?')">
+                                <i class="bi bi-trash me-1"></i>삭제
+                            </button>
+                        </form>
+
+                        <div class="collapse mt-3" id="editReview">
+                            <form th:action="@{/web/mybooks/{id}/review/{rid}/update(id=${mybook.id},rid=${review.id})}"
+                                  method="post">
+                                <div class="mb-2">
+                                    <label class="form-label small fw-semibold">별점</label>
+                                    <select class="form-select form-select-sm" name="starRating">
+                                        <option value="1.0" th:selected="${review.starRating == 1.0}">★ 1.0</option>
+                                        <option value="2.0" th:selected="${review.starRating == 2.0}">★★ 2.0</option>
+                                        <option value="3.0" th:selected="${review.starRating == 3.0}">★★★ 3.0</option>
+                                        <option value="4.0" th:selected="${review.starRating == 4.0}">★★★★ 4.0</option>
+                                        <option value="5.0" th:selected="${review.starRating == 5.0}">★★★★★ 5.0</option>
+                                    </select>
+                                </div>
+                                <div class="mb-2">
+                                    <textarea class="form-control form-control-sm" name="content" rows="3"
+                                              th:text="${review.content}" placeholder="리뷰 내용"></textarea>
+                                </div>
+                                <button type="submit" class="btn btn-sm btn-mybrary w-100">수정 저장</button>
+                            </form>
+                        </div>
+                    </div>
+
+                    <!-- 리뷰 없을 때 작성 폼 -->
+                    <div th:if="${review == null}">
+                        <p class="text-muted small mb-3">이 책에 대한 리뷰를 작성해보세요.</p>
+                        <form th:action="@{/web/mybooks/{id}/review(id=${mybook.id})}" method="post">
+                            <div class="mb-2">
+                                <label class="form-label small fw-semibold">별점</label>
+                                <select class="form-select form-select-sm" name="starRating">
+                                    <option value="1.0">★ 1.0</option>
+                                    <option value="2.0">★★ 2.0</option>
+                                    <option value="3.0">★★★ 3.0</option>
+                                    <option value="4.0" selected>★★★★ 4.0</option>
+                                    <option value="5.0">★★★★★ 5.0</option>
+                                </select>
+                            </div>
+                            <div class="mb-2">
+                                <textarea class="form-control form-control-sm" name="content" rows="3"
+                                          placeholder="이 책의 감상을 남겨보세요..."></textarea>
+                            </div>
+                            <button type="submit" class="btn btn-mybrary btn-sm w-100">리뷰 등록</button>
+                        </form>
+                    </div>
+                </div>
+            </div>
+
+            <!-- 삭제 버튼 -->
+            <form th:action="@{/web/mybooks/{id}/delete(id=${mybook.id})}" method="post">
+                <button type="submit" class="btn btn-outline-danger w-100 mb-3"
+                        onclick="return confirm('내 책 목록에서 삭제할까요?')">
+                    <i class="bi bi-trash me-1"></i>내 책에서 삭제
+                </button>
+            </form>
+
+        </div>
+    </div>
+</div>
+</body>
+</html>

--- a/backend/mybrary-server/src/main/resources/templates/web/mybooks-interest.html
+++ b/backend/mybrary-server/src/main/resources/templates/web/mybooks-interest.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org"
+      xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      layout:decorate="~{layout/base}">
+<head>
+    <title>관심 도서</title>
+</head>
+<body>
+<div layout:fragment="content">
+    <div class="page-container">
+
+        <div class="section-header mb-3">
+            <span class="section-title">관심 도서</span>
+            <a href="/web/mybooks" class="btn btn-sm btn-outline-secondary" style="font-size:0.75rem;">
+                <i class="bi bi-arrow-left me-1"></i>내 책
+            </a>
+        </div>
+
+        <!-- 정렬 -->
+        <div class="d-flex gap-2 mb-3">
+            <a th:href="@{/web/mybooks/interest(orderType='NONE')}"
+               th:classappend="${orderType == 'NONE' or orderType == null} ? 'active' : ''"
+               class="filter-chip">기본</a>
+            <a th:href="@{/web/mybooks/interest(orderType='PUBLICATION')}"
+               th:classappend="${orderType == 'PUBLICATION'} ? 'active' : ''"
+               class="filter-chip">출판일순</a>
+        </div>
+
+        <!-- 관심 도서 목록 -->
+        <div th:if="${interestBooks != null and !#lists.isEmpty(interestBooks)}">
+            <div class="row g-2">
+                <div class="col-6 col-sm-4" th:each="book : ${interestBooks}">
+                    <a th:href="@{/web/search/detail(isbn13=${book.isbn13})}" class="text-decoration-none">
+                        <div class="book-card h-100">
+                            <div class="position-relative">
+                                <img th:src="${book.thumbnailUrl}"
+                                     th:alt="${book.title}"
+                                     onerror="this.src='https://via.placeholder.com/180x160?text=N/A'">
+                                <button class="btn btn-sm position-absolute top-0 end-0 m-1 p-1"
+                                        style="background:rgba(255,255,255,0.9); border:none;">
+                                    <i class="bi bi-heart-fill text-danger" style="font-size:0.8rem;"></i>
+                                </button>
+                            </div>
+                            <div class="book-card-body">
+                                <div class="book-card-title" th:text="${book.title}">제목</div>
+                                <div class="book-card-author" th:text="${book.author}">저자</div>
+                            </div>
+                        </div>
+                    </a>
+                </div>
+            </div>
+        </div>
+
+        <div th:if="${interestBooks == null or #lists.isEmpty(interestBooks)}" class="text-center text-muted py-5">
+            <i class="bi bi-heart" style="font-size:3rem; color:#CCC;"></i>
+            <p class="mt-3 fw-semibold">관심 도서가 없어요</p>
+            <a href="/web/search" class="btn btn-mybrary btn-sm mt-2">
+                <i class="bi bi-search me-1"></i>도서 검색
+            </a>
+        </div>
+
+    </div>
+</div>
+<th:block layout:fragment="page-styles">
+<style>
+    .filter-chip { border-radius:20px; padding:5px 14px; font-size:0.78rem; border:1.5px solid #DDD; background:#fff; color:#555; cursor:pointer; text-decoration:none; }
+    .filter-chip.active { background:#19C568; border-color:#19C568; color:#fff; }
+</style>
+</th:block>
+</body>
+</html>

--- a/backend/mybrary-server/src/main/resources/templates/web/mybooks.html
+++ b/backend/mybrary-server/src/main/resources/templates/web/mybooks.html
@@ -1,0 +1,99 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org"
+      xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      layout:decorate="~{layout/base}">
+<head>
+    <title>내 책</title>
+    <th:block layout:fragment="page-styles">
+    <style>
+        .filter-chip { border-radius:20px; padding:5px 14px; font-size:0.78rem; border:1.5px solid #DDD; background:#fff; color:#555; cursor:pointer; text-decoration:none; }
+        .filter-chip.active { background:#19C568; border-color:#19C568; color:#fff; }
+        .mybook-card { background:#fff; border-radius:12px; padding:12px; box-shadow:0 1px 4px rgba(0,0,0,0.06); }
+        .mybook-thumb { width:55px; height:78px; object-fit:cover; border-radius:6px; flex-shrink:0; background:#EEE; }
+        .read-status-badge { font-size:0.7rem; padding:2px 8px; border-radius:10px; }
+        .status-TO_READ { background:#F1F2F5; color:#555; }
+        .status-READING { background:#DBEAFE; color:#1D4ED8; }
+        .status-COMPLETED { background:#D1FAE5; color:#065F46; }
+    </style>
+    </th:block>
+</head>
+<body>
+<div layout:fragment="content">
+    <div class="page-container">
+
+        <div class="section-header mb-3">
+            <span class="section-title">내 책</span>
+            <a href="/web/mybooks/interest" class="btn btn-sm btn-outline-danger" style="font-size:0.75rem;">
+                <i class="bi bi-heart me-1"></i>관심 도서
+            </a>
+        </div>
+
+        <!-- 필터: 독서 상태 -->
+        <div class="d-flex gap-2 overflow-auto pb-2 mb-3" style="scrollbar-width:none;">
+            <a href="/web/mybooks" th:classappend="${readStatus == null} ? 'active' : ''" class="filter-chip flex-shrink-0">전체</a>
+            <a th:href="@{/web/mybooks(readStatus='TO_READ')}"
+               th:classappend="${readStatus == 'TO_READ'} ? 'active' : ''"
+               class="filter-chip flex-shrink-0">읽기전</a>
+            <a th:href="@{/web/mybooks(readStatus='READING')}"
+               th:classappend="${readStatus == 'READING'} ? 'active' : ''"
+               class="filter-chip flex-shrink-0">읽는중</a>
+            <a th:href="@{/web/mybooks(readStatus='COMPLETED')}"
+               th:classappend="${readStatus == 'COMPLETED'} ? 'active' : ''"
+               class="filter-chip flex-shrink-0">완독</a>
+        </div>
+
+        <!-- 정렬 -->
+        <div class="d-flex gap-2 mb-3">
+            <a th:href="@{/web/mybooks(orderType='NONE',readStatus=${readStatus})}"
+               th:classappend="${orderType == 'NONE' or orderType == null} ? 'active' : ''"
+               class="filter-chip" style="font-size:0.72rem;">기본</a>
+            <a th:href="@{/web/mybooks(orderType='TITLE',readStatus=${readStatus})}"
+               th:classappend="${orderType == 'TITLE'} ? 'active' : ''"
+               class="filter-chip" style="font-size:0.72rem;">제목순</a>
+            <a th:href="@{/web/mybooks(orderType='REGISTRATION',readStatus=${readStatus})}"
+               th:classappend="${orderType == 'REGISTRATION'} ? 'active' : ''"
+               class="filter-chip" style="font-size:0.72rem;">등록순</a>
+        </div>
+
+        <!-- 책 목록 -->
+        <div th:if="${mybooks != null and !#lists.isEmpty(mybooks)}" class="d-flex flex-column gap-2">
+            <a th:each="mybook : ${mybooks}"
+               th:href="@{/web/mybooks/{id}(id=${mybook.id})}"
+               class="mybook-card d-flex gap-3 text-decoration-none">
+                <img th:src="${mybook.book.thumbnailUrl}"
+                     alt="표지"
+                     class="mybook-thumb"
+                     onerror="this.src='https://via.placeholder.com/55x78?text=N/A'">
+                <div class="flex-grow-1 overflow-hidden">
+                    <div class="fw-semibold mb-1"
+                         style="font-size:0.88rem; color:#313333; display:-webkit-box; -webkit-line-clamp:2; -webkit-box-orient:vertical; overflow:hidden;"
+                         th:text="${mybook.book.title}">제목</div>
+                    <div class="text-muted mb-1" style="font-size:0.75rem;" th:text="${mybook.book.authors}">저자</div>
+                    <div class="d-flex align-items-center gap-2">
+                        <span class="read-status-badge"
+                              th:classappend="'status-' + ${mybook.readStatus}"
+                              th:text="${mybook.readStatus != null ? mybook.readStatus.status : '미설정'}">상태</span>
+                        <span class="text-muted" style="font-size:0.7rem;" th:if="${mybook.startDateOfPossession}"
+                              th:text="${mybook.startDateOfPossession}">날짜</span>
+                    </div>
+                    <div class="d-flex gap-2 mt-1">
+                        <span th:if="${mybook.showable}" class="text-muted" style="font-size:0.65rem;"><i class="bi bi-eye me-1"></i>공개</span>
+                        <span th:if="${mybook.exchangeable}" class="text-muted" style="font-size:0.65rem;"><i class="bi bi-arrow-left-right me-1"></i>교환</span>
+                        <span th:if="${mybook.shareable}" class="text-muted" style="font-size:0.65rem;"><i class="bi bi-share me-1"></i>나눔</span>
+                    </div>
+                </div>
+            </a>
+        </div>
+
+        <div th:if="${mybooks == null or #lists.isEmpty(mybooks)}" class="text-center text-muted py-5">
+            <i class="bi bi-book" style="font-size:3rem; color:#CCC;"></i>
+            <p class="mt-3 fw-semibold">등록된 책이 없어요</p>
+            <a href="/web/search" class="btn btn-mybrary btn-sm mt-2">
+                <i class="bi bi-search me-1"></i>도서 검색
+            </a>
+        </div>
+
+    </div>
+</div>
+</body>
+</html>

--- a/backend/mybrary-server/src/main/resources/templates/web/profile-edit.html
+++ b/backend/mybrary-server/src/main/resources/templates/web/profile-edit.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org"
+      xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      layout:decorate="~{layout/base}">
+<head>
+    <title>프로필 수정</title>
+</head>
+<body>
+<div layout:fragment="content">
+    <div class="page-container">
+
+        <div class="section-header mb-3">
+            <span class="section-title">프로필 수정</span>
+            <a href="/web/profile" class="btn btn-sm btn-outline-secondary">
+                <i class="bi bi-arrow-left me-1"></i>뒤로
+            </a>
+        </div>
+
+        <div class="card">
+            <div class="card-body">
+                <!-- 현재 프로필 이미지 -->
+                <div class="text-center mb-4">
+                    <img th:src="${profile != null ? profile.profileImageUrl : ''}"
+                         alt="프로필"
+                         class="rounded-circle mb-2"
+                         style="width:80px; height:80px; object-fit:cover; border:3px solid #19C568;"
+                         onerror="this.src='https://via.placeholder.com/80?text=?'">
+                    <div class="text-muted small">
+                        이미지 변경은 모바일 앱에서 지원됩니다
+                    </div>
+                </div>
+
+                <form th:action="@{/web/profile/edit}" method="post">
+                    <div class="mb-3">
+                        <label class="form-label fw-semibold small">닉네임</label>
+                        <input type="text" class="form-control" name="nickname"
+                               th:value="${profile != null ? profile.nickname : ''}"
+                               placeholder="닉네임 (특수문자 제외 2~20자)" required>
+                        <div class="form-text">한글, 영문, 숫자, -, _만 사용 가능</div>
+                    </div>
+                    <div class="mb-4">
+                        <label class="form-label fw-semibold small">소개</label>
+                        <textarea class="form-control" name="introduction" rows="3" maxlength="100"
+                                  placeholder="자신을 소개해보세요 (최대 100자)"
+                                  th:text="${profile != null ? profile.introduction : ''}"></textarea>
+                        <div class="form-text">최대 100자</div>
+                    </div>
+                    <div class="d-flex gap-2">
+                        <a href="/web/profile" class="btn btn-outline-secondary flex-fill">취소</a>
+                        <button type="submit" class="btn btn-mybrary flex-fill">저장</button>
+                    </div>
+                </form>
+            </div>
+        </div>
+
+    </div>
+</div>
+</body>
+</html>

--- a/backend/mybrary-server/src/main/resources/templates/web/profile.html
+++ b/backend/mybrary-server/src/main/resources/templates/web/profile.html
@@ -1,0 +1,91 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org"
+      xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      layout:decorate="~{layout/base}">
+<head>
+    <title>프로필</title>
+    <th:block layout:fragment="page-styles">
+    <style>
+        .profile-img { width:80px; height:80px; object-fit:cover; border-radius:50%; border:3px solid #19C568; background:#EEE; }
+        .stat-box { flex:1; text-align:center; }
+        .stat-box .num { font-size:1.3rem; font-weight:800; color:#313333; }
+        .stat-box .label { font-size:0.72rem; color:#A0A0A0; }
+    </style>
+    </th:block>
+</head>
+<body>
+<div layout:fragment="content">
+    <div class="page-container">
+
+        <div th:if="${profile != null}">
+            <!-- 프로필 헤더 -->
+            <div class="card mb-3 p-4">
+                <div class="d-flex align-items-center gap-3 mb-3">
+                    <img th:src="${profile.profileImageUrl}"
+                         alt="프로필 이미지"
+                         class="profile-img"
+                         onerror="this.src='https://via.placeholder.com/80?text=?'">
+                    <div>
+                        <div class="fw-bold" style="font-size:1.1rem;" th:text="${profile.nickname}">닉네임</div>
+                        <div class="text-muted small mt-1" th:text="${targetUserId}">아이디</div>
+                        <div class="text-muted small mt-1"
+                             th:if="${profile.introduction != null and !#strings.isEmpty(profile.introduction)}"
+                             th:text="${profile.introduction}">소개</div>
+                    </div>
+                </div>
+
+                <!-- 팔로워 / 팔로잉 통계 -->
+                <div class="d-flex border-top pt-3">
+                    <a th:href="@{/web/profile/{uid}/followers(uid=${targetUserId})}"
+                       class="stat-box text-decoration-none">
+                        <div class="num" th:text="${followerCount}">0</div>
+                        <div class="label">팔로워</div>
+                    </a>
+                    <div class="vr mx-2"></div>
+                    <a th:href="@{/web/profile/{uid}/followings(uid=${targetUserId})}"
+                       class="stat-box text-decoration-none">
+                        <div class="num" th:text="${followingCount}">0</div>
+                        <div class="label">팔로잉</div>
+                    </a>
+                </div>
+
+                <!-- 액션 버튼 -->
+                <div class="mt-3" th:if="${isMyProfile}">
+                    <a href="/web/profile/edit" class="btn btn-mybrary-outline btn-outline-success w-100">
+                        <i class="bi bi-pencil me-1"></i>프로필 수정
+                    </a>
+                </div>
+                <div class="mt-3 d-flex gap-2" th:if="${!isMyProfile}">
+                    <form th:if="${!isFollowing}" th:action="@{/web/profile/{uid}/follow(uid=${targetUserId})}" method="post" class="flex-fill">
+                        <button type="submit" class="btn btn-mybrary w-100">
+                            <i class="bi bi-person-plus me-1"></i>팔로우
+                        </button>
+                    </form>
+                    <form th:if="${isFollowing}" th:action="@{/web/profile/{uid}/unfollow(uid=${targetUserId})}" method="post" class="flex-fill">
+                        <button type="submit" class="btn btn-outline-secondary w-100">
+                            <i class="bi bi-person-check me-1"></i>팔로잉
+                        </button>
+                    </form>
+                </div>
+            </div>
+
+            <!-- 다른 사용자의 공개 책 링크 -->
+            <div th:if="${!isMyProfile}" class="card p-3">
+                <div class="section-title mb-2">
+                    <span th:text="${profile.nickname}">님</span>의 책
+                </div>
+                <a th:href="@{/web/mybooks}" class="btn btn-sm btn-mybrary-outline btn-outline-success">
+                    <i class="bi bi-book me-1"></i>내 책으로 이동
+                </a>
+            </div>
+        </div>
+
+        <div th:if="${errorMessage}" class="text-center text-muted py-5">
+            <i class="bi bi-person-x" style="font-size:3rem; color:#CCC;"></i>
+            <p class="mt-3" th:text="${errorMessage}">오류</p>
+        </div>
+
+    </div>
+</div>
+</body>
+</html>

--- a/backend/mybrary-server/src/main/resources/templates/web/search-detail.html
+++ b/backend/mybrary-server/src/main/resources/templates/web/search-detail.html
@@ -1,0 +1,143 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org"
+      xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      layout:decorate="~{layout/base}">
+<head>
+    <title>도서 상세</title>
+    <th:block layout:fragment="page-styles">
+    <style>
+        .book-cover { width:120px; height:170px; object-fit:cover; border-radius:10px; box-shadow:0 4px 16px rgba(0,0,0,0.15); flex-shrink:0; }
+        .tag-badge { background:#F1F2F5; color:#555; border-radius:16px; padding:4px 10px; font-size:0.75rem; }
+        .review-card { background:#fff; border-radius:10px; padding:14px; box-shadow:0 1px 4px rgba(0,0,0,0.06); }
+        .star-icon { color:#FFBB36; }
+    </style>
+    </th:block>
+</head>
+<body>
+<div layout:fragment="content">
+    <div class="page-container">
+
+        <!-- 에러 -->
+        <div th:if="${errorMessage}" class="alert alert-danger" th:text="${errorMessage}"></div>
+
+        <!-- 도서 정보 -->
+        <div th:if="${book != null}">
+
+            <!-- 헤더 (표지 + 기본정보) -->
+            <div class="d-flex gap-3 mb-4">
+                <img th:src="${book.thumbnail}"
+                     alt="도서 표지"
+                     class="book-cover"
+                     onerror="this.src='https://via.placeholder.com/120x170?text=No+Image'">
+                <div class="flex-grow-1">
+                    <h6 class="fw-bold mb-1 lh-sm" style="color:#313333;" th:text="${book.title}">제목</h6>
+                    <div class="text-muted small mb-1">
+                        <span th:if="${book.subTitle}" th:text="${book.subTitle + ' | '}"></span>
+                    </div>
+                    <div class="small text-muted mb-1" th:if="${book.authors != null and !#lists.isEmpty(book.authors)}">
+                        <i class="bi bi-person me-1"></i>
+                        <span th:each="a, stat : ${book.authors}">
+                            <span th:text="${a.name}">저자</span><span th:unless="${stat.last}">, </span>
+                        </span>
+                    </div>
+                    <div class="small text-muted mb-1" th:if="${book.publisher}" th:text="'출판: ' + ${book.publisher}">출판사</div>
+                    <div class="small text-muted mb-2" th:if="${book.publicationDate}" th:text="${book.publicationDate}">출판일</div>
+                    <div class="d-flex align-items-center gap-1 mb-2">
+                        <span class="star-icon"><i class="bi bi-star-fill"></i></span>
+                        <span class="fw-bold small" th:text="${book.starRating != null ? #numbers.formatDecimal(book.starRating,1,1) : '-'}">0.0</span>
+                        <span class="text-muted small" th:if="${book.reviewCount != null}" th:text="'(' + ${book.reviewCount} + '리뷰)'"></span>
+                    </div>
+                    <div class="d-flex gap-2 small text-muted">
+                        <span><i class="bi bi-people me-1"></i><span th:text="${book.holderCount != null ? book.holderCount : 0}">0</span>소장</span>
+                        <span><i class="bi bi-heart me-1"></i><span th:text="${book.interestCount != null ? book.interestCount : 0}">0</span>관심</span>
+                    </div>
+                </div>
+            </div>
+
+            <!-- 액션 버튼 -->
+            <div class="d-flex gap-2 mb-3">
+                <!-- 관심 도서 토글 -->
+                <form th:action="@{/web/search/interest}" method="post" class="flex-fill">
+                    <input type="hidden" name="isbn13" th:value="${book.isbn13}">
+                    <input type="hidden" name="returnUrl" th:value="${#httpServletRequest.requestURI + '?' + (#httpServletRequest.queryString != null ? #httpServletRequest.queryString : '')}">
+                    <button type="submit" class="btn w-100"
+                            th:classappend="${interested} ? 'btn-danger' : 'btn-outline-danger'">
+                        <i class="bi" th:classappend="${interested} ? 'bi-heart-fill' : 'bi-heart'"></i>
+                        <span th:text="${interested} ? '관심 해제' : '관심 도서'">관심</span>
+                    </button>
+                </form>
+
+                <!-- MyBook 등록 -->
+                <form th:action="@{/web/search/mybook}" method="post" class="flex-fill" th:if="${!registered}">
+                    <input type="hidden" name="isbn13" th:value="${book.isbn13}">
+                    <button type="submit" class="btn btn-mybrary w-100">
+                        <i class="bi bi-plus-circle me-1"></i>내 책 등록
+                    </button>
+                </form>
+                <div class="flex-fill" th:if="${registered}">
+                    <a href="/web/mybooks" class="btn btn-mybrary-outline btn-outline-success w-100">
+                        <i class="bi bi-check-circle me-1"></i>등록됨
+                    </a>
+                </div>
+            </div>
+
+            <!-- 태그 -->
+            <div class="d-flex flex-wrap gap-2 mb-3" th:if="${book.category}">
+                <span class="tag-badge" th:text="${book.category}">카테고리</span>
+                <span class="tag-badge" th:if="${book.pages}" th:text="${book.pages} + 'p'">0p</span>
+                <span class="tag-badge" th:if="${book.priceSales}" th:text="${#numbers.formatInteger(book.priceSales, 0, 'COMMA')} + '원'">0원</span>
+            </div>
+
+            <!-- 책 소개 -->
+            <div class="card mb-3 p-3" th:if="${book.description}">
+                <div class="section-title mb-2">책 소개</div>
+                <div style="font-size:0.85rem; color:#535353; line-height:1.6;" th:text="${book.description}">설명</div>
+            </div>
+
+            <!-- 목차 -->
+            <div class="card mb-3 p-3" th:if="${book.toc}">
+                <div class="section-title mb-2">목차</div>
+                <div style="font-size:0.82rem; color:#555; line-height:1.5; white-space:pre-line;" th:text="${book.toc}">목차</div>
+            </div>
+
+            <!-- 리뷰 -->
+            <div class="section-header mt-2">
+                <span class="section-title">리뷰</span>
+                <span class="text-muted small" th:if="${reviews != null}"
+                      th:text="'평균 ' + ${#numbers.formatDecimal(reviews.starRatingAverage,1,1)} + '점'">평균</span>
+            </div>
+
+            <div th:if="${reviews != null and reviews.myBookReviewList != null and !#lists.isEmpty(reviews.myBookReviewList)}">
+                <div class="d-flex flex-column gap-2">
+                    <div class="review-card" th:each="review : ${reviews.myBookReviewList}">
+                        <div class="d-flex align-items-center gap-2 mb-2">
+                            <img th:src="${review.userPictureUrl}"
+                                 alt="프로필"
+                                 class="rounded-circle"
+                                 style="width:32px;height:32px;object-fit:cover;"
+                                 onerror="this.src='https://via.placeholder.com/32?text=?'">
+                            <div>
+                                <div class="fw-semibold" style="font-size:0.82rem;" th:text="${review.userNickname}">닉네임</div>
+                                <div class="text-muted" style="font-size:0.72rem;" th:text="${review.createdAt}">날짜</div>
+                            </div>
+                            <div class="ms-auto">
+                                <span class="star-icon" style="font-size:0.8rem;" th:text="${'★'.repeat(review.starRating != null ? review.starRating.intValue() : 0)}">★</span>
+                                <span class="text-muted small" th:text="${review.starRating != null ? #numbers.formatDecimal(review.starRating,1,1) : ''}"></span>
+                            </div>
+                        </div>
+                        <div style="font-size:0.83rem; color:#535353;" th:text="${review.content}">리뷰 내용</div>
+                    </div>
+                </div>
+            </div>
+
+            <div th:if="${reviews == null or reviews.myBookReviewList == null or #lists.isEmpty(reviews.myBookReviewList)}"
+                 class="text-center text-muted py-3 small">
+                <i class="bi bi-chat-left-text" style="font-size:1.5rem; color:#CCC;"></i>
+                <p class="mt-1">아직 리뷰가 없습니다.</p>
+            </div>
+
+        </div>
+    </div>
+</div>
+</body>
+</html>

--- a/backend/mybrary-server/src/main/resources/templates/web/search.html
+++ b/backend/mybrary-server/src/main/resources/templates/web/search.html
@@ -1,0 +1,103 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org"
+      xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      layout:decorate="~{layout/base}">
+<head>
+    <title>도서 검색</title>
+    <th:block layout:fragment="page-styles">
+    <style>
+        .search-box { background:#fff; border-radius:14px; padding:16px; box-shadow:0 2px 8px rgba(0,0,0,0.06); margin-bottom:12px; }
+        .search-input { border-radius:10px; border:1.5px solid #DDD; }
+        .search-input:focus { border-color:#19C568; box-shadow:0 0 0 3px rgba(25,197,104,0.15); }
+        .ranking-tag { background:#F1F2F5; border-radius:20px; padding:4px 12px; font-size:0.78rem; color:#555; cursor:pointer; white-space:nowrap; }
+        .ranking-tag:hover { background:#19C568; color:#fff; }
+        .rank-num { font-weight:700; color:#19C568; margin-right:4px; }
+        .result-item { background:#fff; border-radius:12px; padding:12px; box-shadow:0 1px 4px rgba(0,0,0,0.06); }
+        .result-item:hover { box-shadow:0 3px 12px rgba(0,0,0,0.1); }
+        .result-img { width:60px; height:85px; object-fit:cover; border-radius:6px; background:#EEE; flex-shrink:0; }
+    </style>
+    </th:block>
+</head>
+<body>
+<div layout:fragment="content">
+    <div class="page-container">
+
+        <!-- 검색창 -->
+        <div class="search-box">
+            <form th:action="@{/web/search}" method="get" class="d-flex gap-2">
+                <input type="text" name="keyword" class="form-control search-input"
+                       placeholder="책 제목, 저자, ISBN 검색"
+                       th:value="${keyword}">
+                <button type="submit" class="btn btn-mybrary px-3">
+                    <i class="bi bi-search"></i>
+                </button>
+            </form>
+        </div>
+
+        <!-- 인기 검색어 -->
+        <div th:if="${ranking != null and !#lists.isEmpty(ranking)}" class="mb-3">
+            <div class="section-title mb-2">인기 검색어</div>
+            <div class="d-flex flex-wrap gap-2">
+                <a th:each="rank, stat : ${ranking}"
+                   th:href="@{/web/search(keyword=${rank.keyword})}"
+                   class="ranking-tag text-decoration-none">
+                    <span class="rank-num" th:text="${stat.index + 1}">1</span>
+                    <span th:text="${rank.keyword}">키워드</span>
+                </a>
+            </div>
+        </div>
+
+        <!-- 검색 결과 없음 상태 -->
+        <div th:if="${keyword == null or keyword.isBlank()}" class="text-center text-muted py-5">
+            <i class="bi bi-search" style="font-size:3rem; color:#CCC;"></i>
+            <p class="mt-3 fw-semibold">책 제목, 저자, ISBN으로 검색해보세요</p>
+        </div>
+
+        <!-- 검색 에러 -->
+        <div th:if="${searchError}" class="alert alert-warning small">
+            <i class="bi bi-exclamation-triangle me-1"></i>
+            <span th:text="${searchError}"></span>
+        </div>
+
+        <!-- 검색 결과 목록 -->
+        <div th:if="${searchResults != null}">
+            <div class="section-header">
+                <span class="section-title">
+                    '<span th:text="${keyword}"></span>' 검색 결과
+                </span>
+                <span class="text-muted small" th:text="${#lists.size(searchResults) + '건'}"></span>
+            </div>
+
+            <div th:if="${#lists.isEmpty(searchResults)}" class="text-center text-muted py-4">
+                <i class="bi bi-inbox" style="font-size:2.5rem; color:#CCC;"></i>
+                <p class="mt-2">검색 결과가 없습니다.</p>
+            </div>
+
+            <div class="d-flex flex-column gap-2">
+                <a th:each="book : ${searchResults}"
+                   th:href="@{/web/search/detail(isbn13=${book.isbn13})}"
+                   class="result-item d-flex gap-3 text-decoration-none">
+                    <img th:src="${book.thumbnailUrl}"
+                         alt="표지"
+                         class="result-img"
+                         onerror="this.src='https://via.placeholder.com/60x85?text=N/A'">
+                    <div class="flex-grow-1 overflow-hidden">
+                        <div class="fw-semibold" style="font-size:0.88rem; color:#313333; display:-webkit-box; -webkit-line-clamp:2; -webkit-box-orient:vertical; overflow:hidden;"
+                             th:text="${book.title}">제목</div>
+                        <div class="text-muted mt-1" style="font-size:0.78rem;" th:text="${book.author}">저자</div>
+                        <div class="text-muted" style="font-size:0.75rem;" th:text="${book.publicationDate}">출판일</div>
+                        <div class="mt-1">
+                            <span class="star-rating">
+                                <i class="bi bi-star-fill"></i>
+                            </span>
+                            <span style="font-size:0.78rem; color:#555;" th:text="${book.starRating != null ? #numbers.formatDecimal(book.starRating,1,1) : '-'}">0.0</span>
+                        </div>
+                    </div>
+                </a>
+            </div>
+        </div>
+
+    </div>
+</div>
+</body>
+</html>

--- a/backend/mybrary-server/src/main/resources/templates/web/settings.html
+++ b/backend/mybrary-server/src/main/resources/templates/web/settings.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org"
+      xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      layout:decorate="~{layout/base}">
+<head>
+    <title>설정</title>
+</head>
+<body>
+<div layout:fragment="content">
+    <div class="page-container">
+
+        <div class="section-title mb-4">설정</div>
+
+        <!-- 계정 정보 -->
+        <div class="card mb-3">
+            <div class="card-body">
+                <div class="fw-semibold mb-1" style="font-size:0.85rem; color:#555;">현재 계정</div>
+                <div class="fw-bold" th:text="${loginId}">아이디</div>
+            </div>
+        </div>
+
+        <!-- 계정 메뉴 -->
+        <div class="card mb-3">
+            <div class="list-group list-group-flush rounded-3">
+                <a href="/web/profile" class="list-group-item list-group-item-action d-flex align-items-center gap-2">
+                    <i class="bi bi-person-circle text-success"></i>
+                    <span>프로필 보기</span>
+                    <i class="bi bi-chevron-right ms-auto text-muted"></i>
+                </a>
+                <a href="/web/profile/edit" class="list-group-item list-group-item-action d-flex align-items-center gap-2">
+                    <i class="bi bi-pencil-square text-primary"></i>
+                    <span>프로필 수정</span>
+                    <i class="bi bi-chevron-right ms-auto text-muted"></i>
+                </a>
+                <a href="/web/interests" class="list-group-item list-group-item-action d-flex align-items-center gap-2">
+                    <i class="bi bi-heart text-danger"></i>
+                    <span>관심사 설정</span>
+                    <i class="bi bi-chevron-right ms-auto text-muted"></i>
+                </a>
+            </div>
+        </div>
+
+        <!-- 로그아웃 -->
+        <div class="card mb-3">
+            <div class="card-body">
+                <form th:action="@{/web/logout}" method="post">
+                    <button type="submit" class="btn btn-outline-secondary w-100">
+                        <i class="bi bi-box-arrow-right me-1"></i>로그아웃
+                    </button>
+                </form>
+            </div>
+        </div>
+
+        <!-- 계정 탈퇴 -->
+        <div class="card border-danger">
+            <div class="card-body">
+                <div class="fw-semibold text-danger mb-2">
+                    <i class="bi bi-exclamation-triangle me-1"></i>위험 구역
+                </div>
+                <p class="text-muted small mb-3">
+                    계정을 탈퇴하면 모든 데이터(내 책, 리뷰, 팔로우 정보)가 삭제되며 복구할 수 없습니다.
+                </p>
+                <button type="button" class="btn btn-outline-danger w-100" data-bs-toggle="modal" data-bs-target="#deleteModal">
+                    <i class="bi bi-trash me-1"></i>계정 탈퇴
+                </button>
+            </div>
+        </div>
+
+        <!-- 앱 정보 -->
+        <div class="text-center text-muted small mt-4 mb-2">
+            <div>mybrary v1.0.0</div>
+            <div>책으로 이어지는 사람들</div>
+        </div>
+
+    </div>
+
+    <!-- 탈퇴 확인 모달 -->
+    <div class="modal fade" id="deleteModal" tabindex="-1">
+        <div class="modal-dialog modal-dialog-centered">
+            <div class="modal-content rounded-4">
+                <div class="modal-header border-0">
+                    <h5 class="modal-title text-danger">
+                        <i class="bi bi-exclamation-triangle me-1"></i>계정 탈퇴
+                    </h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+                </div>
+                <div class="modal-body">
+                    <p>정말로 탈퇴하시겠습니까?</p>
+                    <p class="small text-muted">모든 데이터가 영구적으로 삭제됩니다.</p>
+                </div>
+                <div class="modal-footer border-0">
+                    <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">취소</button>
+                    <form th:action="@{/web/settings/delete-account}" method="post">
+                        <button type="submit" class="btn btn-danger">탈퇴 확인</button>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+</body>
+</html>

--- a/backend/mybrary-server/src/main/resources/templates/web/signup.html
+++ b/backend/mybrary-server/src/main/resources/templates/web/signup.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>회원가입 - Mybrary</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <style>
+        :root { --mybrary-primary: #19C568; }
+        body { min-height: 100vh; background: linear-gradient(160deg, #60E56D 0%, #CDE7BE 100%); display: flex; align-items: center; justify-content: center; }
+        .signup-card { background: #fff; border-radius: 24px; padding: 36px 32px 28px; width: 100%; max-width: 380px; box-shadow: 0 8px 32px rgba(0,0,0,0.12); }
+        .brand-logo { color: var(--mybrary-primary); font-size: 1.6rem; font-weight: 800; margin-bottom: 6px; }
+        .form-control { border-radius: 10px; border: 1.5px solid #DDD; padding: 11px 14px; }
+        .form-control:focus { border-color: var(--mybrary-primary); box-shadow: 0 0 0 3px rgba(25,197,104,0.15); }
+        .form-label { font-size: 0.82rem; font-weight: 600; color: #555; }
+        .btn-signup { background: var(--mybrary-primary); border: none; border-radius: 12px; padding: 13px; font-weight: 700; font-size: 1rem; color: #fff; width: 100%; }
+        .btn-signup:hover { background: #15b05e; color: #fff; }
+        .link-area { text-align: center; margin-top: 14px; font-size: 0.85rem; color: #888; }
+        .link-area a { color: var(--mybrary-primary); text-decoration: none; font-weight: 600; }
+    </style>
+</head>
+<body>
+<div class="signup-card">
+    <div class="brand-logo">mybrary</div>
+    <p class="text-muted small mb-4">새 계정을 만들어보세요</p>
+
+    <div th:if="${errorMessage}" class="alert alert-danger py-2 px-3 mb-3 rounded-3" style="font-size:0.85rem;">
+        <span th:text="${errorMessage}"></span>
+    </div>
+
+    <form th:action="@{/web/signup}" method="post" th:object="${signUpRequest}">
+        <div class="mb-3">
+            <label class="form-label">아이디</label>
+            <input type="text" class="form-control" name="loginId" placeholder="아이디 (영문/숫자 4~20자)" required>
+        </div>
+        <div class="mb-3">
+            <label class="form-label">비밀번호</label>
+            <input type="password" class="form-control" name="password" placeholder="비밀번호 (8~20자)" required>
+        </div>
+        <div class="mb-3">
+            <label class="form-label">닉네임</label>
+            <input type="text" class="form-control" name="nickname" placeholder="닉네임 (2~20자)" required>
+        </div>
+        <div class="mb-4">
+            <label class="form-label">이메일</label>
+            <input type="email" class="form-control" name="email" placeholder="이메일 주소">
+        </div>
+        <button type="submit" class="btn-signup">회원가입</button>
+    </form>
+
+    <div class="link-area">
+        이미 계정이 있으신가요? <a href="/web/login">로그인</a>
+    </div>
+</div>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## 개요
Flutter 앱 전체 화면을 Thymeleaf MPA(서버사이드 렌더링)로 재현.
로컬에서 즉시 실행 가능한 개발 환경(Docker Compose + 파일 스토리지 + 시드 데이터) 구성.

## 변경 사항
- Thymeleaf MPA 14개 화면 구현 (login/signup/home/search/mybook/profile/interests/settings 등)
- WebController: 서비스 레이어 직접 호출 (HTTP 라운드트립 없음)
- 이중 SecurityFilterChain: `/web/**` 세션 기반 / `/api/v1/**` 기존 JWT 유지
- `docker-compose.yml`: MySQL 8.0 + Redis 7.2 로컬 컨테이너
- `LocalStorageService`: local 프로파일에서 S3 대신 `./local-uploads/` 파일 기반 저장
- `LocalDataInitializer`: 시작 시 admin/admin 계정 + 샘플 도서 10권 + MyBook 자동 등록
- Thymeleaf 3.1 `#request` 비활성화 이슈 수정 (`@ModelAttribute currentPath` 주입)
- MIGRATION_PLAN.md Phase 2 체크리스트 완료 반영

## 관련 커밋
```
3006633 feat(p2-01): Thymeleaf MPA 전체 페이지 구현
105b151 feat(p2-02): 로컬 개발 환경 세팅 (Docker Compose + 파일 기반 스토리지)
8584494 feat(local): 로컬 개발용 어드민 계정 자동 생성
0354d94 feat(local): 샘플 도서 10권 + MyBook 자동 초기화
4f0c3a4 chore(local): 어드민 계정 admin/admin으로 변경
daca2f7 fix: Thymeleaf 3.1 #request 비활성화 이슈 수정
794e18b fix(local): admin MyBook 누락 방지
8f081dc docs: MIGRATION_PLAN Phase 2 체크리스트 완료 반영
```

## 테스트
- [x] 로컬 빌드 확인 (BUILD SUCCESSFUL)
- [x] 전체 페이지 HTTP 200 확인 (/web, /search, /mybooks, /profile 등 10개 경로)
- [x] admin/admin 로그인 → 내 책 10권 정상 표시 확인

## 참고 사항
- 로컬 실행: `docker compose up -d` → `./gradlew bootRun --args='--spring.profiles.active=local'`
- 접속: http://localhost:8090/web/login (admin / admin)
- 알리딘 API Key는 별도 세팅 필요 (`ALADIN_API_KEY` 환경변수)
- S3는 local 프로파일에서 파일 기반으로 대체됨 (프로필 이미지 업로드 가능)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)